### PR TITLE
Simplified external access logic

### DIFF
--- a/pkg/controller/quayecosystem/externalaccess/ingress.go
+++ b/pkg/controller/quayecosystem/externalaccess/ingress.go
@@ -42,7 +42,6 @@ func (r *IngressExternalAccess) ManageQuayConfigExternalAccess(meta metav1.Objec
 	if !utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname) {
 		r.QuayConfiguration.QuayConfigHostname = r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname
 		return r.configureIngress(meta, r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname, true)
-
 	} else {
 		r.QuayConfiguration.QuayConfigHostname = meta.Name
 		return nil

--- a/pkg/controller/quayecosystem/externalaccess/ingress.go
+++ b/pkg/controller/quayecosystem/externalaccess/ingress.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	"github.com/redhat-cop/quay-operator/pkg/controller/quayecosystem/logging"
 	"github.com/redhat-cop/quay-operator/pkg/controller/quayecosystem/resources"
+	"github.com/redhat-cop/quay-operator/pkg/controller/quayecosystem/utils"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,9 +39,15 @@ func (r *IngressExternalAccess) ManageQuayConfigExternalAccess(meta metav1.Objec
 
 	meta.Name = resources.GetQuayConfigResourcesName(r.QuayConfiguration.QuayEcosystem)
 
-	r.QuayConfiguration.QuayConfigHostname = r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname
+	if !utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname) {
+		r.QuayConfiguration.QuayConfigHostname = r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname
+		return r.configureIngress(meta, r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname, true)
 
-	return r.configureIngress(meta, r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname, true)
+	} else {
+		r.QuayConfiguration.QuayConfigHostname = meta.Name
+		return nil
+	}
+
 }
 
 func (r *IngressExternalAccess) RemoveQuayConfigExternalAccess(meta metav1.ObjectMeta) error {

--- a/pkg/controller/quayecosystem/externalaccess/loadbalancer.go
+++ b/pkg/controller/quayecosystem/externalaccess/loadbalancer.go
@@ -33,8 +33,10 @@ func (r *LoadBalancerExternalAccess) ManageQuayExternalAccess(meta metav1.Object
 		return err
 	}
 
-	if !utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname) {
+	if utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.Hostname) {
 		r.QuayConfiguration.QuayHostname = hostname
+	} else {
+		r.QuayConfiguration.QuayHostname = r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.Hostname
 	}
 
 	return nil

--- a/pkg/controller/quayecosystem/externalaccess/loadbalancer.go
+++ b/pkg/controller/quayecosystem/externalaccess/loadbalancer.go
@@ -33,7 +33,9 @@ func (r *LoadBalancerExternalAccess) ManageQuayExternalAccess(meta metav1.Object
 		return err
 	}
 
-	r.QuayConfiguration.QuayHostname = hostname
+	if !utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname) {
+		r.QuayConfiguration.QuayHostname = hostname
+	}
 
 	return nil
 
@@ -49,7 +51,9 @@ func (r *LoadBalancerExternalAccess) ManageQuayConfigExternalAccess(meta metav1.
 		return err
 	}
 
-	r.QuayConfiguration.QuayConfigHostname = hostname
+	if !utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname) {
+		r.QuayConfiguration.QuayConfigHostname = hostname
+	}
 
 	return nil
 
@@ -74,7 +78,7 @@ func (r *LoadBalancerExternalAccess) getHostnameFromExternalName(serviceName str
 	if service.Status.LoadBalancer.Ingress[0].Hostname != "" {
 		hostname := service.Status.LoadBalancer.Ingress[0].Hostname
 
-		logging.Log.Info(fmt.Sprintf("Waiting for Resolve LoadBalancer Service '%s'", hostname))
+		logging.Log.Info(fmt.Sprintf("Waiting to Resolve LoadBalancer Service '%s'", hostname))
 
 		err := utils.Retry(60, 5*time.Second, func() (err error) {
 			_, err = net.LookupIP(hostname)

--- a/pkg/controller/quayecosystem/externalaccess/nodeport.go
+++ b/pkg/controller/quayecosystem/externalaccess/nodeport.go
@@ -7,6 +7,7 @@ import (
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	"github.com/redhat-cop/quay-operator/pkg/controller/quayecosystem/logging"
 	"github.com/redhat-cop/quay-operator/pkg/controller/quayecosystem/resources"
+	"github.com/redhat-cop/quay-operator/pkg/controller/quayecosystem/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,11 @@ func (r *NodePortExternalAccess) ManageQuayExternalAccess(meta metav1.ObjectMeta
 		return err
 	}
 
-	r.QuayConfiguration.QuayHostname = r.formatHostname(r.QuayConfiguration.QuayHostname, nodePort)
+	if utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.Hostname) {
+		r.QuayConfiguration.QuayHostname = r.formatHostname(r.QuayConfiguration.QuayHostname, nodePort)
+	} else {
+		r.QuayConfiguration.QuayHostname = r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.Hostname
+	}
 
 	r.QuayConfiguration.QuayEcosystem.Status.Hostname = r.QuayConfiguration.QuayHostname
 
@@ -45,7 +50,9 @@ func (r *NodePortExternalAccess) ManageQuayConfigExternalAccess(meta metav1.Obje
 		return err
 	}
 
-	r.QuayConfiguration.QuayConfigHostname = r.formatHostname(r.QuayConfiguration.QuayConfigHostname, nodePort)
+	if utils.IsZeroOfUnderlyingType(r.QuayConfiguration.QuayEcosystem.Spec.Quay.ExternalAccess.ConfigHostname) {
+		r.QuayConfiguration.QuayConfigHostname = r.formatHostname(r.QuayConfiguration.QuayConfigHostname, nodePort)
+	}
 
 	return nil
 


### PR DESCRIPTION
Readjusted how hostnames are managed:

1. No longer automatically defaulting using provisioned external access methods for config routes
2. No longer overriding hostname to enable users to provide their own