### PR TITLE
Zero Config Installation (PROJQUAY-853)

### DIFF
--- a/api/v1/quayregistry_types.go
+++ b/api/v1/quayregistry_types.go
@@ -53,7 +53,7 @@ type QuayRegistrySpec struct {
 	// If omitted, will default to the latest version that the Operator knows how to manage.
 	DesiredVersion QuayVersion `json:"desiredVersion,omitempty"`
 	// ConfigBundleSecret is the name of the Kubernetes `Secret` in the same namespace which contains the base Quay config and extra certs.
-	ConfigBundleSecret string `json:"configBundleSecret"`
+	ConfigBundleSecret string `json:"configBundleSecret,omitempty"`
 	// Components declare how the Operator should handle backing Quay services.
 	Components []Component `json:"components,omitempty"`
 }

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -69,8 +69,6 @@ spec:
                 the Operator will not upgrade. If omitted, will default to the latest
                 version that the Operator knows how to manage.
               type: string
-          required:
-          - configBundleSecret
           type: object
         status:
           description: QuayRegistryStatus defines the observed state of QuayRegistry.

--- a/config/samples/managed.quayregistry.yaml
+++ b/config/samples/managed.quayregistry.yaml
@@ -2,5 +2,3 @@ apiVersion: quay.redhat.com/v1
 kind: QuayRegistry
 metadata:
   name: skynet
-spec:
-  configBundleSecret: quay-config-bundle-abc123

--- a/controllers/quayregistry_controller_test.go
+++ b/controllers/quayregistry_controller_test.go
@@ -144,7 +144,33 @@ var _ = Describe("QuayRegistryReconciler", func() {
 		})
 
 		Context("on a newly created `QuayRegistry`", func() {
-			Context("which references a `configBundleSecret` that does not exist", func() {
+			When("the `configBundleSecret` field is empty", func() {
+				BeforeEach(func() {
+					quayRegistry.Spec.ConfigBundleSecret = ""
+				})
+
+				It("should not return an error", func() {
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				It("should create a fresh `Secret` and populate `configBundleSecret`", func() {
+					var updatedQuayRegistry v1.QuayRegistry
+					var configBundleSecret corev1.Secret
+
+					Expect(k8sClient.Get(context.Background(), quayRegistryName, &updatedQuayRegistry)).To(Succeed())
+					Expect(updatedQuayRegistry.Spec.ConfigBundleSecret).To(ContainSubstring(quayRegistry.GetName() + "-config-bundle-"))
+
+					Expect(k8sClient.Get(
+						context.Background(),
+						types.NamespacedName{
+							Name:      updatedQuayRegistry.Spec.ConfigBundleSecret,
+							Namespace: quayRegistry.GetNamespace()},
+						&configBundleSecret)).
+						Should(Succeed())
+				})
+			})
+
+			When("it references a `configBundleSecret` that does not exist", func() {
 				BeforeEach(func() {
 					quayRegistry.Spec.ConfigBundleSecret = "does-not-exist"
 				})
@@ -171,12 +197,12 @@ var _ = Describe("QuayRegistryReconciler", func() {
 				It("does not set the current version in the `status` block", func() {
 					var updatedQuayRegistry v1.QuayRegistry
 
-					Expect(k8sClient.Get(context.Background(), quayRegistryName, &updatedQuayRegistry))
+					Expect(k8sClient.Get(context.Background(), quayRegistryName, &updatedQuayRegistry)).Should(Succeed())
 					Expect(len(updatedQuayRegistry.Status.CurrentVersion)).To(Equal(0))
 				})
 			})
 
-			Context("which references a `configBundleSecret` that does exist", func() {
+			When("it references a `configBundleSecret` that does exist", func() {
 				It("should not return an error", func() {
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -223,7 +249,7 @@ var _ = Describe("QuayRegistryReconciler", func() {
 					It("will populate the `spec.desiredVersion` field with the latest version", func() {
 						var updatedQuayRegistry v1.QuayRegistry
 
-						Expect(k8sClient.Get(context.Background(), quayRegistryName, &updatedQuayRegistry))
+						Expect(k8sClient.Get(context.Background(), quayRegistryName, &updatedQuayRegistry)).Should(Succeed())
 						Expect(updatedQuayRegistry.Spec.DesiredVersion).To(Equal(v1.QuayVersionQuiGon))
 					})
 				})
@@ -273,7 +299,33 @@ var _ = Describe("QuayRegistryReconciler", func() {
 				_ = k8sClient.List(context.Background(), &oldPods, &listOptions)
 			})
 
-			Context("which references a `configBundleSecret` that does not exist", func() {
+			When("the `configBundleSecret` field is empty", func() {
+				BeforeEach(func() {
+					quayRegistry.Spec.ConfigBundleSecret = ""
+				})
+
+				It("should not return an error", func() {
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				It("should create a fresh `Secret` and populate `configBundleSecret`", func() {
+					var updatedQuayRegistry v1.QuayRegistry
+					var configBundleSecret corev1.Secret
+
+					Expect(k8sClient.Get(context.Background(), quayRegistryName, &updatedQuayRegistry)).To(Succeed())
+					Expect(updatedQuayRegistry.Spec.ConfigBundleSecret).To(ContainSubstring(quayRegistry.GetName() + "-config-bundle-"))
+
+					Expect(k8sClient.Get(
+						context.Background(),
+						types.NamespacedName{
+							Name:      updatedQuayRegistry.Spec.ConfigBundleSecret,
+							Namespace: quayRegistry.GetNamespace()},
+						&configBundleSecret)).
+						Should(Succeed())
+				})
+			})
+
+			When("it references a `configBundleSecret` that does not exist", func() {
 				JustBeforeEach(func() {
 					Expect(k8sClient.Get(context.Background(), quayRegistryName, &quayRegistry))
 					quayRegistry.Spec.ConfigBundleSecret = "does-not-exist"
@@ -310,7 +362,7 @@ var _ = Describe("QuayRegistryReconciler", func() {
 				})
 			})
 
-			Context("which references a `configBundleSecret` that does exist", func() {
+			When("it references a `configBundleSecret` that does exist", func() {
 				JustBeforeEach(func() {
 					result, err = controller.Reconcile(reconcile.Request{NamespacedName: quayRegistryName})
 				})

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -191,6 +191,15 @@ func ConfigFileFor(component string, quay *v1.QuayRegistry) ([]byte, error) {
 	}
 }
 
+// BaseConfigBundle returns a minimum config bundle with values that Quay doesn't have defaults for.
+func BaseConfigBundle() map[string][]byte {
+	return map[string][]byte{
+		"config.yaml": encode(map[string]interface{}{
+			"FEATURE_MAILING": false,
+		}),
+	}
+}
+
 // componentConfigFilesFor returns specific config files for managed components of a Quay registry.
 func componentConfigFilesFor(component string, quay *v1.QuayRegistry) (map[string][]byte, error) {
 	switch component {


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-853

**Changelog:** Allow creating `QuayRegistry` without specifying `spec.configBundleSecret`.

**Docs:** You can now get a full working installation by creating a `QuayRegistry` with an empty `spec` block.

**Testing:** 

1. Run the controller:
```sh 
$ go run main.go
```

2. Create the `QuayRegistry`
```sh
$ kubectl create -n <your-namespace> -f ./config/samples/managed.quayregistry.yaml
```

3. Expect that `spec.configBundleSecret` is populated and references a `Secret` which exists. Expect that all components deploy successfully and eventually registry is accessible via `status.registryEndpoint`

**Details:** 
When creating a `QuayRegistry` without specifying `spec.configBundleSecret`, the Operator will create a base `Secret` for you and fill in the field itself. Only guaranteed to work if all components are marked as `managed: true` (otherwise Quay app pod will fail because of missing component config, for example database connection string).
