### PR TITLE
kustomize: add ServiceAccounts for managed components (PROJQUAY-1909)

### DIFF
--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         quay-component: quay-app-upgrade
     spec:
+      serviceAccountName: quay-app
       volumes:
         - name: configvolume
           secret:

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         quay-component: clair-app
     spec:
+      serviceAccountName: clair-app
       containers:
         - image: quay.io/projectquay/clair@sha256:5fec3cf459159eabe2e4e1089687e25f638183a7e9bed1ecea8724e0597f8a14
           imagePullPolicy: IfNotPresent

--- a/kustomize/components/clair/clair.serviceaccount.yaml
+++ b/kustomize/components/clair/clair.serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clair-app

--- a/kustomize/components/clair/kustomization.yaml
+++ b/kustomize/components/clair/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources: 
+  - ./clair.serviceaccount.yaml
   - ./postgres.serviceaccount.yaml
   - ./clair.deployment.yaml
   - ./clair.service.yaml

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         quay-component: quay-mirror
     spec:
+      serviceAccountName: quay-app
       volumes:
         - name: configvolume
           secret:

--- a/kustomize/components/redis/kustomization.yaml
+++ b/kustomize/components/redis/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources: 
+  - ./redis.serviceaccount.yaml
   - ./redis.deployment.yaml
   - ./redis.service.yaml

--- a/kustomize/components/redis/redis.deployment.yaml
+++ b/kustomize/components/redis/redis.deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         quay-component: redis
     spec:
+      serviceAccountName: quay-redis
       containers:
         - name: redis-master
           image: centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542

--- a/kustomize/components/redis/redis.serviceaccount.yaml
+++ b/kustomize/components/redis/redis.serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: quay-redis

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -223,6 +223,7 @@ var quayComponents = map[string][]client.Object{
 		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "clair-app"}},
 	},
 	"postgres": {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "postgres-bootstrap"}},
@@ -236,6 +237,7 @@ var quayComponents = map[string][]client.Object{
 	"redis": {
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-redis"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-redis"}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "quay-redis"}},
 	},
 	"objectstorage": {
 		&objectbucket.ObjectBucketClaim{ObjectMeta: metav1.ObjectMeta{Name: "quay-datastorage"}},


### PR DESCRIPTION
Add separate ServiceAccounts for all managed components to avoid
RBAC issues when a special SCC is added to the default namespace
ServiceAccount.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>