### PR TITLE
Remove fsGroup from Postgres Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ NAME     MGMT-ENDPOINTS              S3-ENDPOINTS                IMAGE          
 noobaa   [https://10.0.32.3:30318]   [https://10.0.32.3:31958]   registry.redhat.io/ocs4/mcg-core-rhel8@sha256:56624aa7dd4ca178c1887343c7445a9425a841600b1309f6deace37ce6b8678d   Ready   3d18h
 ```
 
+**Grant filesystem permissions to managed Postgres pods (OpenShift only):**
+```sh
+$ oc adm policy add-scc-to-user nonroot system:serviceaccount:<your-namespace>:default
+```
+
 **Create `QuayRegistry` instance:**
 ```sh
 $ kubectl create -n <your-namespace> -f ./config/samples/managed.quayregistry.yaml

--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -18,9 +18,6 @@ spec:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: clair-postgres
-      # FIXME(alecmerdler): Need to set `fsGroup: 0` for `centos/postgresql-10-centos7` but not `rhel8/postgresql-10`
-      securityContext:
-        fsGroup: 0
       containers:
         - name: postgres
           image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -18,9 +18,6 @@ spec:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: quay-database
-      # FIXME(alecmerdler): Need to set `fsGroup: 0` for `centos/postgresql-10-centos7` but not `rhel8/postgresql-10`
-      securityContext:
-        fsGroup: 0
       containers:
         - name: postgres
           image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33


### PR DESCRIPTION
Unnecessary to have `fsGroup` when using the RHEL-based images. When running the upstream (CentOS) Postgres images on OpenShift, simply execute this command to grant the correct filesystem permissions to the containers:

```sh
$ oc adm policy add-scc-to-user nonroot system:serviceaccount:<your-namespace>:default
```