### PR TITLE
Set debug log to be true by default

### DIFF
--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -31,6 +31,8 @@ spec:
           env:
             - name: QUAY_CONFIG_PATH
               value: /conf/stack
+            - name: DEBUGLOG
+              value: "true"
             - name: QUAY_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-???

**Changelog:** 

- `DEBUGLOG` variable set to true by default on config-editor deployment. This will show all incoming requests as well as any output from the server (errors, panics, etc.) 

**Docs:** 

**Testing:** 

**Details:** 

------