### PR TITLE
Refactor QuayRegistry E2E Tests

### DIFF
--- a/controllers/quay/suite_test.go
+++ b/controllers/quay/suite_test.go
@@ -43,20 +43,29 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var testLogger logr.Logger
-var testEventRecorder record.EventRecorder
+
+// var testEventRecorder record.EventRecorder
+var testEventRecorder *record.FakeRecorder
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"QuayRegistry Controller Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
 
 var _ = BeforeSuite(func(done Done) {
 	testLogger = zap.LoggerTo(GinkgoWriter, true)
 	logf.SetLogger(testLogger)
-	testEventRecorder = record.NewFakeRecorder(10)
+	testEventRecorder = record.NewFakeRecorder(100)
+
+	go func() {
+		for {
+			evt := <-testEventRecorder.Events
+			testLogger.Info(evt)
+		}
+	}()
 
 	By("bootstrapping test environment")
 	// useExistingCluster := true

--- a/controllers/redhatcop/suite_test.go
+++ b/controllers/redhatcop/suite_test.go
@@ -48,7 +48,7 @@ func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"QuayEcosystem Controller Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
 

--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
-    containerImage: quay.io/projectquay/quay-operator@sha256:e3de5957b264b231fd74cda133333c5834fd0ac61af09ff54761c81a3df71f37
+    containerImage: quay.io/projectquay/quay-operator@sha256:3a3b8474985b253940be7c1ab65fa5cacd10b298d258d7d35e1b2ae50bc60dce
     createdAt: 2020-08-24 00:00:00
     description: Opinionated deployment of Quay on Kubernetes.
     repository: https://github.com/quay/quay-operator
@@ -120,7 +120,7 @@ spec:
             spec:
               containers:
               - name: quay-operator
-                image: quay.io/projectquay/quay-operator@sha256:e3de5957b264b231fd74cda133333c5834fd0ac61af09ff54761c81a3df71f37
+                image: quay.io/projectquay/quay-operator@sha256:3a3b8474985b253940be7c1ab65fa5cacd10b298d258d7d35e1b2ae50bc60dce
                 command:
                 - /workspace/manager
                 - '--namespace=$(WATCH_NAMESPACE)'

--- a/deploy/quay-operator.catalogsource.yaml
+++ b/deploy/quay-operator.catalogsource.yaml
@@ -4,4 +4,4 @@ metadata:
   name: quay-operator
 spec:
   sourceType: grpc
-  image: quay.io/projectquay/quay-operator-catalog@sha256:1d8ba69656d23530c22af09b8058c152e1ed0e7d38140072380a7aba7fd4bce3
+  image: quay.io/projectquay/quay-operator-catalog@sha256:a32ebc1d422c5285dacd9e97f2216be4a9aa8f06d20034909e4dba7f4b136004

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -380,16 +380,17 @@ func componentConfigFilesFor(component string, quay *v1.QuayRegistry, configFile
 			"database-root-password": []byte(databaseRootPassword),
 		}, nil
 	case "clair":
-		var quayHostname string
-		for _, component := range quay.Spec.Components {
-			if component.Kind == "route" && component.Managed {
-				config := decode(configFiles["route.config.yaml"])
-				quayHostname = config.(map[string]interface{})["SERVER_HOSTNAME"].(string)
-			}
+		quayHostname := ""
+		if v1.ComponentIsManaged(quay.Spec.Components, "route") {
+			config := decode(configFiles["route.config.yaml"])
+			quayHostname = config.(map[string]interface{})["SERVER_HOSTNAME"].(string)
 		}
+
 		if _, ok := configFiles["config.yaml"]; ok && quayHostname == "" {
 			config := decode(configFiles["config.yaml"])
-			quayHostname = config.(map[string]interface{})["SERVER_HOSTNAME"].(string)
+			if configHostname, ok := config.(map[string]interface{})["SERVER_HOSTNAME"].(string); ok && configHostname != "" {
+				quayHostname = configHostname
+			}
 		}
 
 		if quayHostname == "" {


### PR DESCRIPTION
Improved readability and functionality of the `QuayRegistry` controller e2e tests, and re-enabled them.