### PR TITLE
kustomize: persist DB_URI for managed postgres (PROJQUAY-1635)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           os=$(go env GOOS)
           arch=$(go env GOARCH)
-          curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
           mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
       - name: Tests

--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -64,6 +64,8 @@ var requiredComponents = []ComponentKind{
 	ComponentRoute,
 }
 
+const ManagedKeysName = "quay-registry-managed-secret-keys"
+
 // QuayRegistrySpec defines the desired state of QuayRegistry.
 type QuayRegistrySpec struct {
 	// ConfigBundleSecret is the name of the Kubernetes `Secret` in the same namespace which contains the base Quay config and extra certs.
@@ -375,8 +377,6 @@ func RemoveOwnerReference(quay *QuayRegistry, obj client.Object) (client.Object,
 
 	return obj, nil
 }
-
-const ManagedKeysName = "quay-registry-managed-secret-keys"
 
 // ManagedKeysSecretNameFor returns the name of the `Secret` in which generated secret keys are stored.
 func ManagedKeysSecretNameFor(quay *QuayRegistry) string {

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -34,6 +34,7 @@ const (
 
 	databaseSecretKey = "DATABASE_SECRET_KEY"
 	secretKey         = "SECRET_KEY"
+	dbURI             = "DB_URI"
 
 	GrafanaDashboardConfigNamespace = "openshift-config-managed"
 )
@@ -55,6 +56,7 @@ func (r *QuayRegistryReconciler) checkManagedKeys(ctx *quaycontext.QuayRegistryC
 		if v1.IsManagedKeysSecretFor(quay, &secret) {
 			ctx.DatabaseSecretKey = string(secret.Data[databaseSecretKey])
 			ctx.SecretKey = string(secret.Data[secretKey])
+			ctx.DbUri = string(secret.Data[dbURI])
 			break
 		}
 	}

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -6,8 +6,6 @@ metadata:
     quay-component: postgres
 spec:
   replicas: 1
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       quay-component: postgres

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -22,6 +22,9 @@ type QuayRegistryContext struct {
 	// Secret Keys
 	DatabaseSecretKey string
 	SecretKey         string
+
+	// Database
+	DbUri string
 }
 
 // NewQuayRegistryContext returns a fresh context for reconciling a `QuayRegistry`.

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -30,8 +30,7 @@ import (
 var underTest = false
 
 const (
-	secretKeySecretName = "quay-registry-managed-secret-keys"
-	secretKeyLength     = 80
+	secretKeyLength = 80
 
 	clairService = "clair-app"
 	// FIXME: Ensure this includes the `QuayRegistry` name prefix when we add `builder` managed component.
@@ -81,16 +80,8 @@ func FieldGroupFor(ctx *quaycontext.QuayRegistryContext, component v1.ComponentK
 		if err != nil {
 			return nil, err
 		}
-		user := quay.GetName() + "-quay-database"
-		name := quay.GetName() + "-quay-database"
-		host := strings.Join([]string{quay.GetName(), "quay-database"}, "-")
-		port := "5432"
-		password, err := generateRandomString(32)
-		if err != nil {
-			return nil, err
-		}
 
-		fieldGroup.DbUri = fmt.Sprintf("postgresql://%s:%s@%s:%s/%s", user, password, host, port, name)
+		fieldGroup.DbUri = ctx.DbUri
 
 		return fieldGroup, nil
 	case v1.ComponentObjectStorage:
@@ -150,6 +141,7 @@ func BaseConfig() map[string]interface{} {
 	}
 
 	return map[string]interface{}{
+		"SETUP_COMPLETE":                     true,
 		"FEATURE_MAILING":                    false,
 		"REGISTRY_TITLE":                     registryTitle,
 		"REGISTRY_TITLE_SHORT":               registryTitle,

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -2,7 +2,6 @@ package kustomize
 
 import (
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,7 +79,9 @@ var fieldGroupForTests = []struct {
 		"postgres",
 		"postgres",
 		quayRegistry("test"),
-		quaycontext.QuayRegistryContext{},
+		quaycontext.QuayRegistryContext{
+			DbUri: "postgresql://test-quay-database:postgres@test-quay-database:5432/test-quay-database",
+		},
 		&database.DatabaseFieldGroup{
 			DbUri: "postgresql://test-quay-database:postgres@test-quay-database:5432/test-quay-database",
 			DbConnectionArgs: &database.DbConnectionArgsStruct{
@@ -168,15 +169,6 @@ func TestFieldGroupFor(t *testing.T) {
 
 			assert.True(len(secscanFieldGroup.SecurityScannerV4PSK) > 0, test.name)
 			secscanFieldGroup.SecurityScannerV4PSK = "abc123"
-		} else if test.name == "postgres" {
-			databaseFieldGroup := fieldGroup.(*database.DatabaseFieldGroup)
-			dbURI, err := url.Parse(databaseFieldGroup.DbUri)
-			assert.Nil(err, test.name)
-
-			password, _ := dbURI.User.Password()
-			assert.True(len(password) > 0, test.name)
-			dbURI.User = url.UserPassword(dbURI.User.Username(), "postgres")
-			databaseFieldGroup.DbUri = dbURI.String()
 		}
 
 		expected, err := yaml.Marshal(test.expected)


### PR DESCRIPTION
Change DB_URI to be persisted rather than generated on each
reconcile. This prevents downtime on reconciles because the old and
new Quay pods continue to use the same database password.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>