### PR TITLE
Cherry-Pick #200 into 1.1.0-redhat release branch

### DIFF
--- a/pkg/controller/quayecosystem/resources/deployments.go
+++ b/pkg/controller/quayecosystem/resources/deployments.go
@@ -152,7 +152,7 @@ func GetQuayConfigDeploymentDefinition(meta metav1.ObjectMeta, quayConfiguration
 				InitialDelaySeconds: 10,
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{IntVal: quayConfiguration.QuayEcosystem.GetQuayPort()},
+						Port: intstr.IntOrString{IntVal: constants.QuayHTTPSContainerPort},
 					},
 				},
 			},
@@ -161,7 +161,7 @@ func GetQuayConfigDeploymentDefinition(meta metav1.ObjectMeta, quayConfiguration
 				InitialDelaySeconds: 30,
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{IntVal: quayConfiguration.QuayEcosystem.GetQuayPort()},
+						Port: intstr.IntOrString{IntVal: constants.QuayHTTPSContainerPort},
 					},
 				},
 			},


### PR DESCRIPTION
- Fixes issue where the probe failed when using TLS Termination
  of types `edge` or `none`.