### PR TITLE
Config Editor Credentials Secret (PROJQUAY-1240)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -123,6 +123,8 @@ type QuayRegistryStatus struct {
 	// ConfigEditorEndpoint is the external access point for a web-based reconfiguration interface
 	// for the Quay registry instance.
 	ConfigEditorEndpoint string `json:"configEditorEndpoint,omitempty"`
+	// ConfigEditorCredentialsSecret is the Kubernetes `Secret` containing the config editor password.
+	ConfigEditorCredentialsSecret string `json:"configEditorCredentialsSecret,omitempty"`
 	// Conditions represent the conditions that a QuayRegistry can have.
 	Conditions []Condition `json:"conditions,omitempty"`
 }

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -92,6 +92,10 @@ spec:
                     type: string
                 type: object
               type: array
+            configEditorCredentialsSecret:
+              description: ConfigEditorCredentialsSecret is the Kubernetes `Secret`
+                containing the config editor password.
+              type: string
             configEditorEndpoint:
               description: ConfigEditorEndpoint is the external access point for a
                 web-based reconfiguration interface for the Quay registry instance.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - quay.redhat.com.quay.redhat.com
+  - quay.redhat.com
   resources:
   - quayregistries
   verbs:
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - quay.redhat.com.quay.redhat.com
+  - quay.redhat.com
   resources:
   - quayregistries/status
   verbs:

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -7,6 +7,9 @@ import (
 	objectbucket "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/quay/quay-operator/apis/quay/v1"
@@ -117,4 +120,18 @@ func stripObjectBucketClaimAnnotations(quay *v1.QuayRegistry) *v1.QuayRegistry {
 	delete(existingAnnotations, v1.StorageSecretKeyAnnotation)
 
 	return quay
+}
+
+func configEditorCredentialsSecretFrom(objs []runtime.Object) string {
+	for _, obj := range objs {
+		objectMeta, _ := meta.Accessor(obj)
+		groupVersionKind := obj.GetObjectKind().GroupVersionKind().String()
+		secretGVK := schema.GroupVersionKind{Version: "v1", Kind: "Secret"}.String()
+
+		if groupVersionKind == secretGVK && strings.Contains(objectMeta.GetName(), "quay-config-editor-credentials") {
+			return objectMeta.GetName()
+		}
+	}
+
+	return ""
 }

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -189,6 +189,8 @@ func (r *QuayRegistryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		}
 	}
 
+	updatedQuay.Status.ConfigEditorCredentialsSecret = configEditorCredentialsSecretFrom(deploymentObjects)
+
 	log.Info("all objects created/updated successfully")
 	updatedQuay, err = r.updateWithCondition(updatedQuay, v1.ConditionTypeRolloutBlocked, metav1.ConditionFalse, v1.ConditionReasonComponentsCreationSuccess, "all objects created/updated successfully")
 	if err != nil {

--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
-    containerImage: quay.io/projectquay/quay-operator@sha256:4cf12a770d040dac36a6d876c797afc233dd6969b595bdd19399e10ccb86154c
+    containerImage: quay.io/projectquay/quay-operator@sha256:3d04e4346775c696a37243caa8ed75cb919363908237b452bcaaf965121acdc3
     createdAt: 2020-08-24 00:00:00
     description: Opinionated deployment of Quay on Kubernetes.
     repository: https://github.com/quay/quay-operator
@@ -81,6 +81,11 @@ spec:
           description: Observed conditions of Quay components.
           x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes.conditions'
+        - path: configEditorCredentialsSecret
+          displayName: Config Editor Credentials Secret
+          description: Name of the secret containing credentials for the Quay config editor.
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
     - kind: QuayEcosystem
       version: v1alpha1
       name: quayecosystems.redhatcop.redhat.io
@@ -105,7 +110,7 @@ spec:
             spec:
               containers:
               - name: quay-operator
-                image: quay.io/projectquay/quay-operator@sha256:4cf12a770d040dac36a6d876c797afc233dd6969b595bdd19399e10ccb86154c
+                image: quay.io/projectquay/quay-operator@sha256:3d04e4346775c696a37243caa8ed75cb919363908237b452bcaaf965121acdc3
                 command:
                 - /workspace/manager
                 - '--namespace=$(WATCH_NAMESPACE)'

--- a/deploy/manifests/quay-operator/0.0.1/quayregistries.quay.redhat.com.crd.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quayregistries.quay.redhat.com.crd.yaml
@@ -90,6 +90,10 @@ spec:
                     type: string
                 type: object
               type: array
+            configEditorCredentialsSecret:
+              description: ConfigEditorCredentialsSecret is the Kubernetes `Secret`
+                containing the config editor password.
+              type: string
             configEditorEndpoint:
               description: ConfigEditorEndpoint is the external access point for a
                 web-based reconfiguration interface for the Quay registry instance.

--- a/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
@@ -81,6 +81,11 @@ spec:
           description: Observed conditions of Quay components.
           x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes.conditions'
+        - path: configEditorCredentialsSecret
+          displayName: Config Editor Credentials Secret
+          description: Name of the secret containing credentials for the Quay config editor.
+          x-descriptors:
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
     - kind: QuayEcosystem
       version: v1alpha1
       name: quayecosystems.redhatcop.redhat.io

--- a/deploy/manifests/quay-operator/3.4.0/quayregistries.quay.redhat.com.crd.yaml
+++ b/deploy/manifests/quay-operator/3.4.0/quayregistries.quay.redhat.com.crd.yaml
@@ -90,6 +90,10 @@ spec:
                     type: string
                 type: object
               type: array
+            configEditorCredentialsSecret:
+              description: ConfigEditorCredentialsSecret is the Kubernetes `Secret`
+                containing the config editor password.
+              type: string
             configEditorEndpoint:
               description: ConfigEditorEndpoint is the external access point for a
                 web-based reconfiguration interface for the Quay registry instance.

--- a/deploy/quay-operator.catalogsource.yaml
+++ b/deploy/quay-operator.catalogsource.yaml
@@ -4,4 +4,4 @@ metadata:
   name: quay-operator
 spec:
   sourceType: grpc
-  image: quay.io/projectquay/quay-operator-catalog@sha256:2a1ed500253072f82bedc2654980c694dd115f3f944fec194a5de72befb0cef1
+  image: quay.io/projectquay/quay-operator-catalog@sha256:a44a4b48f0bf77c49402b3cb5348ebd33c229ae12a91e291e7ca8a1fd4f67398

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -36,6 +36,8 @@ const (
 	managedFieldGroupsKey = "quay-managed-fieldgroups"
 
 	componentImagePrefix = "RELATED_IMAGE_COMPONENT_"
+
+	configEditorUser = "quayconfig"
 )
 
 // componentImageFor checks for an environment variable indicating which component container image
@@ -235,7 +237,7 @@ func KustomizationFor(quay *v1.QuayRegistry, quayConfigFiles map[string][]byte) 
 			GeneratorArgs: types.GeneratorArgs{
 				Name: "quay-config-editor-credentials",
 				KvPairSources: types.KvPairSources{
-					LiteralSources: []string{"password=" + configEditorPassword},
+					LiteralSources: []string{"username=" + configEditorUser, "password=" + configEditorPassword},
 				},
 			},
 		},


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1240

**Changelog:** Adds `status.configEditorCredentialsSecret` to `QuayRegistry` API.

**Docs:** The username/password for the config editor can now be found by checking the `status.configEditorCredentialsSecret` on the `QuayRegistry` object.

**Testing:** N/a

**Details:** Adds API and OLM status descriptor for the `Secret` containing the password to the config editor.