### PR TITLE
Remove fsGroup from Postgres Deployments (PROJQUAY-1201)

### DIFF
--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -18,8 +18,9 @@ spec:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: clair-postgres
-      securityContext:
-        fsGroup: 0
+      # FIXME(alecmerdler): Need to set `fsGroup: 0` for `centos/postgresql-10-centos7` but not `rhel8/postgresql-10`
+      # securityContext:
+      #   fsGroup: 0
       containers:
         - name: postgres
           image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33

--- a/kustomize/components/postgres/init.job.yaml
+++ b/kustomize/components/postgres/init.job.yaml
@@ -8,8 +8,9 @@ spec:
       name: quay-postgres-init
     spec:
       restartPolicy: Never
-      securityContext:
-        fsGroup: 0
+      # FIXME(alecmerdler): Need to set `fsGroup: 0` for `centos/postgresql-10-centos7` but not `rhel8/postgresql-10`
+      # securityContext:
+      #   fsGroup: 0
       volumes:
         - name: postgres-bootstrap
           secret:

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -18,8 +18,9 @@ spec:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: quay-database
-      securityContext:
-        fsGroup: 0
+      # FIXME(alecmerdler): Need to set `fsGroup: 0` for `centos/postgresql-10-centos7` but not `rhel8/postgresql-10`
+      # securityContext:
+      #   fsGroup: 0
       containers:
         - name: postgres
           image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1201

**Changelog:** Removes `fsGroup` from Postgres deployments.

**Docs:** N/a

**Testing:** Create `QuayRegistry` and ensure all Postgres containers run successfully with no filesystem permission errors.

**Details:** The `fsGroup` specification is unnecessary when using the SCL-provided Postgres images and the `restricted` SCC.

**NOTE**: The `fsGroup` _is_ required for the upstream CentOS Postgres image, so we will need to fix this for the upstream version.

