### PR TITLE
Infer Product Branding from Environment Variable (PROJQUAY-1798)

### DIFF
--- a/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
+++ b/deploy/manifests/quay-operator/0.0.1/quay-operator.clusterserviceversion.yaml
@@ -145,6 +145,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['quay-version']
+                - name: QUAY_DEFAULT_BRANDING
+                  value: upstream
                 - name: RELATED_IMAGE_COMPONENT_QUAY
                   value: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
                 - name: RELATED_IMAGE_COMPONENT_CLAIR

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/quay/clair/v4/config"
@@ -141,12 +142,19 @@ func FieldGroupFor(ctx *quaycontext.QuayRegistryContext, component v1.ComponentK
 
 // BaseConfig returns a minimum config bundle with values that Quay doesn't have defaults for.
 func BaseConfig() map[string]interface{} {
+	registryTitle := "Quay"
+	enterpriseLogoURL := "/static/img/quay-horizontal-color.svg"
+	if os.Getenv("QUAY_DEFAULT_BRANDING") == "redhat" {
+		registryTitle = "Red Hat Quay"
+		enterpriseLogoURL = "/static/img/RH_Logo_Quay_Black_UX-horizontal.svg"
+	}
+
 	return map[string]interface{}{
 		"FEATURE_MAILING":                    false,
-		"REGISTRY_TITLE":                     "Quay",
-		"REGISTRY_TITLE_SHORT":               "Quay",
+		"REGISTRY_TITLE":                     registryTitle,
+		"REGISTRY_TITLE_SHORT":               registryTitle,
 		"AUTHENTICATION_TYPE":                "Database",
-		"ENTERPRISE_LOGO_URL":                "/static/img/quay-horizontal-color.svg",
+		"ENTERPRISE_LOGO_URL":                enterpriseLogoURL,
 		"DEFAULT_TAG_EXPIRATION":             "2w",
 		"ALLOW_PULLS_WITHOUT_STRICT_LOGGING": false,
 		"TAG_EXPIRATION_OPTIONS":             []string{"2w"},


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1798

**Changelog:** Use `QUAY_DEFAULT_BRANDING` environment variable to set product branding.

**Docs:** N/a

**Testing:** N/a

**Details:** Uses the `QUAY_DEFAULT_BRANDING` environment variable to set `REGISTRY_TITLE` and `ENTERPRISE_LOGO_URL` in the base `config.yaml` generated by the Operator. Set the value to `redhat` for downstream branding, set to `upstream` (default) for upstream branding.