### PR TITLE
Status Descriptors for Registry and Config Editor Endpoints (PROJQUAY-1267)

### DIFF
--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ spec:
           description: Indicates whether lifecycle of this component is managed by the Operator or externally.
       statusDescriptors:
         - path: currentVersion
-          displayName: CurrentVersion
+          displayName: Current Version
           description: The currently installed version of all Quay components.
         - path: conditions
           displayName: Conditions
@@ -86,6 +86,16 @@ spec:
           description: Name of the secret containing credentials for the Quay config editor.
           x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:Secret'
+        - path: registryEndpoint
+          displayName: Registry Endpoint
+          description: Externally accessible URL for container pull/push and web frontend.
+          x-descriptors:
+            - 'urn:alm:descriptor:org.w3:link'
+        - path: configEditorEndpoint
+          displayName: Config Editor Endpoint
+          description: Externally accessible URL for the config editor UI.
+          x-descriptors:
+            - 'urn:alm:descriptor:org.w3:link'
     - kind: QuayEcosystem
       version: v1alpha1
       name: quayecosystems.redhatcop.redhat.io

--- a/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
@@ -75,7 +75,7 @@ spec:
           description: Indicates whether lifecycle of this component is managed by the Operator or externally.
       statusDescriptors:
         - path: currentVersion
-          displayName: CurrentVersion
+          displayName: Current Version
           description: The currently installed version of all Quay components.
         - path: conditions
           displayName: Conditions
@@ -87,6 +87,16 @@ spec:
           description: Name of the secret containing credentials for the Quay config editor.
           x-descriptors:
             - 'urn:alm:descriptor:io.kubernetes:Secret'
+        - path: registryEndpoint
+          displayName: Registry Endpoint
+          description: Externally accessible URL for container pull/push and web frontend.
+          x-descriptors:
+            - 'urn:alm:descriptor:org.w3:link'
+        - path: configEditorEndpoint
+          displayName: Config Editor Endpoint
+          description: Externally accessible URL for the config editor UI.
+          x-descriptors:
+            - 'urn:alm:descriptor:org.w3:link'
     - kind: QuayEcosystem
       version: v1alpha1
       name: quayecosystems.redhatcop.redhat.io

--- a/deploy/quay-operator.catalogsource.yaml
+++ b/deploy/quay-operator.catalogsource.yaml
@@ -4,4 +4,4 @@ metadata:
   name: quay-operator
 spec:
   sourceType: grpc
-  image: quay.io/projectquay/quay-operator-catalog@sha256:2c9ff77309b708b2e5a394997897e71e4fd8004c6b8ed71f372d14c2eff73e1e
+  image: quay.io/projectquay/quay-operator-catalog@sha256:1db0d17fa559215312accdc5ae07f74bdf7dc117289c3c92ff4a6cb421e85bcc


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1267

**Changelog:** Adds OLM status descriptors for `status.registryEndpoint` and `status.configEditorEndpoint`.

**Docs:** N/a

**Testing:** N/a

**Details:** Adds OLM status descriptors for `status.registryEndpoint` and `status.configEditorEndpoint`.