### PR TITLE
Fix Buildmanager `Route` Blocking Unmanaged Components

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -66,7 +66,7 @@ func (r *QuayRegistryReconciler) checkRoutesAvailable(quay *v1.QuayRegistry) (*v
 
 		return quay, err
 	} else {
-		r.Log.Info("cluster does not support `Route` API")
+		r.Log.Info("cluster does not support `Route` API", "error", err)
 	}
 
 	return quay, nil

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -246,8 +246,8 @@ func (r *QuayRegistryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		}
 	}
 
-	updatedQuay.Status.ConfigEditorCredentialsSecret = configEditorCredentialsSecretFrom(deploymentObjects)
 	updatedQuay, _ = v1.EnsureConfigEditorEndpoint(updatedQuay)
+	updatedQuay.Status.ConfigEditorCredentialsSecret = configEditorCredentialsSecretFrom(deploymentObjects)
 
 	if c := v1.GetCondition(updatedQuay.Status.Conditions, v1.ConditionTypeRolloutBlocked); c != nil && c.Status == metav1.ConditionTrue && c.Reason == v1.ConditionReasonConfigInvalid {
 		return r.reconcileWithCondition(updatedQuay, v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue, v1.ConditionReasonConfigInvalid, c.Message)
@@ -295,7 +295,7 @@ func (r *QuayRegistryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 				if upgradeDeployment.Status.ReadyReplicas > 0 {
 					log.Info("Quay upgrade complete, updating `status.currentVersion`")
 
-					updatedQuay, _ := v1.EnsureRegistryEndpoint(updatedQuay)
+					updatedQuay, _ := v1.EnsureRegistryEndpoint(updatedQuay, userProvidedConfig)
 					msg := "all registry component healthchecks passing"
 					condition := v1.Condition{
 						Type:               v1.ConditionTypeAvailable,


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1574

**Changelog:** Fix creating a `QuayRegistry` with unmanaged components being blocked by buildmanager `Route` error.

**Docs:** N/a

**Testing:** Create `QuayRegistry` with unmanaged `objectstorage` (or some other component besides `route`). Ensure that `status.conditions` does not contain something similar to the following message:
```
all Kubernetes objects not created/updated successfully: Route.route.openshift.io "quay-quay-builder" is invalid: spec.host: Invalid value: "quay-quay-builder-quay-registry.": host must conform to DNS 952 subdomain conventions
```

**Details:** When a component is marked as unmanaged but the `spec.configBundleSecret` is missing the required fields, the controller will update the `QuayRegistry` with that condition in-place, and continue the control loop. The cluster hostname annotation is stripped out when the `QuayRegistry` is updated, so future code is unable to fully construct the builder's hostname and pass it as a variable to the `Route`. This doesn't affect the Quay app `Route` because it just leaves it blank if `SERVER_HOSTNAME` is not present in the config. 

This pull request changes `BUILDMAN_HOSTNAME` to be treated the same way as `SERVER_HOSTNAME`, and just left blank if not provided. This is fine because the docs indicate that you are required to provide the `BUILDMAN_HOSTNAME` if you are using the `route` managed component.

**Screenshots:**

Fully managed Quay + generated certificate with `BUILDMAN_HOSTNAME`
![Screenshot_20210209_192414](https://user-images.githubusercontent.com/11700385/107460124-613b7c00-6b0c-11eb-920c-d054d5e07f33.png)

Fully managed Quay + generated certificate with `SERVER_HOSTNAME` (DNS record manually created)
![Screenshot_20210209_194146](https://user-images.githubusercontent.com/11700385/107461447-d8720f80-6b0e-11eb-90d3-74436dc832ee.png)



