### PR TITLE
PROJQUAY-1157 - set default storage name to RHOCS

### DIFF
--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -165,7 +165,7 @@ func FieldGroupFor(component string, quay *v1.QuayRegistry) (shared.FieldGroup, 
 			DistributedStorageDefaultLocations: []string{"local_us"},
 			DistributedStorageConfig: map[string]*distributedstorage.DistributedStorageDefinition{
 				"local_us": {
-					Name: "RadosGWStorage",
+					Name: "RHOCSStorage",
 					Args: &shared.DistributedStorageArgs{
 						Hostname:    hostname,
 						IsSecure:    true,

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -95,7 +95,7 @@ var fieldGroupForTests = []struct {
 			DistributedStorageDefaultLocations: []string{"local_us"},
 			DistributedStorageConfig: map[string]*distributedstorage.DistributedStorageDefinition{
 				"local_us": {
-					Name: "RadosGWStorage",
+					Name: "RHOCSStorage",
 					Args: &shared.DistributedStorageArgs{
 						AccessKey:   "abc123",
 						BucketName:  "quay-datastore",


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1157

**Changelog:** 
none

**Docs:** 
none

**Testing:** 
Confirm config.yaml contains reference to RHOCS instead of RADOS

**Details:** 
Change string reference to proper storage