### PR TITLE
Populate Quay Config Secret with Extra Certs

### DIFF
--- a/pkg/controller/quayecosystem/resources/secrets.go
+++ b/pkg/controller/quayecosystem/resources/secrets.go
@@ -13,6 +13,7 @@ func GetSecretDefinition(meta metav1.ObjectMeta) *corev1.Secret {
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: meta,
+		Data:       map[string][]byte{},
 	}
 }
 


### PR DESCRIPTION
### Description

The `quay-enterprise-config-secret` will be created with any `extraCaCerts` already populated in the `Secret` body. This causes them to be [mounted and installed into the config app container at startup](https://github.com/quay/quay/pull/276), allowing validation of external services like RHOCS and LDAP which require self-signed certificates.

Fixes https://issues.redhat.com/browse/PROJQUAY-461
Fixes https://issues.redhat.com/browse/PROJQUAY-666
Resolves #137 