### PR TITLE
Mount OpenShift Service CA (PROJQUAY-860)

### DIFF
--- a/kustomize/base/extra-certs.configmap.yaml
+++ b/kustomize/base/extra-certs.configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quay-extra-certs
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources: 
   - ./quay.role.yaml
   - ./quay.rolebinding.yaml
+  - ./extra-certs.configmap.yaml
   - ./quay.deployment.yaml
   - ./quay.service.yaml
   - ./upgrade.deployment.yaml

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -20,6 +20,9 @@ spec:
         - name: configvolume
           secret:
             secretName: quay-config-secret
+        - name: extra-ca-certs
+          configMap:
+            name: quay-extra-certs
       containers:
         - name: quay-app
           image: quay.io/projectquay/quay
@@ -70,3 +73,6 @@ spec:
             - name: configvolume
               readOnly: false
               mountPath: /conf/stack
+            - name: extra-ca-certs
+              readOnly: true
+              mountPath: /conf/kube_extra_certs

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -20,6 +20,9 @@ spec:
         - name: configvolume
           secret:
             secretName: quay-config-secret
+        - name: extra-ca-certs
+          configMap:
+            name: quay-extra-certs
       containers:
         - name: quay-app-upgrade
           image: quay.io/projectquay/quay
@@ -68,3 +71,6 @@ spec:
             - name: configvolume
               readOnly: false
               mountPath: /conf/stack
+            - name: extra-ca-certs
+              readOnly: true
+              mountPath: /conf/kube_extra_certs

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -179,6 +179,7 @@ var quayComponents = map[string][]runtime.Object{
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-app-deployment"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-secret"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-extra-certs"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-registry-managed-secret-keys"}},
 	},
 	"clair": {


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-860

**Changelog:** Mount cluster service serving CA into Quay app pods.

**Docs:** n/a

**Testing:** n/a

**Details:** 
The Quay app pods will now be able to trust any [service using SSL certificates provided by the cluster CA](https://docs.openshift.com/container-platform/4.5/security/certificates/service-serving-certificate.html#add-service-certificate-configmap_service-serving-certificate) (including `Routes` and service serving certs).
