### PR TITLE
Always use Port 8443 for QuayConfig Probe.

### DIFF
--- a/pkg/controller/quayecosystem/resources/deployments.go
+++ b/pkg/controller/quayecosystem/resources/deployments.go
@@ -152,7 +152,7 @@ func GetQuayConfigDeploymentDefinition(meta metav1.ObjectMeta, quayConfiguration
 				InitialDelaySeconds: 10,
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{IntVal: quayConfiguration.QuayEcosystem.GetQuayPort()},
+						Port: intstr.IntOrString{IntVal: constants.QuayHTTPSContainerPort},
 					},
 				},
 			},
@@ -161,7 +161,7 @@ func GetQuayConfigDeploymentDefinition(meta metav1.ObjectMeta, quayConfiguration
 				InitialDelaySeconds: 30,
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{IntVal: quayConfiguration.QuayEcosystem.GetQuayPort()},
+						Port: intstr.IntOrString{IntVal: constants.QuayHTTPSContainerPort},
 					},
 				},
 			},


### PR DESCRIPTION
**Description**

Fixes issue where the probe failed when using TLS Termination of types `edge` or `none`.

Previously, the Quay Configuration app probe would attempt to reach the Config App at port 8080 as it assumed there was no TLS being handled in the Quay pod. However, the Quay Config app _always_ uses a certificate, even if it has to generate it upon initialization.

**Acceptance Criteria**

The following CR should successfully deploy:
```
apiVersion: redhatcop.redhat.io/v1alpha1
kind: QuayEcosystem
metadata:
  name: edge-termination-quayecosystem
spec:
  quay:
    imagePullSecretName: redhat-pull-secret
    externalAccess:
      tls:
        termination: edge
```