### PR TITLE
OpenShift Route Custom Host RBAC

### DIFF
--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -177,6 +177,7 @@ spec:
           - route.openshift.io
           resources:
           - routes
+          - routes/custom-host
           verbs:
           - '*'
         - apiGroups:


### PR DESCRIPTION
### Description

Adds permission needed to set `spec.host` on the OpenShift `Route` resource.