### PR TITLE
Fix Managed Postgres Race Condition During Init (PROJQUAY-1575)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	SupportsRoutesAnnotation  = "quay.redhat.com/supports-routes"
-	ClusterHostnameAnnotation = "quay.redhat.com/router-canonical-hostname"
-
+	SupportsRoutesAnnotation           = "quay.redhat.com/supports-routes"
+	ClusterHostnameAnnotation          = "quay.redhat.com/router-canonical-hostname"
 	SupportsObjectStorageAnnotation    = "quay.redhat.com/supports-object-storage"
 	ObjectStorageInitializedAnnotation = "quay.redhat.com/object-storage-initialized"
 	StorageHostnameAnnotation          = "quay.redhat.com/storage-hostname"

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	upgradePollInterval  = time.Second * 10
-	upgradePollTimeout   = time.Second * 600
+	upgradePollTimeout   = time.Second * 6000
 	creationPollInterval = time.Second * 1
 	creationPollTimeout  = time.Second * 600
 )
@@ -376,7 +376,9 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(ctx context.Context, obj k
 
 	if immutableResources[groupVersionKind] {
 		log.Info("(re)creating immutable resource")
-		if err := r.Client.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) && !errors.IsAlreadyExists(err) {
+
+		propagationPolicy := metav1.DeletePropagationForeground
+		if err := r.Client.Delete(ctx, obj, &client.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil && !errors.IsNotFound(err) && !errors.IsAlreadyExists(err) {
 			log.Error(err, "failed to delete immutable resource")
 
 			return err

--- a/kustomize/components/postgres/create-extensions.sh
+++ b/kustomize/components/postgres/create-extensions.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-echo "attempting to create pg_trgm extension"
-psql -d $POSTGRESQL_DATABASE -h $POSTGRESQL_DATABASE -U postgres -c 'CREATE EXTENSION pg_trgm;' || true
+echo "attempting to create pg_trgm extension if it does not exist"
+
+until psql -d $POSTGRESQL_DATABASE -h $POSTGRESQL_DATABASE -U postgres -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+do
+  echo "..."
+  sleep 1
+done
+
 echo "succesfully created pg_trgm extension"
-break

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -27,7 +27,6 @@ spec:
           ports:
             - containerPort: 5432
               protocol: TCP
-          # TODO(alecmerdler): Readiness/liveliness probes which execute `psql` command to check if database is created.
           env:
             - name: POSTGRESQL_USER
               valueFrom:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1575

**Changelog:** Fix race condition with managed Postgres init.

**Docs:** N/a

**Testing:** N/a

**Details:** Fixes a potential race condition where the `Job` which creates the `pg_trgm` extension never succeeds because the managed Postgres pod is not ready. Also adds `propagationPolicy: Foreground` to the `DeleteOptions` when re-creating the `Job` so that the old `Pods` are garbage collected.
