### PR TITLE
Ensure Extra Certs Uploaded Using Config App

### DIFF
--- a/pkg/client/quay.go
+++ b/pkg/client/quay.go
@@ -195,6 +195,22 @@ func (c *QuayClient) UploadFileResource(fileName string, content []byte) (*http.
 	return resp, quayStatusResponse, err
 }
 
+func (c *QuayClient) UploadCustomCertificate(certName string, certFile []byte) (*http.Response, error) {
+	req, err := c.newFileUploadRequest("POST", fmt.Sprintf("/api/v1/superuser/customcerts/%s", certName), certName, certFile)
+	if err != nil {
+		return nil, err
+	}
+	var result interface{}
+	resp, err := c.do(req, &result)
+
+	// Quay returns `HTTP 204` with an empty body on success
+	if err == io.EOF && resp.StatusCode == 204 {
+		return resp, nil
+	}
+
+	return resp, err
+}
+
 func (c *QuayClient) newFileUploadRequest(method, path string, fileName string, content []byte) (*http.Request, error) {
 	rel := &url.URL{Path: path}
 	u := c.BaseURL.ResolveReference(rel)


### PR DESCRIPTION
### Description

Any secrets of `type: extraCaCert` in the `QuayEcosystem` resource will be uploaded to the config app API (`POST /api/v1/superuser/customcerts/<certname>`), which has the side effect of[ installing them into the config app container](https://github.com/quay/quay/pull/276). Then, when the Operator goes to validate (which uses the config app API) a database, registry, or any other connection that uses self-signed cert, the validation will not fail SSL requirements because the cert has been installed in the container.

Fixes https://issues.redhat.com/browse/PROJQUAY-461