### PR TITLE
Properly Rename Extra CA Certificates (PROJQUAY-1306)

### DIFF
--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -138,7 +138,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_COMPONENT_QUAY
-                  value: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+                  value: quay.io/projectquay/quay@sha256:a544ee36a20cb24d02a5f7b70daef776b169e3b2cdfc8f5dcf605475067ac8b0
                 - name: RELATED_IMAGE_COMPONENT_CLAIR
                   value: quay.io/projectquay/clair@sha256:70c99feceb4c0973540d22e740659cd8d616775d3ad1c1698ddf71d0221f3ce6
                 - name: RELATED_IMAGE_COMPONENT_POSTGRES

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-config-editor
-          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          image: quay.io/projectquay/quay@sha256:a544ee36a20cb24d02a5f7b70daef776b169e3b2cdfc8f5dcf605475067ac8b0
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app
-          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          image: quay.io/projectquay/quay@sha256:a544ee36a20cb24d02a5f7b70daef776b169e3b2cdfc8f5dcf605475067ac8b0
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app-upgrade
-          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          image: quay.io/projectquay/quay@sha256:a544ee36a20cb24d02a5f7b70daef776b169e3b2cdfc8f5dcf605475067ac8b0
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/components/clair/upgrade.deployment.patch.yaml
+++ b/kustomize/components/clair/upgrade.deployment.patch.yaml
@@ -11,7 +11,7 @@ spec:
       # Init conatainer needed to wait for Clair to initialize (can take minutes) before attempting to validate config.
       initContainers:
         - name: quay-app-upgrade-init
-          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          image: quay.io/projectquay/quay@sha256:a544ee36a20cb24d02a5f7b70daef776b169e3b2cdfc8f5dcf605475067ac8b0
           command:
             - /bin/sh
             - -c

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -30,7 +30,7 @@ spec:
                       path: quay-ssl.cert
       initContainers:
         - name: quay-mirror-init
-          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          image: quay.io/projectquay/quay@sha256:a544ee36a20cb24d02a5f7b70daef776b169e3b2cdfc8f5dcf605475067ac8b0
           command:
             - /bin/sh
             - -c
@@ -40,7 +40,7 @@ spec:
               value: $(QUAY_APP_SERVICE_HOST)
       containers:
         - name: quay-mirror
-          image: quay.io/projectquay/quay@sha256:acd4fa1d6c4045020c8b5483a4de5741692240e7137b6cb4a12bdadffe8bdfac
+          image: quay.io/projectquay/quay@sha256:a544ee36a20cb24d02a5f7b70daef776b169e3b2cdfc8f5dcf605475067ac8b0
           command: ["/quay-registry/quay-entrypoint.sh"]
           args: ["repomirror-nomigrate"]
           env:

--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -122,15 +122,20 @@ func createUpdatedSecret(reconfigureRequest request) corev1.Secret {
 	if len(reconfigureRequest.Namespace) == 0 {
 		panic("namespace not provided")
 	}
+
 	if len(reconfigureRequest.QuayRegistryName) == 0 {
 		panic("quayRegistryName not provided")
 	}
 
 	secretData["config.yaml"] = encode(reconfigureRequest.Config)
 	for fullFilePathname, encodedCert := range reconfigureRequest.Certs {
-		log.Println("including cert in secret: " + fullFilePathname)
 		certName := strings.Split(fullFilePathname, "/")[len(strings.Split(fullFilePathname, "/"))-1]
-		secretData["extra_ca_cert_"+strings.ReplaceAll(certName, "extra_ca_cert_", "")] = encodedCert
+		if strings.HasPrefix(fullFilePathname, "extra_ca_certs/") {
+			certName = "extra_ca_cert_" + strings.ReplaceAll(certName, "extra_ca_cert_", "")
+		}
+		secretData[certName] = encodedCert
+
+		log.Println("including cert in secret: " + certName)
 	}
 
 	newSecret := corev1.Secret{


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1306

**Changelog:** Only add `extra_ca_cert_` prefix to actual extra CA certificates when creating new `configBundleSecret`.

**Docs:** N/a

**Testing:** N/a

**Details:** We were previously adding the `extra_ca_cert_` prefix to all certificates received by the `certs` payload to the `/reconfigure` endpoint. This is incorrect, as some files are used for other purposes (like `cloudfront-signing-key.pem`) and are referenced by filename in `config.yaml`. Changing the name of this file breaks Quay when it tries to open the file.
