### PR TITLE
Fix Build Manager TLS Creation (PROJQUAY-1542)

### DIFF
--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -254,7 +254,7 @@ func CustomTLSFor(quay *v1.QuayRegistry, baseConfig map[string]interface{}) ([]b
 			svc,
 			strings.Join([]string{svc, quay.GetNamespace(), "svc"}, "."),
 			strings.Join([]string{svc, quay.GetNamespace(), "svc", "cluster", "local"}, "."),
-			buildManagerHostname,
+			strings.Split(buildManagerHostname, ":")[0],
 		},
 	)
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1542

**Changelog:** Fix TLS cert generation for buildmanager.

**Docs:** N/a

**Testing:** N/a

**Details:** Omit the port when generating TLS cert/key pair which includes `BUILDMAN_HOSTNAME` as a Subject Alternative Name.