### PR TITLE
Use latest Project Quay images

### DIFF
--- a/pkg/controller/quayecosystem/constants/constants.go
+++ b/pkg/controller/quayecosystem/constants/constants.go
@@ -14,13 +14,13 @@ const (
 	// OperatorName is a operator name
 	OperatorName = "quay-operator"
 	// QuayImage is the Quay image
-	QuayImage = "quay.io/projectquay/quay:latest"
+	QuayImage = "quay.io/projectquay/quay:padme"
 	// ImagePullSecret is the name of the image pull secret for retrieving images from a protected image registry
 	ImagePullSecret = "redhat-pull-secret"
 	// RedisImage is the name of the Redis Image
 	RedisImage = "registry.access.redhat.com/rhscl/redis-32-rhel7:latest"
 	// ClairImage is the Clair image
-	ClairImage = "quay.io/redhat/clair-jwt:v3.2.0"
+	ClairImage = "quay.io/projectquay/clair-jwt:padme"
 	// LabelAppKey is the name of the label key
 	LabelAppKey = "app"
 	// LabelAppValue is the name of the label


### PR DESCRIPTION
The latest upstream Project Quay images from the sprint `padme` are now available on quay.io. This Pull Request uses those images.