### PR TITLE
[WIP] Deploy Config Editor (PROJQUAY-909)

### DIFF
--- a/api/v1/quayregistry_types.go
+++ b/api/v1/quayregistry_types.go
@@ -73,6 +73,7 @@ type QuayRegistryStatus struct {
 	CurrentVersion QuayVersion `json:"currentVersion,omitempty"`
 	// RegistryEndpoint is the external access point for the Quay registry.
 	RegistryEndpoint string `json:"registryEndpoint,omitempty"`
+	// TODO(alecmerdler): Config editor endpoint
 }
 
 // +kubebuilder:object:root=true

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quay-config-editor
+  labels:
+    quay-component: quay-config-editor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      quay-component: quay-config-editor
+  template:
+    metadata:
+      labels:
+        quay-component: quay-config-editor
+    spec:
+      volumes:
+        - name: config-bundle
+          secret:
+            secretName: quay-config-secret
+      containers:
+        - name: quay-config-editor
+          # FIXME(alecmerdler): Push to `projectquay/config-tool` and change tag here
+          image: quay.io/alecmerdler/config-tool:editor
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          args: ["editor", "--configPath", "$(QUAY_CONFIG_PATH)", "--password", "$(QUAY_PASSWORD)"]
+          env:
+            - name: QUAY_CONFIG_PATH
+              value: /config-bundle
+            - name: QUAY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: quay-config-editor-credentials
+                  key: password
+          volumeMounts:
+            - name: config-bundle
+              subPath: config.yaml
+              mountPath: /config-bundle

--- a/kustomize/base/config.service.yaml
+++ b/kustomize/base/config.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: quay-config-editor
+  labels:
+    quay-component: quay-config-editor
+spec:
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    quay-component: quay-config-editor

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -9,3 +9,13 @@ resources:
   - ./quay.deployment.yaml
   - ./quay.service.yaml
   - ./upgrade.deployment.yaml
+  - ./config.deployment.yaml
+  - ./config.service.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+secretGenerator:
+  - name: quay-config-editor-credentials
+    # FIXME(alecmerdler): Make this more secure...
+    literals:
+      - password=configeditor
+  

--- a/kustomize/components/route/config.route.yaml
+++ b/kustomize/components/route/config.route.yaml
@@ -1,0 +1,13 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: quay-config-editor
+spec:
+  to:
+    kind: Service
+    name: quay-config-editor
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/kustomize/components/route/config.service.patch.yaml
+++ b/kustomize/components/route/config.service.patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: quay-config-editor
+  labels:
+    quay-component: quay-config-editor
+spec:
+  type: ClusterIP
+  selector:
+    quay-component: quay-config-editor

--- a/kustomize/components/route/kustomization.yaml
+++ b/kustomize/components/route/kustomization.yaml
@@ -5,6 +5,8 @@ crds:
   - ./route.crd.json
 resources: 
   - ./quay.route.yaml
+  - ./config.route.yaml
 patchesStrategicMerge:
   # Switch `Service` to `type: ClusterIP`
   - ./quay.service.patch.yaml
+  - ./config.service.patch.yaml

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -196,6 +196,7 @@ func componentConfigFilesFor(component string, quay *v1.QuayRegistry) (map[strin
 	switch component {
 	case "clair":
 		return map[string][]byte{"config.yaml": clairConfigFor(quay)}, nil
+	// TODO(alecmerdler): Could add `config-editor` as separate component and generate password here...
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-909

**Changelog:** Web UI config editor is deployed with `Route` or `LoadBalancer` endpoint.

**Docs:** n/a

**Testing:** 
Confirm that a `Service` or `Route` is created when deploying a `QuayRegistry`

**Details:** 
Adds k8s `Deployment` and `Service` (and `Route` on OpenShift) which enables access to the config editor for re-configuration of Quay. This is an initial effort to have the config editor deployed; improvements to the re-configuration process will follow.

