### PR TITLE
PROJQUAY-1434 add OCP infra node tolerations

### DIFF
--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         quay-component: quay-config-editor
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       volumes:
         - name: config-bundle
           secret:

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         quay-component: quay-app
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       volumes:
         - name: configvolume
           secret:

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         quay-component: quay-app-upgrade
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       volumes:
         - name: configvolume
           secret:

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         quay-component: clair-app
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       containers:
         - image: quay.io/projectquay/clair@sha256:5fec3cf459159eabe2e4e1089687e25f638183a7e9bed1ecea8724e0597f8a14
           imagePullPolicy: IfNotPresent

--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         quay-component: clair-postgres
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       volumes:
         - name: postgres-data
           persistentVolumeClaim:

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         quay-component: quay-mirror
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       volumes:
         - name: configvolume
           secret:

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         quay-component: postgres
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       volumes:
         - name: postgres-data
           persistentVolumeClaim:

--- a/kustomize/components/redis/redis.deployment.yaml
+++ b/kustomize/components/redis/redis.deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         quay-component: redis
     spec:
+      tolerations:
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
       containers:
         - name: redis-master
           image: centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1434

**Changelog:** 

adds the required tolerations for Quay to be schedulable on OCP Infra nodes as per https://docs.openshift.com/container-platform/4.6/machine_management/creating-infrastructure-machinesets.html#assigning-machineset-resources-to-infra-nodes

**Docs:** 

tbd

**Testing:** 

tbd

**Details:** 

https://issues.redhat.com/browse/PROJQUAY-1566
