### PR TITLE
Current Version

### DIFF
--- a/api/v1/quayregistry_types.go
+++ b/api/v1/quayregistry_types.go
@@ -27,6 +27,13 @@ var allComponents = []string{
 	"storage",
 }
 
+type QuayVersion string
+
+const (
+	QuayVersionPadme  QuayVersion = "padme"
+	QuayVersionQuiGon QuayVersion = "qui-gon"
+)
+
 // QuayRegistrySpec defines the desired state of QuayRegistry.
 type QuayRegistrySpec struct {
 	// ConfigBundleSecret is the name of the Kubernetes `Secret` in the same namespace which contains the base Quay config and extra certs.
@@ -46,6 +53,8 @@ type Component struct {
 
 // QuayRegistryStatus defines the observed state of QuayRegistry.
 type QuayRegistryStatus struct {
+	// CurrentVersion is the actual version of Quay that is actively deployed.
+	CurrentVersion QuayVersion `json:"currentVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -64,6 +64,11 @@ spec:
           type: object
         status:
           description: QuayRegistryStatus defines the observed state of QuayRegistry.
+          properties:
+            currentVersion:
+              description: CurrentVersion is the actual version of Quay that is actively
+                deployed.
+              type: string
           type: object
       type: object
   version: v1

--- a/controllers/quayregistry_controller.go
+++ b/controllers/quayregistry_controller.go
@@ -79,6 +79,7 @@ func (r *QuayRegistryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		log.Error(err, "could not ensure default `spec.components`")
 		return ctrl.Result{}, err
 	}
+
 	if !v1.ComponentsMatch(quay.Spec.Components, updatedQuay.Spec.Components) {
 		log.Info("updating QuayRegistry `spec.components` to include defaults")
 		if err = r.Client.Update(ctx, updatedQuay); err != nil {
@@ -99,6 +100,14 @@ func (r *QuayRegistryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 
 	log.Info("all objects created/updated successfully")
+
+	updatedQuay.Status.CurrentVersion = v1.QuayVersionQuiGon
+	err = r.Client.Status().Update(ctx, updatedQuay)
+	if err != nil {
+		log.Error(err, "could not update QuayRegistry status with current version")
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
### Description

Implements basic `status.currentVersion` for the QuayRegistry` API. This field reflects the currently deployed version of the Quay app and components, and will be used by the Operator to know which rules to follow when upgrading.

Addresses https://issues.redhat.com/browse/PROJQUAY-908