### PR TITLE
kustomize: prevent race conditions by sorting k8s objects before creation (PROJQUAY-1915)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -272,7 +272,7 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	for _, obj := range deploymentObjects {
+	for _, obj := range kustomize.EnsureCreationOrder(deploymentObjects) {
 		// For metrics and dashboards to work, we need to deploy the Grafana ConfigMap
 		// in the `openshift-config-managed` namespace and add the label
 		// `openshift.io/cluster-monitoring: true` to the registry namespace


### PR DESCRIPTION
Sort the k8s objects generated from Kustomize to ensure that
Deployments are created after their dependencies (Secrets, ConfigMaps,
etc). This prevents container startup errors when kube cannot mount
a required Secret into a pod.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>