### PR TITLE
Python2 Images (quayio)

### DIFF
--- a/bundle/upstream/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/upstream/manifests/quay-operator.clusterserviceversion.yaml
@@ -149,7 +149,7 @@ spec:
                 - name: QUAY_DEFAULT_BRANDING
                   value: upstream
                 - name: RELATED_IMAGE_COMPONENT_QUAY
-                  value: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
+                  value: quay.io/alecmerdler/quay@sha256:2dd5687703c5e92325b4870d516bc595d12b70fb0762a9de2116302e34daf033
                 - name: RELATED_IMAGE_COMPONENT_CLAIR
                   value: quay.io/projectquay/clair@sha256:5fec3cf459159eabe2e4e1089687e25f638183a7e9bed1ecea8724e0597f8a14
                 - name: RELATED_IMAGE_COMPONENT_POSTGRES

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-config-editor
-          image: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
+          image: quay.io/alecmerdler/quay@sha256:2dd5687703c5e92325b4870d516bc595d12b70fb0762a9de2116302e34daf033
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -23,7 +23,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app
-          image: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
+          image: quay.io/alecmerdler/quay@sha256:2dd5687703c5e92325b4870d516bc595d12b70fb0762a9de2116302e34daf033
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME: Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -25,7 +25,7 @@ spec:
             name: cluster-service-ca
       containers:
         - name: quay-app-upgrade
-          image: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
+          image: quay.io/alecmerdler/quay@sha256:2dd5687703c5e92325b4870d516bc595d12b70fb0762a9de2116302e34daf033
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME: Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/components/clair/upgrade.deployment.patch.yaml
+++ b/kustomize/components/clair/upgrade.deployment.patch.yaml
@@ -11,7 +11,7 @@ spec:
       # Init conatainer needed to wait for Clair to initialize (can take minutes) before attempting to validate config.
       initContainers:
         - name: quay-app-upgrade-init
-          image: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
+          image: quay.io/alecmerdler/quay@sha256:2dd5687703c5e92325b4870d516bc595d12b70fb0762a9de2116302e34daf033
           command:
             - /bin/sh
             - -c

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -32,7 +32,7 @@ spec:
                       path: quay-ssl.cert
       initContainers:
         - name: quay-mirror-init
-          image: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
+          image: quay.io/alecmerdler/quay@sha256:2dd5687703c5e92325b4870d516bc595d12b70fb0762a9de2116302e34daf033
           command:
             - /bin/sh
             - -c
@@ -42,7 +42,7 @@ spec:
               value: $(QUAY_APP_SERVICE_HOST)
       containers:
         - name: quay-mirror
-          image: quay.io/projectquay/quay@sha256:46334210eeb21aa6205215d1c4dbc40ea3381887c21a05d0bc47203c8f938987
+          image: quay.io/alecmerdler/quay@sha256:2dd5687703c5e92325b4870d516bc595d12b70fb0762a9de2116302e34daf033
           command: ["/quay-registry/quay-entrypoint.sh"]
           args: ["repomirror-nomigrate"]
           env:


### PR DESCRIPTION
Update the Quay app container images to use the most recent Python2 build from the `quayio` branch.