### PR TITLE
Fix Clair PSK Config 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/quay/clair/v4 v4.0.0-rc.3
+	github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7
 	github.com/quay/claircore v1.0.5 // indirect
 	github.com/quay/config-tool v0.1.2-0.20201013214416-e1ea29372174
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -415,6 +417,8 @@ github.com/jackc/pgconn v1.5.0/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr
 github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
 github.com/jackc/pgconn v1.6.1 h1:lwofaXKPbIx6qEaK8mNm7uZuOwxHw+PnAFGDsDFpkRI=
 github.com/jackc/pgconn v1.6.1/go.mod h1:g8mKMqmSUO6AzAvha7vy07g1rbGOlc7iF0nU0ei83hc=
+github.com/jackc/pgconn v1.6.2 h1:ifRs/oHByR6NfEXfusvjoTqX/KcSvDYNFASoK/wXKfs=
+github.com/jackc/pgconn v1.6.2/go.mod h1:w2pne1C2tZgP+TvjqLpOigGzNqjBgQW9dUw/4Chex78=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye4717ITLaNwV9mWbJx0dLCpcRzdA=
@@ -432,6 +436,8 @@ github.com/jackc/pgproto3/v2 v2.0.2 h1:q1Hsy66zh4vuNsajBUF2PNqfAMMfxU5mk594lPE9v
 github.com/jackc/pgproto3/v2 v2.0.2/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8 h1:Q3tB+ExeflWUW7AFcAhXqk40s9mnNYLk1nOkKNZ5GnU=
 github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
+github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b h1:C8S2+VttkHFdOOCXJe+YGfa4vHYwlt4Zx+IVXQ97jYg=
+github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgtype v0.0.0-20190421001408-4ed0de4755e0/go.mod h1:hdSHsc1V01CGwFsrv11mJRHWJ6aifDLfdV3aVjFF0zg=
 github.com/jackc/pgtype v0.0.0-20190824184912-ab885b375b90/go.mod h1:KcahbBH1nCMSo2DXpzsoWOAfFkdEtEJpPbVLq8eE+mc=
 github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59/go.mod h1:MWlu30kVJrUS8lot6TQqcg7mtthZ9T0EoIBFiJcmcyw=
@@ -440,6 +446,8 @@ github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a/go.mod h1:vaogEUkAL
 github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/VzJ9/lxTO5R5sf80p0DiucVtN7ZxvaC4GmQ=
 github.com/jackc/pgtype v1.4.0 h1:pHQfb4jh9iKqHyxPthq1fr+0HwSNIl3btYPbw2m2lbM=
 github.com/jackc/pgtype v1.4.0/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
+github.com/jackc/pgtype v1.4.1 h1:8PRKqCS9Nt2FQbNegoEAIlY6r/DTP2aaXyh5bAEn89g=
+github.com/jackc/pgtype v1.4.1/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
 github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9WuGR0JG/JseM9irFbnEPbuWV2EELPNuM=
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=
@@ -448,6 +456,8 @@ github.com/jackc/pgx/v4 v4.6.1-0.20200510190926-94ba730bb1e9/go.mod h1:t3/cdRQl6
 github.com/jackc/pgx/v4 v4.6.1-0.20200606145419-4e5062306904/go.mod h1:ZDaNWkt9sW1JMiNn0kdYBaLelIhw7Pg4qd+Vk6tw7Hg=
 github.com/jackc/pgx/v4 v4.7.1 h1:aqUSOcStk6fik+lSE+tqfFhvt/EwT8q/oMtJbP9CjXI=
 github.com/jackc/pgx/v4 v4.7.1/go.mod h1:nu42q3aPjuC1M0Nak4bnoprKlXPINqopEKqbq5AZSC4=
+github.com/jackc/pgx/v4 v4.7.2 h1:0DJC1AiqH0Lba79JHFQkcoxi0sOAn75Zr+QCRCAXvBc=
+github.com/jackc/pgx/v4 v4.7.2/go.mod h1:IaoCMFiHwe2J7SjRZ97Qc7zr8QGNwnlAU4J0f3S1UYk=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
@@ -479,6 +489,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.11/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
@@ -641,9 +652,9 @@ github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d h1:K6eOUihrFLdZjZ
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/clair/v4 v4.0.0-rc.3 h1:jrNePecowIHTEjjK0UoNEerz2CS9EGgif28y3Mm9X1c=
-github.com/quay/clair/v4 v4.0.0-rc.3/go.mod h1:05hmwvDxXCf81woZWUoWxBU7qLrlElar3RJ5lzHiT7E=
-github.com/quay/claircore v0.1.8/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
+github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7 h1:P5VV0gAFTkZgVpeZA341tbu7wTJ9XzV/Gi54Q3CwaFo=
+github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7/go.mod h1:7oE9Vug5TcdaBGU+J0T60ckdvccXxivu45hZJlkjjN4=
+github.com/quay/claircore v0.1.13/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
 github.com/quay/claircore v1.0.5 h1:Q7zz0MedTefnHEv8rB8gxJJENT76NEHdAx/XL4mBMp0=
 github.com/quay/claircore v1.0.5/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
 github.com/quay/config-tool v0.1.2-0.20201013214416-e1ea29372174 h1:SDv0LAaX+zaw3BAyQbUZQ9xRbBumqMnyMk5tdu7GTbI=
@@ -1012,8 +1023,8 @@ golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200612220849-54c614fe050c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200811032001-fd80f4dbb3ea/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200923053713-ba800b16d873 h1:Q5Sq7Lt0bkn6Ax1NAraQhKRN7xxxy1LV4guxsyFHZx4=
-golang.org/x/tools v0.0.0-20200923053713-ba800b16d873/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20200928182047-19e03678916f h1:VwGa2Wf+rHGIxvsssCkUNIyFv8jQY0VCBCNWtikoWq0=
+golang.org/x/tools v0.0.0-20200928182047-19e03678916f/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -35,10 +35,11 @@ spec:
               name: config
             - mountPath: /var/run/certs
               name: certs
-          readinessProbe:
-            httpGet:
-              path: /indexer/api/v1/index_state
-              port: 8080
+          # FIXME: This fails because there is no JWT header.
+          # readinessProbe:
+          #   httpGet:
+          #     path: /indexer/api/v1/index_state
+          #     port: 8080
       restartPolicy: Always
       volumes:
         - name: config

--- a/kustomize/overlays/upstream/vader/kustomization.yaml
+++ b/kustomize/overlays/upstream/vader/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   - name: quay.io/projectquay/quay
     digest: sha256:93e183982e405782733a520ebfb5cf815b90ae38a4695973d420cda46eea6c8a
   - name: quay.io/projectquay/clair
-    newTag: 4.0.0-rc.16
+    newTag: 4.0.0-rc.18

--- a/kustomize/overlays/upstream/vader/upgrade/kustomization.yaml
+++ b/kustomize/overlays/upstream/vader/upgrade/kustomization.yaml
@@ -13,4 +13,4 @@ images:
   - name: quay.io/projectquay/quay
     digest: sha256:93e183982e405782733a520ebfb5cf815b90ae38a4695973d420cda46eea6c8a
   - name: quay.io/projectquay/clair
-    newTag: 4.0.0-rc.16
+    newTag: 4.0.0-rc.18

--- a/vendor/github.com/google/uuid/README.md
+++ b/vendor/github.com/google/uuid/README.md
@@ -16,4 +16,4 @@ change is the ability to represent an invalid UUID (vs a NIL UUID).
 
 Full `go doc` style documentation for the package can be viewed online without
 installing this package by using the GoDoc site here: 
-http://godoc.org/github.com/google/uuid
+http://pkg.go.dev/github.com/google/uuid

--- a/vendor/github.com/google/uuid/marshal.go
+++ b/vendor/github.com/google/uuid/marshal.go
@@ -16,10 +16,11 @@ func (uuid UUID) MarshalText() ([]byte, error) {
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (uuid *UUID) UnmarshalText(data []byte) error {
 	id, err := ParseBytes(data)
-	if err == nil {
-		*uuid = id
+	if err != nil {
+		return err
 	}
-	return err
+	*uuid = id
+	return nil
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.

--- a/vendor/github.com/google/uuid/version1.go
+++ b/vendor/github.com/google/uuid/version1.go
@@ -17,12 +17,6 @@ import (
 //
 // In most cases, New should be used.
 func NewUUID() (UUID, error) {
-	nodeMu.Lock()
-	if nodeID == zeroID {
-		setNodeInterface("")
-	}
-	nodeMu.Unlock()
-
 	var uuid UUID
 	now, seq, err := GetTime()
 	if err != nil {
@@ -38,7 +32,13 @@ func NewUUID() (UUID, error) {
 	binary.BigEndian.PutUint16(uuid[4:], timeMid)
 	binary.BigEndian.PutUint16(uuid[6:], timeHi)
 	binary.BigEndian.PutUint16(uuid[8:], seq)
+
+	nodeMu.Lock()
+	if nodeID == zeroID {
+		setNodeInterface("")
+	}
 	copy(uuid[10:], nodeID[:])
+	nodeMu.Unlock()
 
 	return uuid, nil
 }

--- a/vendor/github.com/google/uuid/version4.go
+++ b/vendor/github.com/google/uuid/version4.go
@@ -27,8 +27,13 @@ func New() UUID {
 //  equivalent to the odds of creating a few tens of trillions of UUIDs in a
 //  year and having one duplicate.
 func NewRandom() (UUID, error) {
+	return NewRandomFromReader(rander)
+}
+
+// NewRandomFromReader returns a UUID based on bytes read from a given io.Reader.
+func NewRandomFromReader(r io.Reader) (UUID, error) {
 	var uuid UUID
-	_, err := io.ReadFull(rander, uuid[:])
+	_, err := io.ReadFull(r, uuid[:])
 	if err != nil {
 		return Nil, err
 	}

--- a/vendor/github.com/quay/clair/v4/clair-error/notifications.go
+++ b/vendor/github.com/quay/clair/v4/clair-error/notifications.go
@@ -117,7 +117,7 @@ type ErrDeliveryFailed struct {
 }
 
 func (e ErrDeliveryFailed) Error() string {
-	return "failed to delivery notification"
+	return "failed to deliver notification"
 }
 
 func (e ErrDeliveryFailed) Unwrap() error {

--- a/vendor/github.com/quay/clair/v4/config/auth.go
+++ b/vendor/github.com/quay/clair/v4/config/auth.go
@@ -26,13 +26,14 @@ type AuthKeyserver struct {
 	API          string `yaml:"api" json:"api"`
 	Intraservice []byte `yaml:"intraservice" json:"intraservice"`
 }
+type keyserverConfig struct {
+	API          string `yaml:"api" json:"api"`
+	Intraservice string `yaml:"intraservice" json:"intraservice"`
+}
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (a *AuthKeyserver) UnmarshalYAML(f func(interface{}) error) error {
-	var m struct {
-		API          string `yaml:"api"`
-		Intraservice string `yaml:"intraservice"`
-	}
+	var m keyserverConfig
 	if err := f(&m); err != nil {
 		return nil
 	}
@@ -45,20 +46,29 @@ func (a *AuthKeyserver) UnmarshalYAML(f func(interface{}) error) error {
 	return nil
 }
 
+// MarshalYAML implements yaml.Marshaler.
+func (a *AuthKeyserver) MarshalYAML() (interface{}, error) {
+	return &keyserverConfig{
+		API:          a.API,
+		Intraservice: base64.StdEncoding.EncodeToString(a.Intraservice),
+	}, nil
+}
+
 // AuthPSK is the configuration for doing pre-shared key based authentication.
 //
 // The "Issuer" key is what the service expects to verify as the "issuer" claim.
 type AuthPSK struct {
 	Key    []byte   `yaml:"key" json:"key"`
-	Issuer []string `yaml:"iss" json:"issuer"`
+	Issuer []string `yaml:"iss" json:"iss"`
+}
+type pskConfig struct {
+	Key    string   `yaml:"key" json:"key"`
+	Issuer []string `yaml:"iss" json:"iss"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (a *AuthPSK) UnmarshalYAML(f func(interface{}) error) error {
-	var m struct {
-		Issuer []string `yaml:"iss" json:"issuer"`
-		Key    string   `yaml:"key" json:"key"`
-	}
+	var m pskConfig
 	if err := f(&m); err != nil {
 		return nil
 	}
@@ -69,4 +79,12 @@ func (a *AuthPSK) UnmarshalYAML(f func(interface{}) error) error {
 	}
 	a.Key = s
 	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (a *AuthPSK) MarshalYAML() (interface{}, error) {
+	return &pskConfig{
+		Key:    base64.StdEncoding.EncodeToString(a.Key),
+		Issuer: a.Issuer,
+	}, nil
 }

--- a/vendor/github.com/quay/clair/v4/notifier/mockstore.go
+++ b/vendor/github.com/quay/clair/v4/notifier/mockstore.go
@@ -10,6 +10,7 @@ import (
 type MockStore struct {
 	Notifications_        func(ctx context.Context, id uuid.UUID, page *Page) ([]Notification, Page, error)
 	PutNotifications_     func(ctx context.Context, opts PutOpts) error
+	PutReceipt_           func(ctx context.Context, updater string, r Receipt) error
 	DeleteNotitfications_ func(ctx context.Context, id uuid.UUID) error
 	Receipt_              func(ctx context.Context, id uuid.UUID) (Receipt, error)
 	ReceiptByUOID_        func(ctx context.Context, id uuid.UUID) (Receipt, error)
@@ -39,6 +40,14 @@ func (m *MockStore) Notifications(ctx context.Context, id uuid.UUID, page *Page)
 // returns the persisted notification id.
 func (m *MockStore) PutNotifications(ctx context.Context, opts PutOpts) error {
 	return m.PutNotifications_(ctx, opts)
+}
+
+// PutReceipt allows for the caller to directly add a receipt to the store
+// without notifications being created.
+//
+// After this method returns all methods on the Receipter interface must work accordingly.
+func (m *MockStore) PutReceipt(ctx context.Context, updater string, r Receipt) error {
+	return m.PutReceipt_(ctx, updater, r)
 }
 
 // DeleteNotifications garbage collects all notifications associated

--- a/vendor/github.com/quay/clair/v4/notifier/poller.go
+++ b/vendor/github.com/quay/clair/v4/notifier/poller.go
@@ -117,12 +117,18 @@ func (p *Poller) onTick(ctx context.Context, c chan<- Event) {
 			select {
 			case c <- e:
 			default:
-				log.Warn().Str("updater", e.updater).Str("UOID", e.uo.Ref.String()).Msg("could not deliver event to channel. backing off till next tick")
+				log.Warn().
+					Str("updater", updater).
+					Str("UOID", latest.Ref.String()).
+					Msg("could not deliver event to channel. skipping updater now")
 			}
-			return
+			continue
 		}
 		if err != nil {
-			log.Error().Err(err).Msg("received error getting receipt by UOID. backing off till next tick")
+			log.Error().Err(err).
+				Str("updater", updater).
+				Str("UOID", latest.Ref.String()).
+				Msg("received error getting receipt by UOID. backing off till next tick")
 			return
 		}
 	}

--- a/vendor/github.com/quay/clair/v4/notifier/receipt.go
+++ b/vendor/github.com/quay/clair/v4/notifier/receipt.go
@@ -22,6 +22,8 @@ const (
 
 // Receipt represents the current status of a notification
 type Receipt struct {
+	// The update operation associated with this receipt
+	UOID uuid.UUID
 	// the id a client may use to retrieve a set of notifications
 	NotificationID uuid.UUID
 	// the current status  of the notification

--- a/vendor/github.com/quay/clair/v4/notifier/store.go
+++ b/vendor/github.com/quay/clair/v4/notifier/store.go
@@ -53,6 +53,11 @@ type Notificationer interface {
 	// successful persistence of notifications in such a way that Receipter.Created()
 	// returns the persisted notification id.
 	PutNotifications(ctx context.Context, opts PutOpts) error
+	// PutReceipt allows for the caller to directly add a receipt to the store
+	// without notifications being created.
+	//
+	// After this method returns all methods on the Receipter interface must work accordingly.
+	PutReceipt(ctx context.Context, updater string, r Receipt) error
 	// DeleteNotifications garbage collects all notifications associated
 	// with a notification id.
 	//

--- a/vendor/github.com/quay/clair/v4/notifier/webhook/deliverer.go
+++ b/vendor/github.com/quay/clair/v4/notifier/webhook/deliverer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"time"
 
 	"github.com/google/uuid"
@@ -83,8 +82,10 @@ func (d *Deliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 		Str("notification_id", nID.String()).
 		Logger()
 
-	callback := d.conf.callback
-	callback.Path = path.Join(callback.Path, nID.String())
+	callback, err := d.conf.callback.Parse(nID.String())
+	if err != nil {
+		return err
+	}
 
 	wh := notifier.Callback{
 		NotificationID: nID,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,7 +73,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/gofuzz
 # github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 github.com/google/shlex
-# github.com/google/uuid v1.1.1
+# github.com/google/uuid v1.1.2
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.3.1
 github.com/googleapis/gnostic/OpenAPIv2
@@ -193,7 +193,7 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d
 github.com/qri-io/starlib/util
-# github.com/quay/clair/v4 v4.0.0-rc.3
+# github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7
 github.com/quay/clair/v4/clair-error
 github.com/quay/clair/v4/config
 github.com/quay/clair/v4/indexer
@@ -326,7 +326,7 @@ golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 golang.org/x/time/rate
-# golang.org/x/tools v0.0.0-20200923053713-ba800b16d873
+# golang.org/x/tools v0.0.0-20200928182047-19e03678916f
 golang.org/x/tools/cmd/stringer
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter


### PR DESCRIPTION
### Description

Updates `clair/v4` Go library to ensure that the PSK is correctly converted into a base64 string during marshaling to YAML.

Requires https://github.com/quay/clair/pull/1110