### PR TITLE
Update Quay & Clair references to use v3.2.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ metadata:
   name: example-quayecosystem
 spec:
   quay:
-    image: myregistry.example.com/quay/quay:v3.1.0
+    image: myregistry.example.com/quay/quay:v3.2.0
 ```
 
 ### Compute Resources

--- a/pkg/controller/quayecosystem/constants/constants.go
+++ b/pkg/controller/quayecosystem/constants/constants.go
@@ -14,13 +14,13 @@ const (
 	// OperatorName is a operator name
 	OperatorName = "quay-operator"
 	// QuayImage is the Quay image
-	QuayImage = "quay.io/redhat/quay:v3.1.3"
+	QuayImage = "quay.io/redhat/quay:v3.2.0"
 	// ImagePullSecret is the name of the image pull secret for retrieving images from a protected image registry
 	ImagePullSecret = "redhat-pull-secret"
 	// RedisImage is the name of the Redis Image
 	RedisImage = "registry.access.redhat.com/rhscl/redis-32-rhel7:latest"
 	// ClairImage is the Clair image
-	ClairImage = "quay.io/redhat/clair-jwt:v3.1.3"
+	ClairImage = "quay.io/redhat/clair-jwt:v3.2.0"
 	// LabelAppKey is the name of the label key
 	LabelAppKey = "app"
 	// LabelAppValue is the name of the label


### PR DESCRIPTION
There are new versions of Quay and Clair available. This change-set simply updates the references to use those images.

Addresses #108 