### PR TITLE
Remove Extra Reconciliation During Errors (PROJQUAY-1102)

### DIFF
--- a/controllers/features.go
+++ b/controllers/features.go
@@ -88,6 +88,8 @@ func (r *QuayRegistryReconciler) checkObjectBucketClaimsAvailable(quay *v1.QuayR
 			}
 		}
 		quay.SetAnnotations(existingAnnotations)
+	} else if err != nil {
+		r.Log.Info("cluster does not support `ObjectBucketClaim` API")
 	}
 
 	return quay, nil

--- a/controllers/quayregistry_controller_test.go
+++ b/controllers/quayregistry_controller_test.go
@@ -161,8 +161,8 @@ var _ = Describe("QuayRegistryReconciler", func() {
 					quayRegistry.Spec.ConfigBundleSecret = "does-not-exist"
 				})
 
-				It("should return an error", func() {
-					Expect(err).To(HaveOccurred())
+				It("should not return an error", func() {
+					Expect(err).NotTo(HaveOccurred())
 					Expect(result.Requeue).To(BeFalse())
 				})
 
@@ -191,6 +191,7 @@ var _ = Describe("QuayRegistryReconciler", func() {
 			When("it references a `configBundleSecret` that does exist", func() {
 				It("should not return an error", func() {
 					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
 				})
 
 				It("will create Quay objects on the cluster with `ownerReferences` back to the `QuayRegistry`", func() {
@@ -292,6 +293,7 @@ var _ = Describe("QuayRegistryReconciler", func() {
 
 				It("should not return an error", func() {
 					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
 				})
 
 				It("should create a fresh `Secret` and populate `configBundleSecret`", func() {
@@ -320,8 +322,8 @@ var _ = Describe("QuayRegistryReconciler", func() {
 					result, err = controller.Reconcile(reconcile.Request{NamespacedName: quayRegistryName})
 				})
 
-				It("should return an error", func() {
-					Expect(err).To(HaveOccurred())
+				It("should not return an error", func() {
+					Expect(err).NotTo(HaveOccurred())
 					Expect(result.Requeue).To(BeFalse())
 				})
 
@@ -397,6 +399,7 @@ var _ = Describe("QuayRegistryReconciler", func() {
 
 			It("should not return an error", func() {
 				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
 			})
 		})
 	})


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1102

**Changelog:** Stop returning errors from `Reconcile()` function when requeue is unnecessary.

**Docs:** N/a

**Testing:** Create `QuayRegistry` which has some misconfigured field and ensure that it does not requeue. 

**Details:** Discovered from [this article on using Kubebuilder](https://engineering.pivotal.io/post/gp4k-kubebuilder-lessons/), the `controller-runtime` library will requeue the reconcile by default if an error is returned from the `Reconcile()` function. Change all our returned errors to `nil` or use `Requeue: true` if we desired this behavior in order to avoid verbose logging of the full stack trace in addition to our own error logging.
