### PR TITLE
Expose Build Manager gRPC Port (PROJQUAY-1424)

### DIFF
--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -138,7 +138,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_COMPONENT_QUAY
-                  value: quay.io/projectquay/quay@sha256:8687bb4d2279f1747725f15318bb86a20b8ee131e2ca49d49f5dbe2d03d14cd2
+                  value: quay.io/projectquay/quay@sha256:3c8b7755732b93786ba738fd0d0831a4aea73837e05cc26bbdff19f84e9ed58d
                 - name: RELATED_IMAGE_COMPONENT_CLAIR
                   value: quay.io/projectquay/clair@sha256:5fec3cf459159eabe2e4e1089687e25f638183a7e9bed1ecea8724e0597f8a14
                 - name: RELATED_IMAGE_COMPONENT_POSTGRES

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-config-editor
-          image: quay.io/projectquay/quay@sha256:8687bb4d2279f1747725f15318bb86a20b8ee131e2ca49d49f5dbe2d03d14cd2
+          image: quay.io/projectquay/quay@sha256:3c8b7755732b93786ba738fd0d0831a4aea73837e05cc26bbdff19f84e9ed58d
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app
-          image: quay.io/projectquay/quay@sha256:8687bb4d2279f1747725f15318bb86a20b8ee131e2ca49d49f5dbe2d03d14cd2
+          image: quay.io/projectquay/quay@sha256:3c8b7755732b93786ba738fd0d0831a4aea73837e05cc26bbdff19f84e9ed58d
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/base/quay.service.yaml
+++ b/kustomize/base/quay.service.yaml
@@ -19,5 +19,9 @@ spec:
       protocol: TCP
       port: 8081
       targetPort: 8081
+    - name: grpc
+      protocol: TCP
+      port: 55443
+      targetPort: 55443
   selector:
     quay-component: quay-app

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -25,7 +25,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app-upgrade
-          image: quay.io/projectquay/quay@sha256:8687bb4d2279f1747725f15318bb86a20b8ee131e2ca49d49f5dbe2d03d14cd2
+          image: quay.io/projectquay/quay@sha256:3c8b7755732b93786ba738fd0d0831a4aea73837e05cc26bbdff19f84e9ed58d
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME(alecmerdler): Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/components/clair/upgrade.deployment.patch.yaml
+++ b/kustomize/components/clair/upgrade.deployment.patch.yaml
@@ -11,7 +11,7 @@ spec:
       # Init conatainer needed to wait for Clair to initialize (can take minutes) before attempting to validate config.
       initContainers:
         - name: quay-app-upgrade-init
-          image: quay.io/projectquay/quay@sha256:8687bb4d2279f1747725f15318bb86a20b8ee131e2ca49d49f5dbe2d03d14cd2
+          image: quay.io/projectquay/quay@sha256:3c8b7755732b93786ba738fd0d0831a4aea73837e05cc26bbdff19f84e9ed58d
           command:
             - /bin/sh
             - -c

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -32,7 +32,7 @@ spec:
                       path: quay-ssl.cert
       initContainers:
         - name: quay-mirror-init
-          image: quay.io/projectquay/quay@sha256:8687bb4d2279f1747725f15318bb86a20b8ee131e2ca49d49f5dbe2d03d14cd2
+          image: quay.io/projectquay/quay@sha256:3c8b7755732b93786ba738fd0d0831a4aea73837e05cc26bbdff19f84e9ed58d
           command:
             - /bin/sh
             - -c
@@ -42,7 +42,7 @@ spec:
               value: $(QUAY_APP_SERVICE_HOST)
       containers:
         - name: quay-mirror
-          image: quay.io/projectquay/quay@sha256:8687bb4d2279f1747725f15318bb86a20b8ee131e2ca49d49f5dbe2d03d14cd2
+          image: quay.io/projectquay/quay@sha256:3c8b7755732b93786ba738fd0d0831a4aea73837e05cc26bbdff19f84e9ed58d
           command: ["/quay-registry/quay-entrypoint.sh"]
           args: ["repomirror-nomigrate"]
           env:

--- a/kustomize/components/route/builder.route.yaml
+++ b/kustomize/components/route/builder.route.yaml
@@ -1,0 +1,14 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: quay-builder
+spec:
+  host: $(BUILDMAN_HOSTNAME)
+  to:
+    kind: Service
+    name: quay-app
+  port:
+    targetPort: grpc
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect

--- a/kustomize/components/route/kustomization.yaml
+++ b/kustomize/components/route/kustomization.yaml
@@ -6,6 +6,7 @@ crds:
 resources: 
   - ./quay.route.yaml
   - ./config.route.yaml
+  - ./builder.route.yaml
 patchesStrategicMerge:
   # Switch `Service` to `type: ClusterIP`
   - ./quay.service.patch.yaml
@@ -21,3 +22,10 @@ vars:
       name: quay-app
     fieldref:
       fieldpath: metadata.annotations["quay-registry-hostname"]
+  - name: BUILDMAN_HOSTNAME
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: quay-app
+    fieldref:
+      fieldpath: metadata.annotations["quay-buildmanager-hostname"]

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -34,6 +34,7 @@ import (
 const (
 	configSecretPrefix         = "quay-config-secret"
 	registryHostnameKey        = "quay-registry-hostname"
+	buildManagerHostnameKey    = "quay-buildmanager-hostname"
 	managedFieldGroupsKey      = "quay-managed-fieldgroups"
 	operatorServiceEndpointKey = "quay-operator-service-endpoint"
 	quayRegistryNameKey        = "quay-operator/quayregistry"
@@ -230,7 +231,7 @@ func KustomizationFor(quay *v1.QuayRegistry, quayConfigFiles map[string][]byte) 
 
 	configFiles := []string{}
 	for key := range quayConfigFiles {
-		if key != registryHostnameKey {
+		if key != registryHostnameKey && key != buildManagerHostnameKey {
 			configFiles = append(configFiles, filepath.Join("bundle", key))
 		}
 	}
@@ -315,6 +316,7 @@ func KustomizationFor(quay *v1.QuayRegistry, quayConfigFiles map[string][]byte) 
 		CommonAnnotations: map[string]string{
 			managedFieldGroupsKey:      strings.ReplaceAll(strings.Join(managedFieldGroups, ","), ",,", ","),
 			registryHostnameKey:        string(quayConfigFiles[registryHostnameKey]),
+			buildManagerHostnameKey:    string(quayConfigFiles[buildManagerHostnameKey]),
 			operatorServiceEndpointKey: operatorServiceEndpoint(),
 		},
 		// NOTE: Using `vars` in Kustomize is kinda ugly because it's basically templating, so don't abuse them


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1424

**Changelog:** Exposes the gRPC port on the Quay app `Service` for the build manager.

**Docs:** https://github.com/quay/quay-docs/pull/117

**Testing:** See docs.

**Details:** The gRPC port needs to be exposed for users to manually hook up the build manager. This will become a fully managed component in the future.