### PR TITLE
Component Images in ClusterServiceVersion (PROJQUAY-1196)

### DIFF
--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
-    containerImage: quay.io/projectquay/quay-operator@sha256:3c9a130c3149deadb3f2269cf5f6ee432d8a217ec90b4f420cbdfcce7051f832
+    containerImage: quay.io/projectquay/quay-operator@sha256:4cf12a770d040dac36a6d876c797afc233dd6969b595bdd19399e10ccb86154c
     createdAt: 2020-08-24 00:00:00
     description: Opinionated deployment of Quay on Kubernetes.
     repository: https://github.com/quay/quay-operator
@@ -99,7 +99,9 @@ spec:
               name: quay-operator-alm-owned
             spec:
               containers:
-              - command:
+              - name: quay-operator
+                image: quay.io/projectquay/quay-operator@sha256:4cf12a770d040dac36a6d876c797afc233dd6969b595bdd19399e10ccb86154c
+                command:
                 - /workspace/manager
                 - '--namespace=$(WATCH_NAMESPACE)'
                 env:
@@ -115,8 +117,14 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/projectquay/quay-operator@sha256:3c9a130c3149deadb3f2269cf5f6ee432d8a217ec90b4f420cbdfcce7051f832
-                name: quay-operator
+                - name: RELATED_IMAGE_COMPONENT_QUAY
+                  value: quay.io/projectquay/quay@sha256:c35f5af964431673f4ff5c9e90bdf45f19e38b8742b5903d41c10cc7f6339a6d
+                - name: RELATED_IMAGE_COMPONENT_CLAIR
+                  value: quay.io/projectquay/clair@sha256:70c99feceb4c0973540d22e740659cd8d616775d3ad1c1698ddf71d0221f3ce6
+                - name: RELATED_IMAGE_COMPONENT_POSTGRES
+                  value: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33
+                - name: RELATED_IMAGE_COMPONENT_REDIS
+                  value: centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542
               serviceAccountName: quay-operator
       permissions:
       - rules:

--- a/deploy/quay-operator.catalogsource.yaml
+++ b/deploy/quay-operator.catalogsource.yaml
@@ -4,4 +4,4 @@ metadata:
   name: quay-operator
 spec:
   sourceType: grpc
-  image: quay.io/projectquay/quay-operator-catalog@sha256:47ab7690cf9244b41b6a378f6f54a4cd0025dc2cc176f3118b18dc2c79efcf06
+  image: quay.io/projectquay/quay-operator-catalog@sha256:2a1ed500253072f82bedc2654980c694dd115f3f944fec194a5de72befb0cef1

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-config-editor
-          image: quay.io/projectquay/quay
+          image: quay.io/projectquay/quay@sha256:c35f5af964431673f4ff5c9e90bdf45f19e38b8742b5903d41c10cc7f6339a6d
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app
-          image: quay.io/projectquay/quay
+          image: quay.io/projectquay/quay@sha256:c35f5af964431673f4ff5c9e90bdf45f19e38b8742b5903d41c10cc7f6339a6d
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -15,7 +15,7 @@ spec:
         quay-component: clair
     spec:
       containers:
-        - image: quay.io/projectquay/clair
+        - image: quay.io/projectquay/clair@sha256:70c99feceb4c0973540d22e740659cd8d616775d3ad1c1698ddf71d0221f3ce6
           imagePullPolicy: IfNotPresent
           name: clair
           env:

--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 0
       containers:
         - name: postgres
-          image: centos/postgresql-10-centos7
+          image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # FIXME(alecmerdler): May need an `initContainer` which blocks until Quay app is running...
       containers:
         - name: quay-mirror
-          image: quay.io/projectquay/quay
+          image: quay.io/projectquay/quay@sha256:c35f5af964431673f4ff5c9e90bdf45f19e38b8742b5903d41c10cc7f6339a6d
           command: ["/quay-registry/quay-entrypoint.sh"]
           args: ["repomirror-nomigrate"]
           env:

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 0
       containers:
         - name: postgres
-          image: centos/postgresql-10-centos7
+          image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432

--- a/kustomize/components/redis/redis.deployment.yaml
+++ b/kustomize/components/redis/redis.deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: redis-master
-          image: redis:latest
+          image: centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379

--- a/kustomize/overlays/current/kustomization.yaml
+++ b/kustomize/overlays/current/kustomization.yaml
@@ -1,16 +1,7 @@
-# Overlay variant for Project Quay "vader" release.
+# Overlay variant for current Project Quay release.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonAnnotations:
   quay-version: vader
 bases:
   - ../../tmp
-images:
-  - name: quay.io/projectquay/quay
-    digest: sha256:b32a593575fa3330da879409b17698db94e29b18fc7a7a0bd3a0f13a984d56cd
-  - name: quay.io/projectquay/clair
-    newTag: 4.0.0-rc.18
-  - name: redis
-    newName: redis
-  - name: centos/postgresql-10-centos7
-    newName: centos/postgresql-10-centos7

--- a/kustomize/overlays/current/upgrade/kustomization.yaml
+++ b/kustomize/overlays/current/upgrade/kustomization.yaml
@@ -1,4 +1,4 @@
-# Overlay variant for upgrading to Project Quay "vader" release.
+# Overlay variant for upgrading to current Project Quay release.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonAnnotations:
@@ -9,12 +9,3 @@ patchesStrategicMerge:
   # Scale the app deployment to 0 pods in order to run all migrations present in the new container image using the "upgrade" deployment.
   - ./quay.deployment.patch.yaml
   - ./upgrade.deployment.patch.yaml
-images:
-  - name: quay.io/projectquay/quay
-    digest: sha256:b32a593575fa3330da879409b17698db94e29b18fc7a7a0bd3a0f13a984d56cd
-  - name: quay.io/projectquay/clair
-    newTag: 4.0.0-rc.18
-  - name: redis
-    newName: redis
-  - name: centos/postgresql-10-centos7
-    newName: centos/postgresql-10-centos7

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -50,7 +50,7 @@ func componentImageFor(component string) types.Image {
 	defaultImagesFor := map[string]string{
 		"base":     "quay.io/projectquay/quay",
 		"clair":    "quay.io/projectquay/clair",
-		"redis":    "redis",
+		"redis":    "centos/redis-32-centos7",
 		"postgres": "centos/postgresql-10-centos7",
 	}
 

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -92,7 +92,7 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", Digest: "sha256:abc123"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", Digest: "sha256:abc123"},
-				{Name: "redis", NewName: "redis", Digest: "sha256:abc123"},
+				{Name: "centos/redis-32-centos7", NewName: "redis", Digest: "sha256:abc123"},
 				{Name: "centos/postgresql-10-centos7", NewName: "postgres", Digest: "sha256:abc123"},
 			},
 			SecretGenerator: []types.SecretArgs{},


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1196

**Changelog:** Adds environment variables specifying exact images to use for managed components in the CSV.

**Docs:** N/a

**Testing:** Deploy fully managed `QuayRegistry` and ensure component images match.

**Details:** Specify the needed environment variables to control the component images in the `ClusterServiceVersion` and build a new `CatalogSource` image.

Removed the `images` override section from the `kustomization.yaml` files and instead set them in the Go generated Kustomization in `kustomize.go` to centralize where images are overridden for the current version. Running without any `RELATED_IMAGE_COMPONENT_*` environment variables set will just use the default images set in each `Deployment` YAML file in the `kustomize/` directory.
