### PR TITLE
Ensure Correct Clair Config Secret is Used (PROJQUAY-1797)

### DIFF
--- a/kustomize/components/clair/kustomization.yaml
+++ b/kustomize/components/clair/kustomization.yaml
@@ -7,8 +7,6 @@ resources:
   - ./postgres.persistentvolumeclaim.yaml
   - ./postgres.deployment.yaml
   - ./postgres.service.yaml
-generatorOptions:
-  disableNameSuffixHash: true
 vars:
   - name: CLAIR_SERVICE_HOST
     objref:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1797

**Changelog:** Add suffix hash to generated Clair config `Secret` to ensure the correct version is mounted into the pod on re-reconcile.

**Docs:** N/a

**Testing:** N/a

**Details:** Previously had `disableNameSuffixHash: true` on the Kustomize-generated Clair config `Secret`. This meant that the `Secret` was updated and the name stayed the same, causing a race condition between the Clair pod starting up and the contents of the `Secret` being updated (with the new PSK) after a reconcile.
