### PR TITLE
Fix Managed Database Initialization (PROJQUAY-1664)

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -56,17 +56,24 @@ spec:
             limits:
               cpu: 2000m
               memory: 8Gi
-          readinessProbe:
-            exec:
-              command:
-                - curl
-                - '-k'
-                - 'https://localhost:8443/health/instance'
-            initialDelaySeconds: 30
+          startupProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
             timeoutSeconds: 20
             periodSeconds: 15
-            successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
+          livelinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
           volumeMounts:
             - name: configvolume
               readOnly: false

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -56,17 +56,24 @@ spec:
             limits:
               cpu: 2000m
               memory: 8Gi
-          readinessProbe:
-            exec:
-              command:
-                - curl
-                - '-k'
-                - 'https://localhost:8443/health/instance'
-            initialDelaySeconds: 30
+          startupProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
             timeoutSeconds: 20
             periodSeconds: 15
-            successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
+          livelinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
           volumeMounts:
             - name: configvolume
               readOnly: false

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -35,6 +35,11 @@ spec:
               name: config
             - mountPath: /var/run/certs
               name: certs
+          startupProbe:
+            tcpSocket:
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 300
           readinessProbe:
             tcpSocket:
               port: 8080

--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -37,16 +37,18 @@ spec:
               value: postgres
             - name: POSTGRESQL_ADMIN_PASSWORD
               value: postgres
+          startupProbe:
+            exec:
+              command: 
+                - /usr/libexec/check-container
+            periodSeconds: 10
+            failureThreshold: 20
           readinessProbe:
             exec:
-              timeoutSeconds: 1
-              initialDelaySeconds: 5
               command: 
                 - /usr/libexec/check-container
           livelinessProbe:
             exec:
-              timeoutSeconds: 10
-              initialDelaySeconds: 120
               command: 
                 - /usr/libexec/check-container
                 - --live

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -58,6 +58,24 @@ spec:
             - name: ENSURE_NO_MIGRATION
               value: "true"
           # TODO: Determine if we need to set resource requirements
+          startupProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
+            timeoutSeconds: 20
+            periodSeconds: 15
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
+          livelinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
           volumeMounts:
             - name: configvolume
               readOnly: false

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -53,16 +53,18 @@ spec:
               value: 256MB
             - name: POSTGRESQL_MAX_CONNECTIONS
               value: "2000"
+          startupProbe:
+            exec:
+              command: 
+                - /usr/libexec/check-container
+            periodSeconds: 10
+            failureThreshold: 20
           readinessProbe:
             exec:
-              timeoutSeconds: 1
-              initialDelaySeconds: 5
               command: 
                 - /usr/libexec/check-container
           livelinessProbe:
             exec:
-              timeoutSeconds: 10
-              initialDelaySeconds: 120
               command: 
                 - /usr/libexec/check-container
                 - --live


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1664

**Changelog:** Fixes `role does not exist` error for managed database component by adding `startupProbe`.

**Docs:** N/a

**Testing:** Create `QuayRegistry` with managed database and ensure all health checks pass.

**Details:** Fixes an issue where the managed Postgres pod is killed before it completes initialization, and the next pod that starts up reports `role does not exist` error. Followed the [recommendations of the Postgres container maintainers](https://github.com/sclorg/postgresql-container/issues/309) and added `startupProbe` which tells k8s when the container has finished initialization. Apparently the `livenessProbe` [always returns true](https://github.com/sclorg/postgresql-container/pull/320).

