### PR TITLE
Add Quay Metrics Port 9091 to Quay deployment and service

### DIFF
--- a/pkg/controller/quayecosystem/constants/constants.go
+++ b/pkg/controller/quayecosystem/constants/constants.go
@@ -251,8 +251,8 @@ const (
 	QuayHTTPContainerPort = 8080
 	// QuayHTTPSContainerPort is the HTTPS container port for Quay
 	QuayHTTPSContainerPort = 8443
-	// QuayRepoMirrorContainerPort is the port for the Quay Repo Mirror
-	QuayRepoMirrorContainerPort = 9091
+	// QuayMetricsServicePort is the port for the Quay metrics
+	QuayMetricsServicePort = 9091
 	// SecurityScannerService is the name of the security scanner service
 	SecurityScannerService = "security_scanner"
 	// SecurityScannerServiceSecretKey is the name of the key containing the security service private key

--- a/pkg/controller/quayecosystem/resources/deployments.go
+++ b/pkg/controller/quayecosystem/resources/deployments.go
@@ -239,7 +239,7 @@ func GetQuayRepoMirrorDeploymentDefinition(meta metav1.ObjectMeta, quayConfigura
 			Name:  constants.QuayContainerRepoMirrorName,
 			Env:   envVars,
 			Ports: []corev1.ContainerPort{{
-				ContainerPort: constants.QuayRepoMirrorContainerPort,
+				ContainerPort: constants.QuayMetricsServicePort,
 				Name:          "http",
 			}},
 			VolumeMounts: []corev1.VolumeMount{corev1.VolumeMount{
@@ -253,7 +253,7 @@ func GetQuayRepoMirrorDeploymentDefinition(meta metav1.ObjectMeta, quayConfigura
 				InitialDelaySeconds: 10,
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{IntVal: constants.QuayRepoMirrorContainerPort},
+						Port: intstr.IntOrString{IntVal: constants.QuayMetricsServicePort},
 					},
 				},
 			},
@@ -262,7 +262,7 @@ func GetQuayRepoMirrorDeploymentDefinition(meta metav1.ObjectMeta, quayConfigura
 				InitialDelaySeconds: 30,
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{IntVal: constants.QuayRepoMirrorContainerPort},
+						Port: intstr.IntOrString{IntVal: constants.QuayMetricsServicePort},
 					},
 				},
 			},
@@ -354,6 +354,9 @@ func GetQuayDeploymentDefinition(meta metav1.ObjectMeta, quayConfiguration *Quay
 			}, {
 				ContainerPort: constants.QuayHTTPSContainerPort,
 				Name:          "https",
+			}, {
+				ContainerPort: constants.QuayMetricsServicePort,
+				Name:          "metrics",
 			}},
 			VolumeMounts: []corev1.VolumeMount{corev1.VolumeMount{
 				Name:      constants.QuayConfigVolumeName,

--- a/pkg/controller/quayecosystem/resources/services.go
+++ b/pkg/controller/quayecosystem/resources/services.go
@@ -51,9 +51,16 @@ func GetQuayServiceDefinition(meta metav1.ObjectMeta, quayEcosystem *redhatcopv1
 			Selector:  meta.Labels,
 			Ports: []corev1.ServicePort{
 				{
+					Name:       "quay-service",
 					Port:       GetQuayServicePort(*quayEcosystem),
 					Protocol:   "TCP",
 					TargetPort: intstr.FromInt(int(quayEcosystem.GetQuayPort())),
+				},
+				{
+					Name:       "metrics",
+					Port:       9091,
+					Protocol:   "TCP",
+					TargetPort: intstr.FromInt(constants.QuayMetricsServicePort),
 				},
 			},
 		},


### PR DESCRIPTION
Since Prometheus Pushgateway is used for metrics and it can be accessed via port 9091, adding it to the Quay service.

P.S.
Exists in OCP templates as well:
https://github.com/quay/quay/blob/e919361a9aad73df015c692e31a1fe1d015cafa4/deploy/openshift/quay-app.yaml#L62