### PR TITLE
Fix Config Editor Operator Endpoint (PROJQUAY-1285)

### DIFF
--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -47,7 +47,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: QUAY_OPERATOR_ENDPOINT
-              value: http://quay-operator:7071
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['quay-operator-service-endpoint']
             - name: QUAY_CONFIG_READ_ONLY_FIELD_GROUPS
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1285

**Changelog:** Ensure the endpoint of the Quay Operator `Service` includes the namespace when passed to the config editor.

**Docs:** N/a

**Testing:** Ensure that the reconfigure flow works when the Operator is installed in `all-namespaces` mode.

**Details:** We were hard-coding the `Service` endpoint passed to the config editor as `http://quay-operator:7071`, which only works when the Operator is installed in the same namespace as the `QuayRegistry` being reconciled. Use Kustomize to add annotations which contains the full endpoint (including namespace) and pass that to the config editor.
