### PR TITLE
use DeepCopy on baseConfigBundle to ensure certs are preserved

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -390,7 +390,7 @@ func flattenSecret(configBundle *corev1.Secret) (*corev1.Secret, error) {
 func Inflate(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, baseConfigBundle *corev1.Secret, log logr.Logger) ([]k8sruntime.Object, error) {
 	// Each managed component brings its own generated `config.yaml` fields
 	// which are accumulated under the key `<component>.config.yaml` and then added to the base `Secret`.
-	componentConfigFiles := map[string][]byte{}
+	componentConfigFiles := baseConfigBundle.DeepCopy().Data
 
 	var parsedUserConfig map[string]interface{}
 	if err := yaml.Unmarshal(baseConfigBundle.Data["config.yaml"], &parsedUserConfig); err != nil {


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1659

**Changelog:** 
- Operator will take a deep copy of the config bundle to ensure that other files included in the `baseConfigBundle` are preserved during reconciliation. 

**Docs:** 

**Testing:** 
- Reconfigured Quay with additional certs included (`database.pem` for AWS MySQL). Ensured that `database.pem` is included in the new quay-config-secret.
- Quay works with unmanaged MySQL after reconfiguration (`database.pem` is loaded from secret correctly).]

**Details:** 

------
