### PR TITLE
PROJQUAY-839 - annotation for disconnected install

### DIFF
--- a/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
@@ -32,6 +32,7 @@ metadata:
       ]
     operators.operatorframework.io/internal-objects: |-
       ["quayecosystems.redhatcop.redhat.io"]
+    operators.openshift.io/infrastructure-features: '["Disconnected"]'
   name: quay-operator.v3.4.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-839

**Changelog:** 
none

**Docs:** 
https://docs.openshift.com/container-platform/4.6/operators/admin/olm-restricted-networks.html

**Testing:** 
Test disconnected install

**Details:** 
https://docs.openshift.com/container-platform/4.6/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs