### PR TITLE
ServiceAccounts for Managed Postgres Components 

### DIFF
--- a/bundle/downstream/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/downstream/manifests/quay-operator.clusterserviceversion.yaml
@@ -53,6 +53,7 @@ spec:
         - kind: Secret
         - Kind: Job
         - kind: ConfigMap
+        - kind: ServiceAccount
         - kind: PersistentVolumeClaim
         - kind: Ingress
         - kind: Route
@@ -228,6 +229,7 @@ spec:
           - services
           - secrets
           - configmaps
+          - serviceaccounts
           - persistentvolumeclaims
           - events
           verbs:

--- a/bundle/upstream/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/upstream/manifests/quay-operator.clusterserviceversion.yaml
@@ -51,6 +51,7 @@ spec:
         - kind: Secret
         - Kind: Job
         - kind: ConfigMap
+        - kind: ServiceAccount
         - kind: PersistentVolumeClaim
         - kind: Ingress
         - kind: Route
@@ -185,6 +186,7 @@ spec:
           - services
           - secrets
           - configmaps
+          - serviceaccounts
           - persistentvolumeclaims
           - events
           verbs:

--- a/kustomize/components/clair/kustomization.yaml
+++ b/kustomize/components/clair/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources: 
+  - ./postgres.serviceaccount.yaml
   - ./clair.deployment.yaml
   - ./clair.service.yaml
   - ./postgres.persistentvolumeclaim.yaml

--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         quay-component: clair-postgres
     spec:
+      serviceAccountName: clair-postgres
       volumes:
         - name: postgres-data
           persistentVolumeClaim:

--- a/kustomize/components/clair/postgres.serviceaccount.yaml
+++ b/kustomize/components/clair/postgres.serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clair-postgres

--- a/kustomize/components/postgres/kustomization.yaml
+++ b/kustomize/components/postgres/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources: 
+  - ./postgres.serviceaccount.yaml
   - ./postgres.persistentvolumeclaim.yaml
   - ./postgres.deployment.yaml
   - ./postgres.service.yaml

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         quay-component: postgres
     spec:
+      serviceAccountName: quay-database
       volumes:
         - name: postgres-data
           persistentVolumeClaim:

--- a/kustomize/components/postgres/postgres.serviceaccount.yaml
+++ b/kustomize/components/postgres/postgres.serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: quay-database

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -142,6 +142,8 @@ func ModelFor(gvk schema.GroupVersionKind) k8sruntime.Object {
 		return &corev1.Service{}
 	case schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}.String():
 		return &corev1.ConfigMap{}
+	case schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"}.String():
+		return &corev1.ServiceAccount{}
 	case schema.GroupVersionKind{Version: "v1", Kind: "PersistentVolumeClaim"}.String():
 		return &corev1.PersistentVolumeClaim{}
 	case schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}.String():

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -187,6 +187,7 @@ var quayComponents = map[string][]runtime.Object{
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
 		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
 	},
 	"postgres": {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "postgres-bootstrap"}},
@@ -195,6 +196,7 @@ var quayComponents = map[string][]runtime.Object{
 		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "quay-database"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-database"}},
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "quay-database-init"}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "quay-database"}},
 	},
 	"redis": {
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-redis"}},


### PR DESCRIPTION
Use a separate `ServiceAccount` for each managed Postgres `Deployment` (rather than the `default` one in the namespace). This is needed when the Quay app pod needs to run with `anyuid` SCC (for `quayio` branch), which breaks the permissions on Postgres container for mounting the `pgdata` directory.