### PR TITLE
Fix Panic During QuayEcosystem Database Migration (PROJQUAY-1395)

### DIFF
--- a/controllers/redhatcop/quayecosystem_controller.go
+++ b/controllers/redhatcop/quayecosystem_controller.go
@@ -476,7 +476,7 @@ func (r *QuayEcosystemReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 			}
 
 			for _, migrationPod := range migrationPods.Items {
-				if !migrationPod.Status.InitContainerStatuses[0].Ready {
+				if len(migrationPod.Status.InitContainerStatuses) == 0 || !migrationPod.Status.InitContainerStatuses[0].Ready {
 					log.Info("database migration pod in progress")
 
 					return false, nil


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1395

**Changelog:** Fix panic during `QuayEcosystem` database migration.

**Docs:** N/a

**Testing:** N/a

**Details:** Fixes panic by checking the length of `InitContainerStatusus` first.