### PR TITLE
Clair Init Container (PROJQUAY-1281)

### DIFF
--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-config-editor
-          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
+          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app
-          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
+          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app-upgrade
-          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
+          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/components/clair/kustomization.yaml
+++ b/kustomize/components/clair/kustomization.yaml
@@ -9,5 +9,13 @@ resources:
   - ./postgres.service.yaml
 generatorOptions:
   disableNameSuffixHash: true
+vars:
+  - name: CLAIR_SERVICE_HOST
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: clair
+patchesStrategicMerge:
+  - ./upgrade.deployment.patch.yaml
 secretGenerator:
   - name: clair-config-secret

--- a/kustomize/components/clair/upgrade.deployment.patch.yaml
+++ b/kustomize/components/clair/upgrade.deployment.patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quay-app-upgrade
+spec:
+  template:
+    metadata:
+      labels:
+        quay-component: quay-app-upgrade
+    spec:
+      # Init conatainer needed to wait for Clair to initialize (can take minutes) before attempting to validate config.
+      initContainers:
+        - name: quay-app-upgrade-init
+          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          command:
+            - /bin/sh
+            - -c
+            - curl $CLAIR_SERVICE_HOST
+          env:
+            - name: CLAIR_SERVICE_HOST
+              value: $(CLAIR_SERVICE_HOST)

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -31,7 +31,7 @@ spec:
       # FIXME(alecmerdler): May need an `initContainer` which blocks until Quay app is running...
       containers:
         - name: quay-mirror
-          image: quay.io/projectquay/quay@sha256:3bb8ba15910424ef5090324d44a237fbabf60097361e2c5aac2829c6ab98bb4f
+          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
           command: ["/quay-registry/quay-entrypoint.sh"]
           args: ["repomirror-nomigrate"]
           env:

--- a/kustomize/components/postgres/init.job.yaml
+++ b/kustomize/components/postgres/init.job.yaml
@@ -8,9 +8,6 @@ spec:
       name: quay-postgres-init
     spec:
       restartPolicy: Never
-      # FIXME(alecmerdler): Need to set `fsGroup: 0` for `centos/postgresql-10-centos7` but not `rhel8/postgresql-10`
-      # securityContext:
-      #   fsGroup: 0
       volumes:
         - name: postgres-bootstrap
           secret:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1281

**Changelog:** Use `initContainer` to wait until Clair is initialized before attempting config validation.

**Docs:** N/a

**Testing:** Create `QuayRegistry` and ensure upgrade pods do not enter `CrashLoopBackoff` from Clair.

**Details:** Previously, upgrade pods would enter `CrashLoopBackoff` when trying to perform config validation because Clair service takes several minutes to initialize and serve HTTP traffic. Fix this by blocking the main container from starting and attempting validation until Clair service responds.
