### PR TITLE
PROJQUAY-1784: Disable monitoring when running in SingleNamespace mode

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -208,6 +208,13 @@ func (r *QuayRegistryReconciler) checkBuildManagerAvailable(ctx *quaycontext.Qua
 // running in an Openshift environment with cluster monitoring enabled for our
 // monitoring component to work
 func (r *QuayRegistryReconciler) checkMonitoringAvailable(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, rawConfig []byte) (*quaycontext.QuayRegistryContext, *v1.QuayRegistry, error) {
+	if len(r.WatchNamespace) > 0 {
+		msg := "monitoring is only supported in AllNamespaces mode. Disabling component monitoring"
+		r.Log.Info(msg)
+		err := fmt.Errorf(msg)
+		return ctx, quay, err
+	}
+
 	var serviceMonitors prometheusv1.ServiceMonitorList
 	if err := r.Client.List(context.Background(), &serviceMonitors); err != nil {
 		r.Log.Info("Unable to find ServiceMonitor CRD. Monitoring component disabled")

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -72,6 +72,7 @@ type QuayRegistryReconciler struct {
 	Log           logr.Logger
 	Scheme        *runtime.Scheme
 	EventRecorder record.EventRecorder
+	WatchNamespace string
 }
 
 // +kubebuilder:rbac:groups=quay.redhat.com,resources=quayregistries,verbs=get;list;watch;create;update;patch;delete

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func main() {
 		Log:           ctrl.Log.WithName("controllers").WithName("QuayRegistry"),
 		Scheme:        mgr.GetScheme(),
 		EventRecorder: mgr.GetEventRecorderFor("quayregistry-controller"),
+		WatchNamespace: namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "QuayRegistry")
 		os.Exit(1)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1784
**Changelog:** 

Add a check in the `checkMonitoringAvailable` function to error out if running in a singleNamespace mode
