### PR TITLE
Adds support for server in Postgres secret

### DIFF
--- a/pkg/controller/quayecosystem/constants/constants.go
+++ b/pkg/controller/quayecosystem/constants/constants.go
@@ -80,6 +80,8 @@ const (
 	DatabaseCredentialsDatabaseKey = "database-name"
 	// DatabaseCredentialsRootPasswordKey represents the key for the database root password
 	DatabaseCredentialsRootPasswordKey = "database-root-password"
+	// DatabaseCredentialsServer represents the key for the database server
+	DatabaseCredentialsServerKey = "database-server"
 	// QuayDatabaseCredentialsDefaultUsername represents the default database username
 	QuayDatabaseCredentialsDefaultUsername = "quay"
 	// QuayDatabaseCredentialsDefaultPassword represents the default database password

--- a/pkg/controller/quayecosystem/validation/validate.go
+++ b/pkg/controller/quayecosystem/validation/validate.go
@@ -146,6 +146,15 @@ func Validate(client client.Client, quayConfiguration *resources.QuayConfigurati
 			quayConfiguration.QuayDatabase.Password = string(databaseSecret.Data[constants.DatabaseCredentialsPasswordKey])
 			quayConfiguration.QuayDatabase.Database = string(databaseSecret.Data[constants.DatabaseCredentialsDatabaseKey])
 
+			if _, found := databaseSecret.Data[constants.DatabaseCredentialsServerKey]; found {
+				quayConfiguration.QuayEcosystem.Spec.Quay.Database.Server = string(databaseSecret.Data[constants.DatabaseCredentialsServerKey])
+				quayConfiguration.QuayDatabase.Server = quayConfiguration.QuayEcosystem.Spec.Quay.Database.Server
+				quayConfiguration.QuayEcosystem.Spec.Quay.Database.Image = ""
+				quayConfiguration.QuayEcosystem.Spec.Quay.Database.DeploymentStrategy = ""
+				quayConfiguration.QuayEcosystem.Spec.Quay.Database.ReadinessProbe = nil
+				quayConfiguration.QuayEcosystem.Spec.Quay.Database.LivenessProbe = nil
+			}
+
 			if _, found := databaseSecret.Data[constants.DatabaseCredentialsRootPasswordKey]; found {
 				quayConfiguration.QuayDatabase.RootPassword = string(databaseSecret.Data[constants.DatabaseCredentialsRootPasswordKey])
 			}
@@ -469,6 +478,16 @@ func Validate(client client.Client, quayConfiguration *resources.QuayConfigurati
 			quayConfiguration.ClairDatabase.Username = string(databaseSecret.Data[constants.DatabaseCredentialsUsernameKey])
 			quayConfiguration.ClairDatabase.Password = string(databaseSecret.Data[constants.DatabaseCredentialsPasswordKey])
 			quayConfiguration.ClairDatabase.Database = string(databaseSecret.Data[constants.DatabaseCredentialsDatabaseKey])
+
+			// If the server is provided in the Secret, we override the defaults set in defaults.go
+			if _, found := databaseSecret.Data[constants.DatabaseCredentialsServerKey]; found {
+				quayConfiguration.ClairDatabase.Server = string(databaseSecret.Data[constants.DatabaseCredentialsServerKey])
+				quayConfiguration.QuayEcosystem.Spec.Clair.Database.Server = string(databaseSecret.Data[constants.DatabaseCredentialsServerKey])
+				quayConfiguration.QuayEcosystem.Spec.Clair.Database.ReadinessProbe = nil
+				quayConfiguration.QuayEcosystem.Spec.Clair.Database.LivenessProbe = nil
+				quayConfiguration.QuayEcosystem.Spec.Clair.Database.DeploymentStrategy = ""
+				quayConfiguration.QuayEcosystem.Spec.Clair.Database.Image = ""
+			}
 
 			if _, found := databaseSecret.Data[constants.DatabaseCredentialsRootPasswordKey]; found {
 				quayConfiguration.ClairDatabase.RootPassword = string(databaseSecret.Data[constants.DatabaseCredentialsRootPasswordKey])


### PR DESCRIPTION
This PR fixes #249.

## Proposed Changes
- Adds in support an optional key `server` inside of the Postgres. This key overrides the `server` key from the CRD spec if both are provided. This change supports has backward compatibility, and supports the server being provided inside of the CRD as well. 

It is well known that hardcoded credentials can open up security vulnerabilities, although the quay operator currently supports the username, password, database, etc. being stored in the secret, it omits the server's endpoint. This is still a piece of credential information, and as such, it should be treated as a secret. 