### PR TITLE
Remove Need for SANs in Provided Cert/Key Pair

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -61,6 +61,7 @@ var allComponents = []ComponentKind{
 var requiredComponents = []ComponentKind{
 	ComponentPostgres,
 	ComponentObjectStorage,
+	ComponentRoute,
 }
 
 // QuayRegistrySpec defines the desired state of QuayRegistry.

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -233,7 +233,7 @@ func (r *QuayRegistryReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	updatedQuay.Status.Conditions = v1.RemoveCondition(updatedQuay.Status.Conditions, v1.ConditionTypeRolloutBlocked)
 
 	for _, component := range updatedQuay.Spec.Components {
-		contains, err := kustomize.ContainsComponentConfig(userProvidedConfig, component.Kind)
+		contains, err := kustomize.ContainsComponentConfig(userProvidedConfig, component)
 		if err != nil {
 			updatedQuay, err = r.updateWithCondition(&quay, v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue, v1.ConditionReasonConfigInvalid, err.Error())
 			if err != nil {
@@ -463,6 +463,7 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(ctx context.Context, obj k
 
 	immutableResources := map[string]bool{
 		schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}.String(): true,
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}.String():  true,
 	}
 
 	log := r.Log.WithValues(

--- a/kustomize/base/quay.service.yaml
+++ b/kustomize/base/quay.service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     quay-component: quay-app
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - protocol: TCP
       name: https

--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -74,7 +74,7 @@ func ReconfigureHandler(k8sClient client.Client) func(w http.ResponseWriter, r *
 		// Infer managed/unmanaged components from the given `config.yaml`.
 		newComponents := []v1.Component{}
 		for _, component := range quay.Spec.Components {
-			contains, err := kustomize.ContainsComponentConfig(reconfigureRequest.Config, component.Kind)
+			contains, err := kustomize.ContainsComponentConfig(reconfigureRequest.Config, component)
 
 			if err != nil {
 				log.Error(err, "failed to check `config.yaml` for component fieldgroup", "component", component.Kind)

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -1,9 +1,8 @@
 package kustomize
 
 import (
-	"net"
+	"fmt"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -192,6 +191,7 @@ func TestFieldGroupFor(t *testing.T) {
 var containsComponentConfigTests = []struct {
 	name          string
 	component     v1.ComponentKind
+	managed       bool
 	rawConfig     string
 	expected      bool
 	expectedError error
@@ -199,6 +199,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"ClairContains",
 		"clair",
+		true,
 		`FEATURE_SECURITY_SCANNER: true`,
 		true,
 		nil,
@@ -206,6 +207,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"ClairDoesNotContain",
 		"clair",
+		true,
 		``,
 		false,
 		nil,
@@ -213,6 +215,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"PostgresContains",
 		"postgres",
+		true,
 		`DB_URI: postgresql://test-quay-database:postgres@test-quay-database:5432/test-quay-database`,
 		true,
 		nil,
@@ -220,6 +223,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"PostgresDoesNotContain",
 		"postgres",
+		true,
 		``,
 		false,
 		nil,
@@ -227,6 +231,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"RedisContains",
 		"redis",
+		true,
 		`BUILDLOGS_REDIS:
   host: test-quay-redis
 `,
@@ -236,6 +241,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"RedisDoesNotContain",
 		"redis",
+		true,
 		``,
 		false,
 		nil,
@@ -243,6 +249,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"ObjectStorageContains",
 		"objectstorage",
+		true,
 		`DISTRIBUTED_STORAGE_PREFERENCE: 
   - local_us
 `,
@@ -252,6 +259,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"ObjectStorageDoesNotContain",
 		"objectstorage",
+		true,
 		``,
 		false,
 		nil,
@@ -259,6 +267,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"MirrorContains",
 		"mirror",
+		true,
 		`FEATURE_REPO_MIRROR: true`,
 		true,
 		nil,
@@ -266,6 +275,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"MirrorDeosNotContain",
 		"mirror",
+		true,
 		``,
 		false,
 		nil,
@@ -273,6 +283,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"RouteContains",
 		"route",
+		true,
 		`PREFERRED_URL_SCHEME: http`,
 		true,
 		nil,
@@ -280,6 +291,7 @@ var containsComponentConfigTests = []struct {
 	{
 		"RouteContainsServerHostname",
 		"route",
+		true,
 		`SERVER_HOSTNAME: registry.skynet.com`,
 		false,
 		nil,
@@ -287,13 +299,31 @@ var containsComponentConfigTests = []struct {
 	{
 		"RouteDoesNotContain",
 		"route",
+		true,
 		``,
 		false,
 		nil,
 	},
 	{
+		"RouteUnmanagedDoesNotContain",
+		"route",
+		false,
+		``,
+		false,
+		nil,
+	},
+	{
+		"RouteUnmanagedContainsServerHostname",
+		"route",
+		false,
+		`SERVER_HOSTNAME: registry.skynet.com`,
+		true,
+		nil,
+	},
+	{
 		"HorizontalPodAutoscalerDoesNotContain",
 		"horizontalpodautoscaler",
+		true,
 		``,
 		false,
 		nil,
@@ -308,7 +338,7 @@ func TestContainsComponentConfig(t *testing.T) {
 		err := yaml.Unmarshal([]byte(test.rawConfig), &fullConfig)
 		assert.Nil(err, test.name)
 
-		contains, err := ContainsComponentConfig(fullConfig, test.component)
+		contains, err := ContainsComponentConfig(fullConfig, v1.Component{Kind: test.component, Managed: test.managed})
 
 		if test.expectedError != nil {
 			assert.NotNil(err, test.name)
@@ -319,94 +349,107 @@ func TestContainsComponentConfig(t *testing.T) {
 	}
 }
 
+func certKeyPairFor(hostname string, alternateHostnames []string) [][]byte {
+	cert, key, err := cert.GenerateSelfSignedCertKey(hostname, nil, alternateHostnames)
+	if err != nil {
+		panic(err)
+	}
+
+	return [][]byte{cert, key}
+}
+
+var ensureTLSForTests = []struct {
+	name                 string
+	routeManaged         bool
+	serverHostname       string
+	buildManagerHostname string
+	providedCertKeyPair  [][]byte
+	expectedErr          error
+}{
+	{
+		"ManagedRouteNoHostnameNoCerts",
+		true,
+		"",
+		"",
+		[][]byte{nil, nil},
+		nil,
+	},
+	{
+		"ManagedRouteProvidedHostnameProvidedIncorrectCerts",
+		true,
+		"registry.company.com",
+		"",
+		certKeyPairFor("nonexistent.company.com", nil),
+		fmt.Errorf("provided certificate/key pair not valid for host 'registry.company.com': x509: certificate is valid for nonexistent.company.com, not registry.company.com"),
+	},
+	{
+		"ManagedRouteProvidedHostnameNoCerts",
+		true,
+		"registry.company.com",
+		"",
+		[][]byte{nil, nil},
+		nil,
+	},
+	{
+		"ManagedRouteProvidedHostnameProvidedCerts",
+		true,
+		"registry.company.com",
+		"",
+		certKeyPairFor("registry.company.com", nil),
+		nil,
+	},
+	{
+		"ManagedRouteProvidedBuildmanagerHostnameProvidedIncorrectCerts",
+		true,
+		"registry.company.com",
+		"builds.company.com",
+		certKeyPairFor("registry.company.com", nil),
+		fmt.Errorf("provided certificate/key pair not valid for host 'builds.company.com': x509: certificate is valid for registry.company.com, not builds.company.com"),
+	},
+	{
+		"ManagedRouteProvidedBuildmanagerHostnameProvidedCerts",
+		true,
+		"registry.company.com",
+		"builds.company.com",
+		certKeyPairFor("registry.company.com", []string{"builds.company.com"}),
+		nil,
+	},
+	{
+		"ManagedRouteProvidedBuildmanagerHostnameNoCerts",
+		true,
+		"registry.company.com",
+		"builds.company.com",
+		[][]byte{nil, nil},
+		nil,
+	},
+}
+
 func TestEnsureTLSFor(t *testing.T) {
+	assert := assert.New(t)
 
-	emptyCert := []byte{}
-	serverHostname := "serverhostname.com"
-	builderHostname := "builderhostname.com"
-	quayRegistry := quayRegistry("test")
+	for _, test := range ensureTLSForTests {
+		quayRegistry := quayRegistry("test")
 
-	quayContextWithoutBuilder := &quaycontext.QuayRegistryContext{
-		ServerHostname: serverHostname,
-	}
-	quayContextWithBuilder := &quaycontext.QuayRegistryContext{
-		BuildManagerHostname: builderHostname,
-		ServerHostname:       serverHostname,
-	}
-
-	svc := quayRegistry.GetName() + "-quay-app"
-	hostsWithoutBuilder := []string{
-		serverHostname,
-		svc,
-		strings.Join([]string{svc, quayRegistry.GetNamespace(), "svc"}, "."),
-		strings.Join([]string{svc, quayRegistry.GetNamespace(), "svc", "cluster", "local"}, "."),
-	}
-	// Generate certs without builder hostname in SAN
-	pubWithoutBuilder, privWithoutBuilder, err := cert.GenerateSelfSignedCertKey(serverHostname, []net.IP{}, hostsWithoutBuilder)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	// Generate certs with builder hostname in SAN
-	hostsWithBuilder := append(hostsWithoutBuilder, builderHostname)
-	pubWithBuilder, privWithBuilder, err := cert.GenerateSelfSignedCertKey(serverHostname, []net.IP{}, hostsWithBuilder)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	t.Run("Quay context has buildman hostname. Certs are empty, Operator should generate own.", func(t *testing.T) {
-		assert := assert.New(t)
-		// Empty certs, should generate own
-		recPublicKey, recPrivateKey, err := EnsureTLSFor(quayContextWithBuilder, quayRegistry, emptyCert, emptyCert)
-		if err != nil {
-			t.Errorf(err.Error())
+		quayContext := quaycontext.QuayRegistryContext{
+			ServerHostname:       test.serverHostname,
+			BuildManagerHostname: test.buildManagerHostname,
 		}
-		assert.NotEqual(recPublicKey, emptyCert)
-		assert.NotEqual(recPrivateKey, emptyCert)
-	})
 
-	t.Run("Quay context has buildman hostname. Certs do not contain buildman hostname. Operator should generate own.", func(t *testing.T) {
-		assert := assert.New(t)
-		// Buildman missing from certs, should generate own
-		recPublicKey, recPrivateKey, err := EnsureTLSFor(quayContextWithBuilder, quayRegistry, pubWithoutBuilder, privWithoutBuilder)
-		if err != nil {
-			t.Errorf(err.Error())
+		tlsCert, tlsKey, err := EnsureTLSFor(&quayContext, quayRegistry, test.providedCertKeyPair[0], test.providedCertKeyPair[1])
+
+		assert.Equal(test.expectedErr, err, test.name)
+
+		if test.expectedErr == nil {
+			if test.providedCertKeyPair[0] != nil && test.providedCertKeyPair[1] != nil {
+				assert.Equal(string(test.providedCertKeyPair[0]), string(tlsCert), test.name)
+				assert.Equal(string(test.providedCertKeyPair[1]), string(tlsKey), test.name)
+			}
+
+			shared.ValidateCertPairWithHostname(tlsCert, tlsKey, test.serverHostname, fieldGroupNameFor("route"))
+
+			if test.buildManagerHostname != "" {
+				shared.ValidateCertPairWithHostname(tlsCert, tlsKey, test.buildManagerHostname, fieldGroupNameFor("route"))
+			}
 		}
-		assert.NotEqual(recPublicKey, pubWithoutBuilder)
-		assert.NotEqual(recPrivateKey, privWithoutBuilder)
-	})
-
-	t.Run("Quay context has buildman hostname. Certs contain buildman hostname. Operator should not generate own.", func(t *testing.T) {
-		assert := assert.New(t)
-		// Buildman present in certs, should not generate
-		recPublicKey, recPrivateKey, err := EnsureTLSFor(quayContextWithBuilder, quayRegistry, pubWithBuilder, privWithBuilder)
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-		assert.Equal(recPublicKey, pubWithBuilder)
-		assert.Equal(recPrivateKey, privWithBuilder)
-	})
-
-	t.Run("Quay context does not have buildman hostname. Certs do not contain buildman hostname. Operator should not generate own.", func(t *testing.T) {
-		assert := assert.New(t)
-		// Buildman not in certs, not in context, should not generate
-		recPublicKey, recPrivateKey, err := EnsureTLSFor(quayContextWithoutBuilder, quayRegistry, pubWithoutBuilder, privWithoutBuilder)
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-		assert.Equal(recPublicKey, pubWithoutBuilder)
-		assert.Equal(recPrivateKey, privWithoutBuilder)
-	})
-
-	t.Run("Quay context does not have buildman hostname. Certs contain buildman hostname. Operator should not generate own.", func(t *testing.T) {
-		assert := assert.New(t)
-		// Buildman not in certs, not in context, should not generate
-		recPublicKey, recPrivateKey, err := EnsureTLSFor(quayContextWithoutBuilder, quayRegistry, pubWithBuilder, privWithBuilder)
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-		assert.Equal(recPublicKey, pubWithBuilder)
-		assert.Equal(recPrivateKey, privWithBuilder)
-	})
-
+	}
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1737

**Changelog:** Remove the need for SANs of internal k8s service hosts in provided cert/key pair for Quay.

**Docs:** https://github.com/quay/quay-docs/pull/157

**Testing:** There are a few different situations which must be tested:

`Route` | `SERVER_HOSTNAME` | Custom cert/key pair | Expected result
|---|---|---|---|
| Managed | None | None | Uses generated `Route` hostname, self-signed certs |
| Managed | None | Provided (for generated `Route` hostname) | Uses generated `Route` hostname and provided certs |
| Managed | None | Provided (for random hostname) | Blocked rollout, error in `status.conditions` |
| Managed | `registry.company.com` | Provided (invalid) | Blocked rollout, error in `status.conditions` |
| Managed | `registry.company.com` | None | Uses provided hostname and self-signed certs |
| Managed | `registry.company.com` | Provided (valid) | Uses provided hostname and certs |
| Unmanaged | None | None | Error because `SERVER_HOSTNAME` is unset |
| Unmanaged | None | Provided (for random hostname) | Error because `SERVER_HOSTNAME` is unset |
| Unmanaged | `registry.company.com` | None | Uses provided hostname and self-signed certs |
| Unmanaged | `registry.company.com` | Provided (invalid) | Blocked rollout, error in `status.conditions` |
| Unmanaged | `registry.company.com` | Provided (valid) | Uses provided hostname and provided certs |

**Details:** Most public key infrastructure cannot generate cert/key pairs for the internal Kubernetes `Service` hostnames (`quay.namespace.svc`). Previously, the Operator would reject provided certs which did not include these hostnames as Subject Alternative Names (SANs) because they were believed to be needed for TLS connections within the cluster. This is not the case, so this check is removed.

To use a `Route` with the included OpenShift cluster cert/key pair, mark the `route` component as `managed: false`, include `SERVER_HOSTNAME` as the future generated `Route` hostname (follows the pattern `<route-name>-<namespace>.apps.<cluster>`), then create your own `Route` which points to the Quay app `Service` and uses re-encrypt TLS termination, with the `destinationCACertificate` set to the generated `tls.cert` found in the `Secret` mounted into the Quay app pods.