### PR TITLE
Mark `redis` and `hostname` as read-only in the config app.

### DIFF
--- a/pkg/controller/quayecosystem/constants/constants.go
+++ b/pkg/controller/quayecosystem/constants/constants.go
@@ -154,6 +154,13 @@ const (
 	InitialQuaySuperuserDefaultEmail = "changeme@example.com"
 	// EncryptedRobotTokenMigrationPhase represents the name of a envirnment variable required or quay containers
 	EncryptedRobotTokenMigrationPhase = "EncryptedRobotTokenMigrationPhase"
+	// QuayConfigReadOnlyEnvName represents the environment variable used to
+	//     mark fields in the Quay Config App as read only.
+	QuayConfigReadOnlyEnvName = "CONFIG_READ_ONLY_FIELDS"
+	// QuayConfigReadOnlyValues specifies which values should be marked as
+	//     read-only in the Quay Config App. These should be managed and
+	//     reconciled by the Operator.
+	QuayConfigReadOnlyValues = "hostname,redis"
 
 	// RegistryStorageDefaultName is the name of the default storage
 	RegistryStorageDefaultName = "default"

--- a/pkg/controller/quayecosystem/resources/deployments.go
+++ b/pkg/controller/quayecosystem/resources/deployments.go
@@ -98,6 +98,10 @@ func GetQuayConfigDeploymentDefinition(meta metav1.ObjectMeta, quayConfiguration
 			Value: string(quayConfiguration.QuayEcosystem.Spec.Quay.MigrationPhase),
 		},
 		{
+			Name:  constants.QuayConfigReadOnlyEnvName,
+			Value: constants.QuayConfigReadOnlyValues,
+		},
+		{
 			Name:  constants.QuayEntryName,
 			Value: constants.QuayEntryConfigValue,
 		},


### PR DESCRIPTION
**Description:**

This will mark `redis` and the `hostname` as read-only within Quay's configuration app.

**Acceptance Criteria:**

- Deploy Quay, ensuring the Configuration Application is not terminated.
- Access the Configuration Application.
- Verify that the UI does not allow the User to change anything related to the hostname configuration or the Redis configuration.
- The pod running the Quay Config App should have the following environment variable specified: `CONFIG_READ_ONLY_FIELDS=hostname,redis`