### PR TITLE
Route TLS Fixes for Security Scanner (PROJQUAY-1091)

### DIFF
--- a/docs/external-access.md
+++ b/docs/external-access.md
@@ -25,7 +25,7 @@ status:
 
 ### Default Hostname and TLS
 
-By default, a `Route` will be created with the default generated hostname and TLS edge termination using the cluster TLS.
+By default, a `Route` will be created with the default generated hostname and a certificate/key pair will be generated for TLS.
 
 ### Custom Hostname and TLS
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/quay/clair/v4 v4.0.0-rc.2
+	github.com/quay/clair/v4 v4.0.0-rc.3
+	github.com/quay/claircore v1.0.5 // indirect
 	github.com/quay/config-tool v0.1.2-0.20200914221214-89ccb1fec55a
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,9 @@ github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d h1:K6eOUihrFLdZjZ
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/clair/v4 v4.0.0-rc.2 h1:rVK0Axr6LStM1Wby4OOSUWcsumXQQ4oUv8KACpapK+Y=
-github.com/quay/clair/v4 v4.0.0-rc.2/go.mod h1:wRXR+KLKlLoI0bWXnshtsBCJzMIBAePmDSa/ChJcW2g=
+github.com/quay/clair/v4 v4.0.0-rc.3 h1:jrNePecowIHTEjjK0UoNEerz2CS9EGgif28y3Mm9X1c=
+github.com/quay/clair/v4 v4.0.0-rc.3/go.mod h1:05hmwvDxXCf81woZWUoWxBU7qLrlElar3RJ5lzHiT7E=
+github.com/quay/claircore v0.1.8/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
 github.com/quay/claircore v1.0.5 h1:Q7zz0MedTefnHEv8rB8gxJJENT76NEHdAx/XL4mBMp0=
 github.com/quay/claircore v1.0.5/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
 github.com/quay/config-tool v0.1.2-0.20200914221214-89ccb1fec55a h1:D50nwrhJabDMH/I6JeCWp2U5TZGsuMg5nvlOGYS7coQ=
@@ -987,8 +988,8 @@ golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200612220849-54c614fe050c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200811032001-fd80f4dbb3ea/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200911153331-7ad463ce66dd h1:EsTBWdirTvPYbomEwlpq2y7Z3qqsNm6BkseJHhdOvYM=
-golang.org/x/tools v0.0.0-20200911153331-7ad463ce66dd/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20200923053713-ba800b16d873 h1:Q5Sq7Lt0bkn6Ax1NAraQhKRN7xxxy1LV4guxsyFHZx4=
+golang.org/x/tools v0.0.0-20200923053713-ba800b16d873/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=

--- a/kustomize/base/cluster-service-ca.configmap.yaml
+++ b/kustomize/base/cluster-service-ca.configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: quay-extra-certs
+  name: cluster-service-ca
   annotations:
     service.beta.openshift.io/inject-cabundle: 'true'

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -20,7 +20,7 @@ spec:
             secretName: quay-config-secret
         - name: extra-ca-certs
           configMap:
-            name: quay-extra-certs
+            name: cluster-service-ca
       containers:
         - name: quay-config-editor
           image: quay.io/projectquay/config-tool@sha256:9aeff823414c93c3129eb98132affda14adce1d60af23b9e23ce481327591eaf

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ./quay.deployment.yaml
   - ./quay.service.yaml
   - ./upgrade.deployment.yaml
-  - ./extra-certs.configmap.yaml
+  - ./cluster-service-ca.configmap.yaml
   - ./config.deployment.yaml
   - ./config.service.yaml
 generatorOptions:

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -20,7 +20,7 @@ spec:
             secretName: quay-config-secret
         - name: extra-ca-certs
           configMap:
-            name: quay-extra-certs
+            name: cluster-service-ca
       containers:
         - name: quay-app
           image: quay.io/projectquay/quay

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -20,7 +20,7 @@ spec:
             secretName: quay-config-secret
         - name: extra-ca-certs
           configMap:
-            name: quay-extra-certs
+            name: cluster-service-ca
       containers:
         - name: quay-app-upgrade
           image: quay.io/projectquay/quay

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -33,10 +33,18 @@ spec:
           volumeMounts:
             - mountPath: /clair/
               name: config
+            - mountPath: /var/run/certs
+              name: certs
           # TODO(alecmerdler): Define `readinessProbe` which waits until indexer/matcher services are ready.
       restartPolicy: Always
       volumes:
         - name: config
           secret:
             secretName: clair-config-secret
-          
+        - name: certs
+          secret:
+            secretName: quay-config-secret
+            # Mount just the public certificate because we are using storage proxying.
+            items:
+              - key: ssl.cert
+                path: quay-ssl.cert

--- a/kustomize/components/route/kustomization.yaml
+++ b/kustomize/components/route/kustomization.yaml
@@ -21,17 +21,3 @@ vars:
       name: quay-app
     fieldref:
       fieldpath: metadata.annotations["quay-registry-hostname"]
-  - name: QUAY_TLS_TERMINATION
-    objref:
-      kind: Service
-      apiVersion: v1
-      name: quay-app
-    fieldref:
-      fieldpath: metadata.annotations["quay-registry-tls-termination"]
-  - name: QUAY_TARGET_PORT
-    objref:
-      kind: Service
-      apiVersion: v1
-      name: quay-app
-    fieldref:
-      fieldpath: metadata.annotations["quay-registry-target-port"]

--- a/kustomize/components/route/quay.route.yaml
+++ b/kustomize/components/route/quay.route.yaml
@@ -8,7 +8,7 @@ spec:
     kind: Service
     name: quay-app
   port:
-    targetPort: $(QUAY_TARGET_PORT)
+    targetPort: https
   tls:
-    termination: $(QUAY_TLS_TERMINATION)
+    termination: passthrough
     insecureEdgeTerminationPolicy: Redirect

--- a/kustomize/components/route/route.varreferences.yaml
+++ b/kustomize/components/route/route.varreferences.yaml
@@ -1,7 +1,3 @@
 varReference:
   - kind: Route
     path: spec/host
-  - kind: Route
-    path: spec/tls/termination
-  - kind: Route
-    path: spec/port/targetPort

--- a/kustomize/overlays/upstream/vader/kustomization.yaml
+++ b/kustomize/overlays/upstream/vader/kustomization.yaml
@@ -9,4 +9,5 @@ images:
   - name: quay.io/projectquay/quay
     newTag: vader
   - name: quay.io/projectquay/clair
-    newTag: vader
+    # newTag: vader
+    newTag: 4.0.0-rc.3

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -197,7 +197,7 @@ var quayComponents = map[string][]runtime.Object{
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-editor"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-secret"}},
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "quay-extra-certs"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-service-ca"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-editor-credentials"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-registry-managed-secret-keys"}},
 	},

--- a/vendor/github.com/quay/clair/v4/config/auth.go
+++ b/vendor/github.com/quay/clair/v4/config/auth.go
@@ -47,17 +47,17 @@ func (a *AuthKeyserver) UnmarshalYAML(f func(interface{}) error) error {
 
 // AuthPSK is the configuration for doing pre-shared key based authentication.
 //
-// The "Issuer" key is what the service expects to verify as the "issuer claim.
+// The "Issuer" key is what the service expects to verify as the "issuer" claim.
 type AuthPSK struct {
-	Key    []byte `yaml:"key" json:"key"`
-	Issuer string `yaml:"iss" json:"issuer"`
+	Key    []byte   `yaml:"key" json:"key"`
+	Issuer []string `yaml:"iss" json:"issuer"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (a *AuthPSK) UnmarshalYAML(f func(interface{}) error) error {
 	var m struct {
-		Issuer string `yaml:"iss" json:"issuer"`
-		Key    string `yaml:"key" json:"key"`
+		Issuer []string `yaml:"iss" json:"issuer"`
+		Key    string   `yaml:"key" json:"key"`
 	}
 	if err := f(&m); err != nil {
 		return nil

--- a/vendor/github.com/quay/clair/v4/config/notifier.go
+++ b/vendor/github.com/quay/clair/v4/config/notifier.go
@@ -41,7 +41,7 @@ type Notifier struct {
 	// Only one of the following should be provided in the configuration
 	//
 	// Configures the notifier for webhook delivery
-	Webbook *webhook.Config `yaml:"webhook" json:"webhook"`
+	Webhook *webhook.Config `yaml:"webhook" json:"webhook"`
 	// Configures the notifier for AMQP delivery.
 	AMQP *amqp.Config `yaml:"amqp" json:"amqp"`
 	// Configures the notifier for STOMP delivery.

--- a/vendor/golang.org/x/tools/go/internal/gcimporter/gcimporter.go
+++ b/vendor/golang.org/x/tools/go/internal/gcimporter/gcimporter.go
@@ -491,7 +491,7 @@ func (p *parser) parseMapType(parent *types.Package) types.Type {
 //
 // For unqualified and anonymous names, the returned package is the parent
 // package unless parent == nil, in which case the returned package is the
-// package being imported. (The parent package is not nil if the the name
+// package being imported. (The parent package is not nil if the name
 // is an unqualified struct field or interface method name belonging to a
 // type declared in another package.)
 //

--- a/vendor/golang.org/x/tools/go/packages/golist.go
+++ b/vendor/golang.org/x/tools/go/packages/golist.go
@@ -246,6 +246,21 @@ extractQueries:
 			}
 		}
 	}
+	// Add root for any package that matches a pattern. This applies only to
+	// packages that are modified by overlays, since they are not added as
+	// roots automatically.
+	for _, pattern := range restPatterns {
+		match := matchPattern(pattern)
+		for _, pkgID := range modifiedPkgs {
+			pkg, ok := response.seenPackages[pkgID]
+			if !ok {
+				continue
+			}
+			if match(pkg.PkgPath) {
+				response.addRoot(pkg.ID)
+			}
+		}
+	}
 
 	sizeswg.Wait()
 	if sizeserr != nil {
@@ -753,7 +768,8 @@ func (state *golistState) getGoVersion() (string, error) {
 	return state.goVersion, state.goVersionError
 }
 
-// getPkgPath finds the package path of a directory if it's relative to a root directory.
+// getPkgPath finds the package path of a directory if it's relative to a root
+// directory.
 func (state *golistState) getPkgPath(dir string) (string, bool, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {

--- a/vendor/golang.org/x/tools/go/packages/golist_overlay.go
+++ b/vendor/golang.org/x/tools/go/packages/golist_overlay.go
@@ -8,9 +8,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"golang.org/x/tools/internal/gocommand"
 )
 
 // processGolistOverlay provides rudimentary support for adding
@@ -250,7 +253,7 @@ func (state *golistState) processGolistOverlay(response *responseDeduper) (modif
 	return modifiedPkgs, needPkgs, err
 }
 
-// resolveImport finds the the ID of a package given its import path.
+// resolveImport finds the ID of a package given its import path.
 // In particular, it will find the right vendored copy when in GOPATH mode.
 func (state *golistState) resolveImport(sourceDir, importPath string) (string, error) {
 	env, err := state.getEnv()
@@ -325,24 +328,25 @@ func (state *golistState) determineRootDirs() (map[string]string, error) {
 }
 
 func (state *golistState) determineRootDirsModules() (map[string]string, error) {
-	// This will only return the root directory for the main module.
-	// For now we only support overlays in main modules.
+	// List all of the modules--the first will be the directory for the main
+	// module. Any replaced modules will also need to be treated as roots.
 	// Editing files in the module cache isn't a great idea, so we don't
-	// plan to ever support that, but editing files in replaced modules
-	// is something we may want to support. To do that, we'll want to
-	// do a go list -m to determine the replaced module's module path and
-	// directory, and then a go list -m {{with .Replace}}{{.Dir}}{{end}} <replaced module's path>
-	// from the main module to determine if that module is actually a replacement.
-	// See bcmills's comment here: https://github.com/golang/go/issues/37629#issuecomment-594179751
-	// for more information.
-	out, err := state.invokeGo("list", "-m", "-json")
+	// plan to ever support that.
+	out, err := state.invokeGo("list", "-m", "-json", "all")
 	if err != nil {
-		return nil, err
+		// 'go list all' will fail if we're outside of a module and
+		// GO111MODULE=on. Try falling back without 'all'.
+		var innerErr error
+		out, innerErr = state.invokeGo("list", "-m", "-json")
+		if innerErr != nil {
+			return nil, err
+		}
 	}
-	m := map[string]string{}
-	type jsonMod struct{ Path, Dir string }
+	roots := map[string]string{}
+	modules := map[string]string{}
+	var i int
 	for dec := json.NewDecoder(out); dec.More(); {
-		mod := new(jsonMod)
+		mod := new(gocommand.ModuleJSON)
 		if err := dec.Decode(mod); err != nil {
 			return nil, err
 		}
@@ -352,10 +356,15 @@ func (state *golistState) determineRootDirsModules() (map[string]string, error) 
 			if err != nil {
 				return nil, err
 			}
-			m[absDir] = mod.Path
+			modules[absDir] = mod.Path
+			// The first result is the main module.
+			if i == 0 || mod.Replace != nil && mod.Replace.Path != "" {
+				roots[absDir] = mod.Path
+			}
 		}
+		i++
 	}
-	return m, nil
+	return roots, nil
 }
 
 func (state *golistState) determineRootDirsGOPATH() (map[string]string, error) {
@@ -480,4 +489,80 @@ func maybeFixPackageName(newName string, isTestFile bool, pkgsOfDir []*Package) 
 	for _, p := range pkgsOfDir {
 		p.Name = newName
 	}
+}
+
+// This function is copy-pasted from
+// https://github.com/golang/go/blob/9706f510a5e2754595d716bd64be8375997311fb/src/cmd/go/internal/search/search.go#L360.
+// It should be deleted when we remove support for overlays from go/packages.
+//
+// NOTE: This does not handle any ./... or ./ style queries, as this function
+// doesn't know the working directory.
+//
+// matchPattern(pattern)(name) reports whether
+// name matches pattern. Pattern is a limited glob
+// pattern in which '...' means 'any string' and there
+// is no other special syntax.
+// Unfortunately, there are two special cases. Quoting "go help packages":
+//
+// First, /... at the end of the pattern can match an empty string,
+// so that net/... matches both net and packages in its subdirectories, like net/http.
+// Second, any slash-separated pattern element containing a wildcard never
+// participates in a match of the "vendor" element in the path of a vendored
+// package, so that ./... does not match packages in subdirectories of
+// ./vendor or ./mycode/vendor, but ./vendor/... and ./mycode/vendor/... do.
+// Note, however, that a directory named vendor that itself contains code
+// is not a vendored package: cmd/vendor would be a command named vendor,
+// and the pattern cmd/... matches it.
+func matchPattern(pattern string) func(name string) bool {
+	// Convert pattern to regular expression.
+	// The strategy for the trailing /... is to nest it in an explicit ? expression.
+	// The strategy for the vendor exclusion is to change the unmatchable
+	// vendor strings to a disallowed code point (vendorChar) and to use
+	// "(anything but that codepoint)*" as the implementation of the ... wildcard.
+	// This is a bit complicated but the obvious alternative,
+	// namely a hand-written search like in most shell glob matchers,
+	// is too easy to make accidentally exponential.
+	// Using package regexp guarantees linear-time matching.
+
+	const vendorChar = "\x00"
+
+	if strings.Contains(pattern, vendorChar) {
+		return func(name string) bool { return false }
+	}
+
+	re := regexp.QuoteMeta(pattern)
+	re = replaceVendor(re, vendorChar)
+	switch {
+	case strings.HasSuffix(re, `/`+vendorChar+`/\.\.\.`):
+		re = strings.TrimSuffix(re, `/`+vendorChar+`/\.\.\.`) + `(/vendor|/` + vendorChar + `/\.\.\.)`
+	case re == vendorChar+`/\.\.\.`:
+		re = `(/vendor|/` + vendorChar + `/\.\.\.)`
+	case strings.HasSuffix(re, `/\.\.\.`):
+		re = strings.TrimSuffix(re, `/\.\.\.`) + `(/\.\.\.)?`
+	}
+	re = strings.ReplaceAll(re, `\.\.\.`, `[^`+vendorChar+`]*`)
+
+	reg := regexp.MustCompile(`^` + re + `$`)
+
+	return func(name string) bool {
+		if strings.Contains(name, vendorChar) {
+			return false
+		}
+		return reg.MatchString(replaceVendor(name, vendorChar))
+	}
+}
+
+// replaceVendor returns the result of replacing
+// non-trailing vendor path elements in x with repl.
+func replaceVendor(x, repl string) string {
+	if !strings.Contains(x, "vendor") {
+		return x
+	}
+	elem := strings.Split(x, "/")
+	for i := 0; i < len(elem)-1; i++ {
+		if elem[i] == "vendor" {
+			elem[i] = repl
+		}
+	}
+	return strings.Join(elem, "/")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d
 github.com/qri-io/starlib/util
-# github.com/quay/clair/v4 v4.0.0-rc.2
+# github.com/quay/clair/v4 v4.0.0-rc.3
 github.com/quay/clair/v4/clair-error
 github.com/quay/clair/v4/config
 github.com/quay/clair/v4/indexer
@@ -325,7 +325,7 @@ golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 golang.org/x/time/rate
-# golang.org/x/tools v0.0.0-20200911153331-7ad463ce66dd
+# golang.org/x/tools v0.0.0-20200923053713-ba800b16d873
 golang.org/x/tools/cmd/stringer
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1091

**Changelog:** Switch to always `passthrough` TLS for `Route` and generate cert/key pair if not provided.

**Docs:** N/a

**Testing:** TODO(alecmerdler)

**Details:** 

We cannot use `edge` TLS termination with OpenShift `Routes` because there is not an easy or reliable way of retrieving the cluster CA that is used by the Ingress Operator when it creates `Routes`. This is a problem because Clair needs to trust the HTTPS of whatever storage backend it is fetching image layers from. Instead, we switch to always terminating TLS at the Quay container (which is preferred anyway) and generating a cert/key pair if the user does not provide them in their `configBundleSecret`.

- [x] Remove `edge` TLS termination for Quay `Route` and only allow `passthrough` targeting the `https` port
- [x] Ensure `FEATURE_PROXY_STORAGE` is enabled and we are using `s3.openshift-storage.svc` and injecting `service-ca.crt` to Quay and config-tool `Deployments`
- [x] Generate `ssl.key` + `ssl.cert` if not provided

**Reverts work done in:** https://github.com/quay/quay-operator/pull/320 and https://github.com/quay/quay-operator/pull/315

