### PR TITLE
Fix Reconfigure Flow (PROJQUAY-1156)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,72 @@
+# Configuration
+
+Quay is a powerful container registry platform with many features and components, and is highly configurable. The Quay Operator attempts to mitigate the potential headaches of configuration in a few different ways. 
+
+## Quay Config File
+
+All of Quay's config is contained in a single file called `config.yaml`, which is defined in this [schema](https://github.com/quay/quay/blob/master/util/config/schema.py). The Quay application requires this file to be mounted into the container at a specific location at runtime. On Kubernetes, this is accomplished by creating a `Secret` with the `config.yaml` file contents and referencing it as a `volumeMount` in the Quay `Deployment`.
+
+The Quay Operator uses the `spec.configBundleSecret` field of the `QuayRegistry` API to provide a base config to the Quay application that will be deployed. This `Secret` is merged with other config values to produce a final config bundle which is actually mounted into the Quay containers. If you are interested in seeing the full config being used by Quay, simply inspect the Quay `Deployment` and find the `Secret` referenced by the `volumeMount`:
+
+```sh
+$ kubectl get deployments -n <namespace> <quayregistry-name>-quay-app -o jsonpath="{.spec.template.spec.volumes[0].secret.secretName}"
+<quayregistry-name>-quay-config-secret-22dbk9btcg
+$ kubectl get secret -n <namespace> <quayregistry-name>-quay-config-secret-22dbk9btcg -o jsonpath="{.data['config\.yaml']}" | base64 --decode
+```
+
+## Managed Components
+
+The Quay Operator is capable of managing the lifecycle of many of Quay's dependencies, called _components_. Some examples are the main database, object storage, image security scanning, and more. Each of these components usually include relevant config fields in `config.yaml`. When the Operator is managing a component, it will populate the necessary config fields for you. If you choose to use an unmanaged component (provide your own database, for example), then you are responsible for providing the necessary config fields in the `config.yaml`. 
+
+## Configuring Quay 
+
+### Zero-Config, Batteries-Included
+
+If you opt to have all components of Quay fully managed by the Operator and desire no additional configuration changes, you can omit the `spec.configBundleSecret` field of the `QuayRegistry` (in fact, all fields of the `spec` are optional). The Operator will generate a `Secret` for you containing a bundle of `config.yaml` (with all component fields) and TLS key/cert pair (self-signed). The `spec.configBundleSecret` field will then be auto-populated by the Operator during reconciliation.
+
+Note that previous config `Secrets` will not be deleted by the Operator after reconfiguration. They are kept around in case of misconfiguration and a rollback to a previous configuration is necessary to restore the registry service.
+
+### Quay Config Editor
+
+Quay includes a standalone web application for configuration. The Quay Operator will create a Kubernetes `Service` and expose it at the URL specified in `status.configEditorEndpoint` on the `QuayRegistry` after creation. Access it using a web browser.
+
+#### Config Editor Credentials
+
+The password for the config editor is randomly generated during every reconcile. The username/password are contained in a `Secret` in the same namespace referenced in `status.configEditorCredentialsSecret` on the `QuayRegistry` object.
+
+#### Reconfiguring Quay 
+
+Once you have finished making changes to the Quay config using the editor, click the button to validate your changes. If it passes validation, click the button **Reconfigure Quay**. This will send your changes to an HTTP server ran by the Quay Operator, which will create a new `Secret` from the config bundle, and change the `spec.configBundleSecret` field on the `QuayRegistry` to reference it. This will kick off a normal reconcile loop. Once completed, Quay will now be configured with your changes.
+
+See also the [documentation on components](https://github.com/quay/quay-operator/docs/components.md).
+
+### Creating Config Bundle Secret
+
+All that is needed to configure Quay using the Operator is to change the `Secret` referenced by `spec.configBundleSecret` on the `QuayRegistry` object. All the steps handled by the config editor UI flow can be replicated manually using the Kubernetes REST API. This is useful if you want to use GitOps (recommended!) and automated tooling as part of a pipeline to manage configuration changes to your Quay registry.
+
+#### Example
+
+1. Create a `Secret` with your configuration fields in a `config.yaml`:
+
+`config.yaml`:
+```yaml
+REGISTRY_TITLE: My Awesome Quay
+```
+
+```sh
+$ kubectl create secret generic --from-file config.yaml=./config.yaml test-config-bundle
+```
+
+2. Update the `QuayRegistry` to reference the created `Secret`:
+
+`test.quayregistry.yaml`
+```yaml
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: test
+spec:
+  configBundleSecret: test-config-bundle
+```
+
+The deployed Quay application will now use the external database.

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-config-editor
-          image: quay.io/projectquay/quay@sha256:6fe0cfe3ecb544f273d775d16f03e6dff7313775af982dbbd546bf976e3c97e3
+          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -47,7 +47,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: QUAY_OPERATOR_ENDPOINT
-              value: http://quay-operator:7071
+              # FIXME(alecmerdler): Debugging
+              # value: http://quay-operator:7071
+              value: http://9f22be9064aa.ngrok.io
             - name: QUAY_CONFIG_READ_ONLY_FIELD_GROUPS
               valueFrom:
                 fieldRef:

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app
-          image: quay.io/projectquay/quay@sha256:6fe0cfe3ecb544f273d775d16f03e6dff7313775af982dbbd546bf976e3c97e3
+          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app-upgrade
-          image: quay.io/projectquay/quay@sha256:6fe0cfe3ecb544f273d775d16f03e6dff7313775af982dbbd546bf976e3c97e3
+          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # FIXME(alecmerdler): May need an `initContainer` which blocks until Quay app is running...
       containers:
         - name: quay-mirror
-          image: quay.io/projectquay/quay@sha256:6fe0cfe3ecb544f273d775d16f03e6dff7313775af982dbbd546bf976e3c97e3
+          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
           command: ["/quay-registry/quay-entrypoint.sh"]
           args: ["repomirror-nomigrate"]
           env:

--- a/kustomize/overlays/current/config-only/kustomization.yaml
+++ b/kustomize/overlays/current/config-only/kustomization.yaml
@@ -1,0 +1,10 @@
+# Overlay variant for only deploying config editor.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  quay-version: vader
+bases:
+  - ../../../tmp
+patchesStrategicMerge:
+  # Scale the app deployment to 0 pods in order to prevent pod errors on startup from invalid configuration.
+  - ./quay.deployment.patch.yaml

--- a/kustomize/overlays/current/config-only/quay.deployment.patch.yaml
+++ b/kustomize/overlays/current/config-only/quay.deployment.patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quay-app
+  annotations:
+    quay-upgrade: vader
+spec:
+  replicas: 0

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -150,3 +150,133 @@ func TestFieldGroupFor(t *testing.T) {
 		assert.Equal(string(expected), string(configFields), test.name)
 	}
 }
+
+var containsComponentConfigTests = []struct {
+	name          string
+	component     string
+	rawConfig     string
+	expected      bool
+	expectedError error
+}{
+	{
+		"ClairContains",
+		"clair",
+		`FEATURE_SECURITY_SCANNER: true`,
+		true,
+		nil,
+	},
+	{
+		"ClairDoesNotContain",
+		"clair",
+		``,
+		false,
+		nil,
+	},
+	{
+		"PostgresContains",
+		"postgres",
+		`DB_URI: postgresql://test-quay-database:postgres@test-quay-database:5432/test-quay-database`,
+		true,
+		nil,
+	},
+	{
+		"PostgresDoesNotContain",
+		"postgres",
+		``,
+		false,
+		nil,
+	},
+	{
+		"RedisContains",
+		"redis",
+		`BUILDLOGS_REDIS:
+  host: test-quay-redis
+`,
+		true,
+		nil,
+	},
+	{
+		"RedisDoesNotContain",
+		"redis",
+		``,
+		false,
+		nil,
+	},
+	{
+		"ObjectStorageContains",
+		"objectstorage",
+		`DISTRIBUTED_STORAGE_PREFERENCE: 
+  - local_us
+`,
+		true,
+		nil,
+	},
+	{
+		"ObjectStorageDoesNotContain",
+		"objectstorage",
+		``,
+		false,
+		nil,
+	},
+	{
+		"MirrorContains",
+		"mirror",
+		`FEATURE_REPO_MIRROR: true`,
+		true,
+		nil,
+	},
+	{
+		"MirrorDeosNotContain",
+		"mirror",
+		``,
+		false,
+		nil,
+	},
+	{
+		"RouteContains",
+		"route",
+		`PREFERRED_URL_SCHEME: http`,
+		true,
+		nil,
+	},
+	{
+		"RouteContainsServerHostname",
+		"route",
+		`SERVER_HOSTNAME: registry.skynet.com`,
+		false,
+		nil,
+	},
+	{
+		"RouteDoesNotContain",
+		"route",
+		``,
+		false,
+		nil,
+	},
+	{
+		"HorizontalPodAutoscalerDoesNotContain",
+		"horizontalpodautoscaler",
+		``,
+		false,
+		nil,
+	},
+}
+
+func TestContainsComponentConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, test := range containsComponentConfigTests {
+		var fullConfig map[string]interface{}
+		err := yaml.Unmarshal([]byte(test.rawConfig), &fullConfig)
+		assert.Nil(err, test.name)
+
+		contains, err := ContainsComponentConfig(fullConfig, test.component)
+
+		if test.expectedError != nil {
+			assert.NotNil(err, test.name)
+		} else {
+			assert.Nil(err, test.name)
+			assert.Equal(test.expected, contains, test.name)
+		}
+	}
+}


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1156

**Changelog:** Fixes multiple bugs around the reconfiguration UX flow for unmanaged components.

**Docs:** Included.

**Testing:** N/a

**Details:** The `/reconfigure` endpoint now infers which components are managed/unmanaged by detecting which fieldgroups are in the given `config.yaml`. The UX flow for configuring an unmanaged component (like database) can now be done in a single step through the config editor.
