### PR TITLE
Managed Database Max Connections (PROJQUAY-1112)

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -61,7 +61,7 @@ spec:
               command:
                 - curl
                 - '-k'
-                - 'http://localhost:8080/health/instance'
+                - 'https://localhost:8080/health/instance'
             initialDelaySeconds: 30
             timeoutSeconds: 20
             periodSeconds: 15

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -28,6 +28,10 @@ spec:
         - name: postgres
           image: postgres:latest
           imagePullPolicy: IfNotPresent
+          args: [
+            "-c", "shared_buffers=256MB",
+            "-c", "max_connections=2000",
+          ]
           ports:
             - containerPort: 5432
               protocol: TCP


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1112

**Changelog:** Set `max_connections` on the Quay managed database.

**Docs:** N/a

**Testing:** Deploy a `QuayRegistry` and ensure that `peewee.OperationalError: FATAL: sorry, too many clients already` does not occur.

**Details:** The default `max_connections` for the Postgres container is 100, which is much too low. Add a config file which bumps the limit.

**Screenshots**

![Screenshot_20200926_160638](https://user-images.githubusercontent.com/11700385/94351787-53c89e00-0012-11eb-9b01-da0ea2e048b0.png)

