### PR TITLE
kustomize: add clairctl to default allowed issuers

### DIFF
--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -413,7 +413,7 @@ func clairConfigFor(quay *v1.QuayRegistry, quayHostname, preSharedKey string) []
 		Auth: config.Auth{
 			PSK: &config.AuthPSK{
 				Key:    psk,
-				Issuer: []string{"quay"},
+				Issuer: []string{"quay", "clairctl"},
 			},
 		},
 		Metrics: config.Metrics{


### PR DESCRIPTION
This will allow users to use `clairctl` by default when authentication is enabled.

**Issue:** n/a

**Changelog:** This will allow users to use `clairctl` by default when authentication is enabled.

**Docs:** 

**Testing:** 

**Details:** Adds `clairctl`'s issuer to the default list.