### PR TITLE
Enabled ability to specify config file properties

### DIFF
--- a/deploy/crds/redhatcop.redhat.io_quayecosystems_crd-3.x.yaml
+++ b/deploy/crds/redhatcop.redhat.io_quayecosystems_crd-3.x.yaml
@@ -1274,6 +1274,10 @@ spec:
                     - name
                     type: object
                   type: array
+                configFileProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
                 configFiles:
                   items:
                     description: ConfigFiles defines configuration files that are

--- a/deploy/crds/redhatcop.redhat.io_quayecosystems_crd.yaml
+++ b/deploy/crds/redhatcop.redhat.io_quayecosystems_crd.yaml
@@ -1274,6 +1274,10 @@ spec:
                     - name
                     type: object
                   type: array
+                configFileProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
                 configFiles:
                   items:
                     description: ConfigFiles defines configuration files that are

--- a/pkg/apis/redhatcop/v1alpha1/quayecosystem_types.go
+++ b/pkg/apis/redhatcop/v1alpha1/quayecosystem_types.go
@@ -142,9 +142,10 @@ type QuayEcosystemList struct {
 // +k8s:openapi-gen=true
 type Quay struct {
 	// +listType=atomic
-	ConfigEnvVars    []corev1.EnvVar             `json:"configEnvVars,omitempty"`
-	ConfigResources  corev1.ResourceRequirements `json:"configResources,omitempty" protobuf:"bytes,2,opt,name=configResources"`
-	ConfigSecretName string                      `json:"configSecretName,omitempty"`
+	ConfigEnvVars        []corev1.EnvVar             `json:"configEnvVars,omitempty"`
+	ConfigFileProperties map[string]string           `json:"configFileProperties,omitempty" protobuf:"bytes,7,rep,name=configFileProperties"`
+	ConfigResources      corev1.ResourceRequirements `json:"configResources,omitempty" protobuf:"bytes,2,opt,name=configResources"`
+	ConfigSecretName     string                      `json:"configSecretName,omitempty"`
 	// +listType=set
 	ConfigTolerations []corev1.Toleration `json:"configTolerations,omitempty" protobuf:"bytes,22,opt,name=configTolerations"`
 

--- a/pkg/apis/redhatcop/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/redhatcop/v1alpha1/zz_generated.deepcopy.go
@@ -307,6 +307,13 @@ func (in *Quay) DeepCopyInto(out *Quay) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ConfigFileProperties != nil {
+		in, out := &in.ConfigFileProperties, &out.ConfigFileProperties
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.ConfigResources.DeepCopyInto(&out.ConfigResources)
 	if in.ConfigTolerations != nil {
 		in, out := &in.ConfigTolerations, &out.ConfigTolerations

--- a/pkg/apis/redhatcop/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/redhatcop/v1alpha1/zz_generated.openapi.go
@@ -699,6 +699,20 @@ func schema_pkg_apis_redhatcop_v1alpha1_Quay(ref common.ReferenceCallback) commo
 							},
 						},
 					},
+					"configFileProperties": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 					"configResources": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),

--- a/pkg/controller/quayecosystem/setup/setup.go
+++ b/pkg/controller/quayecosystem/setup/setup.go
@@ -255,6 +255,12 @@ func (qm *QuaySetupManager) SetupQuay(quaySetupInstance *QuaySetupInstance) erro
 		quayConfig.Config["SUPER_USERS"] = quaySetupInstance.quayConfiguration.QuayEcosystem.Spec.Quay.Superusers
 	}
 
+	if !utils.IsZeroOfUnderlyingType(quaySetupInstance.quayConfiguration.QuayEcosystem.Spec.Quay.ConfigFileProperties) {
+		for configFileKey, configFile := range quaySetupInstance.quayConfiguration.QuayEcosystem.Spec.Quay.ConfigFileProperties {
+			quayConfig.Config[configFileKey] = configFile
+		}
+	}
+
 	quayConfig.Config["SETUP_COMPLETE"] = true
 	_, quayConfig, err = quaySetupInstance.setupClient.UpdateQuayConfiguration(quayConfig)
 

--- a/pkg/controller/quayecosystem/validation/validate.go
+++ b/pkg/controller/quayecosystem/validation/validate.go
@@ -421,6 +421,14 @@ func Validate(client client.Client, quayConfiguration *resources.QuayConfigurati
 
 	}
 
+	if !utils.IsZeroOfUnderlyingType(quayConfiguration.QuayEcosystem.Spec.Quay.ConfigFileProperties) {
+		for configfileKey, configFileValue := range quayConfiguration.QuayEcosystem.Spec.Quay.ConfigFileProperties {
+			if utils.IsZeroOfUnderlyingType(configFileValue) || len(configFileValue) == 0 {
+				return false, fmt.Errorf("Provided ConfigFile Property with key '%s' not specified", configfileKey)
+			}
+		}
+	}
+
 	if quayConfiguration.QuayEcosystem.Spec.Clair != nil && quayConfiguration.QuayEcosystem.Spec.Clair.Enabled {
 
 		// Validate Clair ImagePullSecret

--- a/pkg/controller/quayecosystem/validation/validate_test.go
+++ b/pkg/controller/quayecosystem/validation/validate_test.go
@@ -225,3 +225,32 @@ func TestValidateQuayDatabaseSecret(t *testing.T) {
 	assert.Equal(t, validQuaySuperuserSecret, true)
 	assert.Equal(t, superuserSecret, secret)
 }
+
+func TestEmptyConfigFileValue(t *testing.T) {
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{}
+	// Initialize fake client
+	cl := fake.NewFakeClient(objs...)
+	// Stub out object placeholders for test
+	quayEcosystem := &redhatcopv1alpha1.QuayEcosystem{}
+
+	quayConfiguration := resources.QuayConfiguration{
+		IsOpenShift:   true,
+		QuayEcosystem: quayEcosystem,
+	}
+
+	// Set default values
+	defaultConfig := SetDefaults(cl, &quayConfiguration)
+	assert.Equal(t, defaultConfig, true)
+
+	quayConfiguration.QuayEcosystem.Spec.Quay.ConfigFileProperties = map[string]string{
+		"MAIL_DEFAULT_SENDER": "",
+	}
+
+	validate, err := Validate(cl, &quayConfiguration)
+
+	assert.Error(t, err)
+	assert.Equal(t, validate, false)
+
+}


### PR DESCRIPTION
New feature to allow users to explicitly specify values for the `config.yaml` file. This enables a new breadth of options that the Operator doesnt currently manage/support

 This has been marked as a Beta feature

Outstanding questions:
* Do we want to have a list of properties that cannot be modified? (blacklist) 

Resolves #18 