### PR TITLE
Change Operator Deployment Name (PROJQUAY-1381)

### DIFF
--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ spec:
   install:
     spec:
       deployments:
-      - name: quay-operator
+      - name: quay-operator-tng
         spec:
           replicas: 1
           selector:

--- a/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/3.4.0/quay-operator.clusterserviceversion.yaml
@@ -107,7 +107,7 @@ spec:
   install:
     spec:
       deployments:
-      - name: quay-operator
+      - name: quay-operator.v3.4.0
         spec:
           replicas: 1
           selector:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1381

**Changelog:** Change Operator's `Deployment` name to fix upgrade path.

**Docs:** N/a

**Testing:** N/a

**Details:** Follows the [OLM recommendation to fix upgrade issue](https://github.com/operator-framework/olm-book/pull/31/files) where OLM tries to `PATCH` the existing `Deployment` (because it has the same name) and runs into "immutable field" error.
