### PR TITLE
Repo Mirror Init Container (PROJQUAY-1144)

### DIFF
--- a/kustomize/components/mirror/kustomization.yaml
+++ b/kustomize/components/mirror/kustomization.yaml
@@ -3,3 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources: 
   - ./mirror.deployment.yaml
+vars:
+  - name: QUAY_APP_SERVICE_HOST
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: quay-app

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -28,7 +28,16 @@ spec:
                   items:
                     - key: ssl.cert
                       path: quay-ssl.cert
-      # FIXME(alecmerdler): May need an `initContainer` which blocks until Quay app is running...
+      initContainers:
+        - name: quay-mirror-init
+          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          command:
+            - /bin/sh
+            - -c
+            - curl $QUAY_APP_SERVICE_HOST
+          env:
+            - name: QUAY_APP_SERVICE_HOST
+              value: $(QUAY_APP_SERVICE_HOST)
       containers:
         - name: quay-mirror
           image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1144

**Changelog:** Use `initContainer` to block `mirror` component until Quay app is running.

**Docs:** N/a

**Testing:** Create `QuayRegistry` and ensure `mirror` pods never enter `CrashLoopBackoff` or `Error`.

**Details:** Improve UX by using `initContainer` to block `mirror` component until Quay app is running which prevents pod errors.
