### PR TITLE
Use Vendor Directory in Dockerfile for Local Dev Overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ FROM golang:1.13 as builder
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
-RUN go mod download
+COPY vendor vendor
 
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o manager main.go
 
 FROM scratch
 WORKDIR /workspace


### PR DESCRIPTION
**Issue:** N/A

**Changelog:** Use `vendor` directory in `Dockerfile`.

**Docs:** N/A

**Testing:** N/A

**Details:** Allows us to still build an Operator container when using overrides in `go.mod`.
