### PR TITLE
Downstream Component Images (PROJQUAY-828)

### DIFF
--- a/kustomize/overlays/downstream/3.4.0/kustomization.yaml
+++ b/kustomize/overlays/downstream/3.4.0/kustomization.yaml
@@ -1,0 +1,20 @@
+# Overlay variant for Project Quay "padme" release.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization	
+commonAnnotations:
+  quay-version: v3.4.0
+bases:
+  - ../../../tmp
+images:
+  - name: quay.io/projectquay/quay
+    newName: quay.io/redhat/quay
+    newTag: v3.4.0
+  - name: quay.io/projectquay/clair
+    newName: quay.io/redhat/clair
+    newTag: v3.4.0
+  - name: redis
+    newName: registry.access.redhat.com/rhscl/redis-32-rhel7
+  - name: postgres
+    newName: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+    newTag: 1-35
+  # FIXME(alecmerdler): Need to handle `redhat-pull-secret` (potentially with a `secretGenerator`?)...

--- a/kustomize/overlays/downstream/3.4.0/upgrade/kustomization.yaml
+++ b/kustomize/overlays/downstream/3.4.0/upgrade/kustomization.yaml
@@ -1,0 +1,24 @@
+# Overlay variant for upgrading to Red Hat Quay "v3.4.0" release.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization	
+commonAnnotations:
+  quay-version: v3.4.0
+bases:
+  - ../../../../tmp
+patchesStrategicMerge:
+  # Scale the app deployment to 0 pods in order to run all migrations present in the new container image using the "upgrade" deployment.
+  - ./quay.deployment.patch.yaml
+  - ./upgrade.deployment.patch.yaml
+images:
+  - name: quay.io/projectquay/quay
+    newName: quay.io/redhat/quay
+    newTag: v3.4.0
+  - name: quay.io/projectquay/clair
+    newName: quay.io/redhat/clair
+    newTag: v3.4.0
+  - name: redis
+    newName: registry.access.redhat.com/rhscl/redis-32-rhel7
+  - name: postgres
+    newName: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+    newTag: 1-35
+  # FIXME(alecmerdler): Need to handle `redhat-pull-secret` (potentially with a `secretGenerator`?)...

--- a/kustomize/overlays/downstream/3.4.0/upgrade/quay.deployment.patch.yaml
+++ b/kustomize/overlays/downstream/3.4.0/upgrade/quay.deployment.patch.yaml
@@ -3,6 +3,6 @@ kind: Deployment
 metadata:
   name: quay-app
   annotations:
-    quay-upgrade: padme
+    quay-upgrade: v3.4.0
 spec:
   replicas: 0

--- a/kustomize/overlays/downstream/3.4.0/upgrade/upgrade.deployment.patch.yaml
+++ b/kustomize/overlays/downstream/3.4.0/upgrade/upgrade.deployment.patch.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: quay-app
+  name: quay-app-upgrade
   annotations:
-    quay-upgrade: padme
+    quay-upgrade: v3.4.0
 spec:
-  replicas: 0
+  replicas: 1


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-828

**Changelog:** Add initial downstream release Kustomize overlay for managed component container images.

**Docs:** Ensure that users know how to create `redhat-pull-secret` ([documentation exists](https://access.redhat.com/solutions/3533201)).

**Testing:** 
1. Create `redhat-pull-secret` in same namespace as `QuayRegistry`.
2. Create `QuayRegistry` with some managed components.

Expected:
- All containers pull successfully.

**Details:** Adds Kustomize overlays for an initial downstream release using official Red Hat container images for relevant managed components. These container images require a [Red Hat pull secret](https://access.redhat.com/solutions/3533201). 
