### PR TITLE
Fix Zero Clair Updaters (PROJQUAY-1268)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7
+	github.com/quay/clair/v4 v4.0.0-rc.20.0.20201112172303-bb3cd669f663
 	github.com/quay/claircore v1.0.5 // indirect
 	github.com/quay/config-tool v0.1.2-0.20201013214416-e1ea29372174
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,7 @@ github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f/go.mod h1:q59u9px8b7UTj0nIjEjvmTWekazka6xIt6Uogz5Dm+8=
 github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d/go.mod h1:o8sgWoz3JADecfc/cTYD92/Et1yMqMy0utV1z+VaZao=
 github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936/go.mod h1:i4sF0l1fFnY1aiw08QQSwVAFxHEm311Me3WsU/X7nL0=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -652,9 +653,9 @@ github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d h1:K6eOUihrFLdZjZ
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7 h1:P5VV0gAFTkZgVpeZA341tbu7wTJ9XzV/Gi54Q3CwaFo=
-github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7/go.mod h1:7oE9Vug5TcdaBGU+J0T60ckdvccXxivu45hZJlkjjN4=
-github.com/quay/claircore v0.1.13/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
+github.com/quay/clair/v4 v4.0.0-rc.20.0.20201112172303-bb3cd669f663 h1:+fHI+xUKkXGidtetZILRXzGenKdKHxBu+MhzK/77QdM=
+github.com/quay/clair/v4 v4.0.0-rc.20.0.20201112172303-bb3cd669f663/go.mod h1:JnKI4ZSOK2asNjIz/JR09P9eseWhguIFO9IFNIHkTNw=
+github.com/quay/claircore v0.1.15/go.mod h1:l1ZRAtV8fqxTBvIRqui6px4u713UaBaU19gvHEVj9Fw=
 github.com/quay/claircore v1.0.5 h1:Q7zz0MedTefnHEv8rB8gxJJENT76NEHdAx/XL4mBMp0=
 github.com/quay/claircore v1.0.5/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
 github.com/quay/config-tool v0.1.2-0.20201013214416-e1ea29372174 h1:SDv0LAaX+zaw3BAyQbUZQ9xRbBumqMnyMk5tdu7GTbI=

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -385,7 +385,7 @@ func clairConfigFor(quay *v1.QuayRegistry, quayHostname, preSharedKey string) []
 	dbConn := fmt.Sprintf("host=%s port=5432 dbname=%s user=%s password=%s sslmode=disable", host, dbname, user, password)
 	config := config.Config{
 		HTTPListenAddr: ":8080",
-		LogLevel:       "debug",
+		LogLevel:       "info",
 		Indexer: config.Indexer{
 			ConnString:           dbConn,
 			ScanLockRetry:        10,

--- a/vendor/github.com/quay/clair/v4/config/config.go
+++ b/vendor/github.com/quay/clair/v4/config/config.go
@@ -58,7 +58,7 @@ type Config struct {
 	Auth     Auth     `yaml:"auth" json:"auth"`
 	Trace    Trace    `yaml:"trace" json:"trace"`
 	Metrics  Metrics  `yaml:"metrics" json:"metrics"`
-	Updaters Updaters `yaml:"updaters" json:"updaters"`
+	Updaters Updaters `yaml:"updaters,omitempty" json:"updaters,omitempty"`
 }
 
 // Updaters configures updater behavior.
@@ -78,7 +78,7 @@ type Updaters struct {
 	// "rhel"
 	// "suse"
 	// "ubuntu"
-	Sets []string `yaml:"sets" json:"sets"`
+	Sets []string `yaml:"sets,omitempty" json:"sets,omitempty"`
 	// Config holds configuration blocks for UpdaterFactories and Updaters,
 	// keyed by name.
 	//

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d
 github.com/qri-io/starlib/util
-# github.com/quay/clair/v4 v4.0.0-rc.18.0.20201022192047-157628dfe1c7
+# github.com/quay/clair/v4 v4.0.0-rc.20.0.20201112172303-bb3cd669f663
 github.com/quay/clair/v4/clair-error
 github.com/quay/clair/v4/config
 github.com/quay/clair/v4/indexer


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1268

**Changelog:** Update Clair dependency to correctly marshal config struct to YAML.

**Docs:** N/a

**Testing:** N/a

**Details:** Clair was being configured with zero updaters versus all updaters due to marshalling the Go struct to YAML incorrectly. Updated Clair dependency so that changes to the config struct tags are used. Also sets the log level of Clair to `info`.
