### PR TITLE
Route Managed Component Enhancements (PROJQUAY-1091)

### DIFF
--- a/controllers/quayregistry_controller_test.go
+++ b/controllers/quayregistry_controller_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,19 +19,6 @@ import (
 
 	v1 "github.com/quay/quay-operator/api/v1"
 )
-
-func encode(value interface{}) []byte {
-	yamlified, _ := yaml.Marshal(value)
-
-	return yamlified
-}
-
-func decode(bytes []byte) interface{} {
-	var value interface{}
-	_ = yaml.Unmarshal(bytes, &value)
-
-	return value
-}
 
 func newQuayRegistry(name, namespace string) v1.QuayRegistry {
 	return v1.QuayRegistry{

--- a/kustomize/app/bundle/config.yaml
+++ b/kustomize/app/bundle/config.yaml
@@ -1,7 +1,1 @@
-ENTERPRISE_LOGO_URL: /static/img/quay-horizontal-color.svg
-FEATURE_MAILING: false
-FEATURE_SUPER_USERS: true
-SUPER_USERS:
-- admin
-REGISTRY_TITLE: Quay
-REGISTRY_TITLE_SHORT: Quay
+SERVER_HOSTNAME: registry.skynet-dev.com

--- a/kustomize/components/route/kustomization.yaml
+++ b/kustomize/components/route/kustomization.yaml
@@ -10,3 +10,28 @@ patchesStrategicMerge:
   # Switch `Service` to `type: ClusterIP`
   - ./quay.service.patch.yaml
   - ./config.service.patch.yaml
+configurations:
+  - ./route.varreferences.yaml
+# NOTE: Using `vars` in Kustomize is kinda ugly because it's basically templating, so don't abuse them
+vars:
+  - name: SERVER_HOSTNAME
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: quay-app
+    fieldref:
+      fieldpath: metadata.annotations["quay-registry-hostname"]
+  - name: QUAY_TLS_TERMINATION
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: quay-app
+    fieldref:
+      fieldpath: metadata.annotations["quay-registry-tls-termination"]
+  - name: QUAY_TARGET_PORT
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: quay-app
+    fieldref:
+      fieldpath: metadata.annotations["quay-registry-target-port"]

--- a/kustomize/components/route/quay.route.yaml
+++ b/kustomize/components/route/quay.route.yaml
@@ -3,11 +3,12 @@ apiVersion: route.openshift.io/v1
 metadata:
   name: quay
 spec:
+  host: $(SERVER_HOSTNAME)
   to:
     kind: Service
     name: quay-app
   port:
-    targetPort: http
+    targetPort: $(QUAY_TARGET_PORT)
   tls:
-    termination: edge
+    termination: $(QUAY_TLS_TERMINATION)
     insecureEdgeTerminationPolicy: Redirect

--- a/kustomize/components/route/route.varreferences.yaml
+++ b/kustomize/components/route/route.varreferences.yaml
@@ -1,0 +1,7 @@
+varReference:
+  - kind: Route
+    path: spec/host
+  - kind: Route
+    path: spec/tls/termination
+  - kind: Route
+    path: spec/port/targetPort

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	v1 "github.com/quay/quay-operator/api/v1"
 )
@@ -32,7 +33,7 @@ func quayRegistry(name string) *v1.QuayRegistry {
 	}
 }
 
-var configFileForTests = []struct {
+var fieldGroupForTests = []struct {
 	name      string
 	component string
 	quay      *v1.QuayRegistry
@@ -99,13 +100,17 @@ FEATURE_STORAGE_REPLICATION: false
 	},
 }
 
-func TestConfigFileFor(t *testing.T) {
+func TestFieldGroupFor(t *testing.T) {
 	assert := assert.New(t)
 
-	for _, test := range configFileForTests {
-		result, err := ConfigFileFor(test.component, test.quay)
+	for _, test := range fieldGroupForTests {
+		fieldGroup, err := FieldGroupFor(test.component, test.quay)
 
 		assert.Nil(err)
-		assert.Equal(string(test.expected), string(result), test.name)
+
+		configFields, err := yaml.Marshal(fieldGroup)
+
+		assert.Nil(err)
+		assert.Equal(string(test.expected), string(configFields), test.name)
 	}
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1091

**Changelog:** Allow user-provided hostname and SSL certificate/key pair for `route` managed component.

**Docs:** There are now two scenarios for using the `route` managed component.
1. User creates and references `configBundleSecret` which contains `SERVER_HOSTNAME` field and `ssl.key` + `ssl.cert`. The created `Route` will have `passthrough` TLS termination and the custom hostname set. User will then need to create a CNAME record for their domain pointing to the router.
2. User creates zero-config `QuayRegistry`. A `Route` is created with a generated hostname and `edge` TLS termination using the cluster CA certs.

**Testing:** Create and reference a `configBundleSecret` which contains `SERVER_HOSTNAME` field and `ssl.key` + `ssl.cert` which are valid for that hostname. Check that the `Route` has the correct hostname and that the keypair is mounted into the Quay app `Deployment`.

**Details:** Previously, the `route` managed component used TLS edge-termination with the cluster certs and just targeted the `HTTP` port on the Quay pod, and also the default generated `spec.hostname`. Now we use TLS `passthrough` with the user-provided certificate/keypair and hostname if they have been provided in the config bundle. If not present, we fall back to existing behavior using cluster certificate and generated hostname.

### Screenshots

**Config editor UI showing managed `route` component w/ user-defined hostname**:
![Screenshot_20200916_130546](https://user-images.githubusercontent.com/11700385/93387059-79d58d80-f81d-11ea-8ea5-0d5903d83f3b.png)
