### PR TITLE
Remove Owner References from Grafana ConfigMap (PROJQUAY-1788)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -357,6 +357,25 @@ func EnsureOwnerReference(quay *QuayRegistry, obj runtime.Object) (runtime.Objec
 	return obj, nil
 }
 
+// RemoveOwnerReference removes the `ownerReference` of `QuayRegistry` on the given object.
+func RemoveOwnerReference(quay *QuayRegistry, obj runtime.Object) (runtime.Object, error) {
+	filteredOwnerReferences := []metav1.OwnerReference{}
+
+	objectMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ownerRef := range objectMeta.GetOwnerReferences() {
+		if ownerRef.Name != quay.GetName() {
+			filteredOwnerReferences = append(filteredOwnerReferences, ownerRef)
+		}
+	}
+	objectMeta.SetOwnerReferences(filteredOwnerReferences)
+
+	return obj, nil
+}
+
 const ManagedKeysName = "quay-registry-managed-secret-keys"
 
 // ManagedKeysSecretNameFor returns the name of the `Secret` in which generated secret keys are stored.


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1788

**Changelog:** 
- Reconcile loop ensures that no `ownerReference` are injected on the grafana-dashboard config map. This prevents the cross-namespace owner references that caused resource to be garbage collected after creation.

**Docs:** 
- N/A

**Testing:** 
- Install operator and create instance with monitoring enabled
- ConfigMap <operator-namespace>-grafana-dashboard-quay should be visible in openshift-config-managed namespace

**Details:** 
- N/A
------
