### PR TITLE
Document Image Pull Secrets (PROJQUAY-1122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ $ kubectl create -n <your-namespace> -f ./deploy/quay-operator.subscription.yaml
 
 ### Using the Operator
 
+#### Component Container Images
+
+When using a downstream build or container image overrides which are hosted in private repositories, you can provide pull secrets by [adding them to the default `ServiceAccount` in the namespace](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account).
+
 #### Batteries-included, zero-config
 
 **Install RHOCS Operator using OperatorHub:**


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1122

**Changelog:** Document how to use k8s-native method of adding pull secrets for private container images used by pods.

**Docs:** https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account

**Testing:** N/a

**Details:** Leverage existing Kubernetes feature of adding pull secrets to `ServiceAccounts` rather than adding `imagePullSecrets` field to our API surface.