### PR TITLE
Fix Reconfigure Marking Components as Unmanaged (PROJQUAY-1267)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -59,6 +59,11 @@ var allComponents = []string{
 	"mirror",
 }
 
+var requiredComponents = []string{
+	"postgres",
+	"objectstorage",
+}
+
 // QuayRegistrySpec defines the desired state of QuayRegistry.
 type QuayRegistrySpec struct {
 	// ConfigBundleSecret is the name of the Kubernetes `Secret` in the same namespace which contains the base Quay config and extra certs.
@@ -265,6 +270,16 @@ func ComponentIsManaged(components []Component, name string) bool {
 	for _, c := range components {
 		if c.Kind == name {
 			return c.Managed
+		}
+	}
+	return false
+}
+
+// RequiredComponent returns whether the given component is required for Quay or not.
+func RequiredComponent(component string) bool {
+	for _, c := range requiredComponents {
+		if c == component {
+			return true
 		}
 	}
 	return false

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -46,7 +46,7 @@ import (
 )
 
 const upgradePollInterval = time.Second * 10
-const upgradePollTimeout = time.Second * 360
+const upgradePollTimeout = time.Second * 600
 
 // QuayRegistryReconciler reconciles a QuayRegistry object
 type QuayRegistryReconciler struct {
@@ -210,8 +210,8 @@ func (r *QuayRegistryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 				return ctrl.Result{}, nil
 			}
-		} else if !component.Managed && !contains {
-			msg := fmt.Sprintf("%s component marked as unmanaged, but `configBundleSecret` is missing required fields", component.Kind)
+		} else if !component.Managed && v1.RequiredComponent(component.Kind) && !contains {
+			msg := fmt.Sprintf("required component `%s` marked as unmanaged, but `configBundleSecret` is missing necessary fields", component.Kind)
 
 			updatedQuay, err = r.updateWithCondition(&quay, v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue, v1.ConditionReasonConfigInvalid, msg)
 			if err != nil {

--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
-    containerImage: quay.io/projectquay/quay-operator@sha256:ddb475693da995260c663d2b335bc7f7a419a52650d84659e2b7cefb674086d7
+    containerImage: quay.io/projectquay/quay-operator@sha256:564024b11ff4d227f0ba2a74eef97e9cb8cd32c3ae12b6c595d13ab564e9a24a
     createdAt: 2020-08-24 00:00:00
     description: Opinionated deployment of Quay on Kubernetes.
     repository: https://github.com/quay/quay-operator
@@ -120,7 +120,7 @@ spec:
             spec:
               containers:
               - name: quay-operator
-                image: quay.io/projectquay/quay-operator@sha256:ddb475693da995260c663d2b335bc7f7a419a52650d84659e2b7cefb674086d7
+                image: quay.io/projectquay/quay-operator@sha256:564024b11ff4d227f0ba2a74eef97e9cb8cd32c3ae12b6c595d13ab564e9a24a
                 command:
                 - /workspace/manager
                 - '--namespace=$(WATCH_NAMESPACE)'
@@ -138,7 +138,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_COMPONENT_QUAY
-                  value: quay.io/projectquay/quay@sha256:6fe0cfe3ecb544f273d775d16f03e6dff7313775af982dbbd546bf976e3c97e3
+                  value: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
                 - name: RELATED_IMAGE_COMPONENT_CLAIR
                   value: quay.io/projectquay/clair@sha256:70c99feceb4c0973540d22e740659cd8d616775d3ad1c1698ddf71d0221f3ce6
                 - name: RELATED_IMAGE_COMPONENT_POSTGRES

--- a/deploy/quay-operator.catalogsource.yaml
+++ b/deploy/quay-operator.catalogsource.yaml
@@ -4,4 +4,4 @@ metadata:
   name: quay-operator
 spec:
   sourceType: grpc
-  image: quay.io/projectquay/quay-operator-catalog@sha256:1db0d17fa559215312accdc5ae07f74bdf7dc117289c3c92ff4a6cb421e85bcc
+  image: quay.io/projectquay/quay-operator-catalog@sha256:66f23a75be0db3df3addba246ee8b179a5d3e495cdf55a841f605f97649d6b56


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1267

**Changelog:** Only check config for required components which are unmanaged.

**Docs:** N/a

**Testing:** N/a

**Details:** When using the config editor to reconfigure the `QuayRegistry`, some components were being incorrectly inferred as unmanaged.