### PR TITLE
tls: persist generated TLS cert/key pair (PROJQUAY-1838)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -64,7 +64,10 @@ var requiredComponents = []ComponentKind{
 	ComponentRoute,
 }
 
-const ManagedKeysName = "quay-registry-managed-secret-keys"
+const (
+	ManagedKeysName         = "quay-registry-managed-secret-keys"
+	QuayConfigTLSSecretName = "quay-config-tls"
+)
 
 // QuayRegistrySpec defines the desired state of QuayRegistry.
 type QuayRegistrySpec struct {
@@ -385,6 +388,10 @@ func ManagedKeysSecretNameFor(quay *QuayRegistry) string {
 
 func IsManagedKeysSecretFor(quay *QuayRegistry, secret *corev1.Secret) bool {
 	return strings.Contains(secret.GetName(), quay.GetName()+"-"+ManagedKeysName)
+}
+
+func IsManagedTLSSecretFor(quay *QuayRegistry, secret *corev1.Secret) bool {
+	return strings.Contains(secret.GetName(), quay.GetName()+"-"+QuayConfigTLSSecretName)
 }
 
 func init() {

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -16,9 +16,13 @@ spec:
     spec:
       serviceAccountName: quay-app
       volumes:
-        - name: configvolume
-          secret:
-            secretName: quay-config-secret
+        - name: config
+          projected:
+            sources:
+            - secret:
+                name: quay-config-secret
+            - secret:
+                name: quay-config-tls
         - name: extra-ca-certs
           configMap:
             name: cluster-service-ca
@@ -76,7 +80,7 @@ spec:
               port: 8443
               scheme: HTTPS
           volumeMounts:
-            - name: configvolume
+            - name: config
               readOnly: false
               mountPath: /conf/stack
             - name: extra-ca-certs

--- a/kustomize/base/upgrade.deployment.yaml
+++ b/kustomize/base/upgrade.deployment.yaml
@@ -18,9 +18,13 @@ spec:
     spec:
       serviceAccountName: quay-app
       volumes:
-        - name: configvolume
-          secret:
-            secretName: quay-config-secret
+        - name: config
+          projected:
+            sources:
+            - secret:
+                name: quay-config-secret
+            - secret:
+                name: quay-config-tls
         - name: extra-ca-certs
           configMap:
             name: cluster-service-ca
@@ -76,10 +80,9 @@ spec:
               port: 8443
               scheme: HTTPS
           volumeMounts:
-            - name: configvolume
+            - name: config
               readOnly: false
               mountPath: /conf/stack
             - name: extra-ca-certs
               readOnly: true
-              # FIXME: Cannot mount here because Quay attempts to write to this directory...
               mountPath: /conf/stack/extra_ca_certs

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -55,7 +55,7 @@ spec:
             secretName: clair-config-secret
         - name: certs
           secret:
-            secretName: quay-config-secret
+            secretName: quay-config-tls
             # Mount just the public certificate because we are using storage proxying.
             items:
               - key: ssl.cert

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -18,14 +18,19 @@ spec:
     spec:
       serviceAccountName: quay-app
       volumes:
-        - name: configvolume
-          secret:
-            secretName: quay-config-secret
+        - name: config
+          projected:
+            sources:
+            - secret:
+                name: quay-config-secret
+            - secret:
+                name: quay-config-tls
         - name: extra-ca-certs
           projected:
             sources:
               - configMap:
                   name: cluster-service-ca
+              # FIXME(alecmerdler): Have this read from `quay-config-tls` instead...
               - secret:
                   name: quay-config-secret
                   items:
@@ -78,7 +83,7 @@ spec:
               port: 8443
               scheme: HTTPS
           volumeMounts:
-            - name: configvolume
+            - name: config
               readOnly: false
               mountPath: /conf/stack
             - name: extra-ca-certs

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -8,6 +8,10 @@ type QuayRegistryContext struct {
 	ServerHostname       string
 	BuildManagerHostname string
 
+	// TLS
+	TLSCert []byte
+	TLSKey  []byte
+
 	// Object Storage
 	SupportsObjectStorage    bool
 	ObjectStorageInitialized bool

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -287,6 +287,17 @@ func KustomizationFor(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistr
 		},
 		{
 			GeneratorArgs: types.GeneratorArgs{
+				Name: v1.QuayConfigTLSSecretName,
+				KvPairSources: types.KvPairSources{
+					LiteralSources: []string{
+						"ssl.cert=" + string(ctx.TLSCert),
+						"ssl.key=" + string(ctx.TLSKey),
+					},
+				},
+			},
+		},
+		{
+			GeneratorArgs: types.GeneratorArgs{
 				Name: "quay-config-editor-credentials",
 				KvPairSources: types.KvPairSources{
 					LiteralSources: []string{
@@ -499,14 +510,14 @@ func Inflate(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, baseCo
 		}
 	}
 
-	log.Info("Ensuring `ssl.cert` and `ssl.key` pair for Quay app TLS")
-	tlsCert, tlsKey, err := EnsureTLSFor(ctx, quay, baseConfigBundle.Data["ssl.cert"], baseConfigBundle.Data["ssl.key"])
+	log.Info("Ensuring TLS cert/key pair for Quay app")
+	tlsCert, tlsKey, err := EnsureTLSFor(ctx, quay)
 	if err != nil {
 		return nil, err
 	}
 
-	componentConfigFiles["ssl.cert"] = tlsCert
-	componentConfigFiles["ssl.key"] = tlsKey
+	ctx.TLSCert = tlsCert
+	ctx.TLSKey = tlsKey
 
 	kustomization, err := KustomizationFor(ctx, quay, componentConfigFiles)
 	check(err)

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -211,6 +211,7 @@ var quayComponents = map[string][]client.Object{
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-editor"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-secret"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-tls"}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-service-ca"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-editor-credentials"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-registry-managed-secret-keys"}},

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -425,9 +425,11 @@ func TestEnsureTLSFor(t *testing.T) {
 		quayContext := quaycontext.QuayRegistryContext{
 			ServerHostname:       test.serverHostname,
 			BuildManagerHostname: test.buildManagerHostname,
+			TLSCert:              test.providedCertKeyPair[0],
+			TLSKey:               test.providedCertKeyPair[1],
 		}
 
-		tlsCert, tlsKey, err := EnsureTLSFor(&quayContext, quayRegistry, test.providedCertKeyPair[0], test.providedCertKeyPair[1])
+		tlsCert, tlsKey, err := EnsureTLSFor(&quayContext, quayRegistry)
 
 		assert.Equal(test.expectedErr, err, test.name)
 


### PR DESCRIPTION
Move the 'ssl.cert' and 'ssl.key' to a separate, persistent
Secret to ensure that the cert/key pair is not re-generated
on every reconcile. Use k8s projected volumes to mount the
config and TLS Secrets to the same directory in the Quay
container.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>