### PR TITLE
Fix Registry Endpoint (PROJQUAY-1278)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -277,7 +277,7 @@ func EnsureRegistryEndpoint(quay *QuayRegistry) (*QuayRegistry, bool) {
 	if supportsRoutes(quay) {
 		clusterHostname := quay.GetAnnotations()[ClusterHostnameAnnotation]
 		// FIXME(alecmerdler): This is incorrect if `SERVER_HOSTNAME` is set...
-		updatedQuay.Status.RegistryEndpoint = strings.Join([]string{
+		updatedQuay.Status.RegistryEndpoint = "https://" + strings.Join([]string{
 			strings.Join([]string{quay.GetName(), "quay", quay.GetNamespace()}, "-"),
 			clusterHostname},
 			".")
@@ -293,7 +293,7 @@ func EnsureConfigEditorEndpoint(quay *QuayRegistry) (*QuayRegistry, bool) {
 
 	if supportsRoutes(quay) {
 		clusterHostname := quay.GetAnnotations()[ClusterHostnameAnnotation]
-		updatedQuay.Status.ConfigEditorEndpoint = strings.Join([]string{
+		updatedQuay.Status.ConfigEditorEndpoint = "https://" + strings.Join([]string{
 			strings.Join([]string{quay.GetName(), "quay-config-editor", quay.GetNamespace()}, "-"),
 			clusterHostname},
 			".")

--- a/apis/quay/v1/quayregistry_types_test.go
+++ b/apis/quay/v1/quayregistry_types_test.go
@@ -322,7 +322,7 @@ var ensureRegistryEndpointTests = []struct {
 				},
 			},
 		},
-		"test-quay-ns-1.apps.example.com",
+		"https://test-quay-ns-1.apps.example.com",
 		false,
 	},
 	{
@@ -337,10 +337,10 @@ var ensureRegistryEndpointTests = []struct {
 				},
 			},
 			Status: QuayRegistryStatus{
-				RegistryEndpoint: "test-quay-ns-1.apps.example.com",
+				RegistryEndpoint: "https://test-quay-ns-1.apps.example.com",
 			},
 		},
-		"test-quay-ns-1.apps.example.com",
+		"https://test-quay-ns-1.apps.example.com",
 		true,
 	},
 	{


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1278

**Changelog:** Add `https://` to `status.registryEndpoint`.

**Docs:** N/a

**Testing:** N/a

**Details:** Ensure the console UI renders a full link to Quay rather than relative link.