### PR TITLE
api: upgrade to apiextensions.k8s.io/v1 (PROJQUAY-1791)

### DIFF
--- a/bundle/downstream/manifests/quayregistries.crd.yaml
+++ b/bundle/downstream/manifests/quayregistries.crd.yaml
@@ -1,4 +1,5 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -13,110 +14,122 @@ spec:
     plural: quayregistries
     singular: quayregistry
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: QuayRegistry is the Schema for the quayregistries API.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: QuayRegistrySpec defines the desired state of QuayRegistry.
-          properties:
-            components:
-              description: Components declare how the Operator should handle backing
-                Quay services.
-              items:
-                description: Component describes how the Operator should handle a
-                  backing Quay service.
-                properties:
-                  kind:
-                    description: Kind is the unique name of this type of component.
-                    type: string
-                  managed:
-                    description: Managed indicates whether or not the Operator is
-                      responsible for the lifecycle of this component. Default is
-                      true.
-                    type: boolean
-                required:
-                - kind
-                - managed
-                type: object
-              type: array
-            configBundleSecret:
-              description: ConfigBundleSecret is the name of the Kubernetes `Secret`
-                in the same namespace which contains the base Quay config and extra
-                certs.
-              type: string
-          type: object
-        status:
-          description: QuayRegistryStatus defines the observed state of QuayRegistry.
-          properties:
-            conditions:
-              description: Conditions represent the conditions that a QuayRegistry
-                can have.
-              items:
-                description: 'Condition is a single condition of a QuayRegistry. Conditions
-                  should follow the "abnormal-true" principle in order to only bring
-                  the attention of users to "broken" states. Example: a condition
-                  of `type: "Ready", status: "True"`` is less useful and should be
-                  omitted whereas `type: "NotReady", status: "True"` is more useful
-                  when trying to monitor when something is wrong.'
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            configEditorCredentialsSecret:
-              description: ConfigEditorCredentialsSecret is the Kubernetes `Secret`
-                containing the config editor password.
-              type: string
-            configEditorEndpoint:
-              description: ConfigEditorEndpoint is the external access point for a
-                web-based reconfiguration interface for the Quay registry instance.
-              type: string
-            currentVersion:
-              description: CurrentVersion is the actual version of Quay that is actively
-                deployed.
-              type: string
-            lastUpdated:
-              description: LastUpdate is the timestamp when the Operator last processed
-                this instance.
-              type: string
-            registryEndpoint:
-              description: RegistryEndpoint is the external access point for the Quay
-                registry.
-              type: string
-          type: object
-      type: object
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: QuayRegistry is the Schema for the quayregistries API.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: QuayRegistrySpec defines the desired state of QuayRegistry.
+              properties:
+                components:
+                  description:
+                    Components declare how the Operator should handle backing
+                    Quay services.
+                  items:
+                    description:
+                      Component describes how the Operator should handle a
+                      backing Quay service.
+                    properties:
+                      kind:
+                        description: Kind is the unique name of this type of component.
+                        type: string
+                      managed:
+                        description:
+                          Managed indicates whether or not the Operator is
+                          responsible for the lifecycle of this component. Default is
+                          true.
+                        type: boolean
+                    required:
+                      - kind
+                      - managed
+                    type: object
+                  type: array
+                configBundleSecret:
+                  description:
+                    ConfigBundleSecret is the name of the Kubernetes `Secret`
+                    in the same namespace which contains the base Quay config and extra
+                    certs.
+                  type: string
+              type: object
+            status:
+              description: QuayRegistryStatus defines the observed state of QuayRegistry.
+              properties:
+                conditions:
+                  description:
+                    Conditions represent the conditions that a QuayRegistry
+                    can have.
+                  items:
+                    description:
+                      'Condition is a single condition of a QuayRegistry. Conditions
+                      should follow the "abnormal-true" principle in order to only bring
+                      the attention of users to "broken" states. Example: a condition
+                      of `type: "Ready", status: "True"`` is less useful and should be
+                      omitted whereas `type: "NotReady", status: "True"` is more useful
+                      when trying to monitor when something is wrong.'
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                configEditorCredentialsSecret:
+                  description:
+                    ConfigEditorCredentialsSecret is the Kubernetes `Secret`
+                    containing the config editor password.
+                  type: string
+                configEditorEndpoint:
+                  description:
+                    ConfigEditorEndpoint is the external access point for a
+                    web-based reconfiguration interface for the Quay registry instance.
+                  type: string
+                currentVersion:
+                  description:
+                    CurrentVersion is the actual version of Quay that is actively
+                    deployed.
+                  type: string
+                lastUpdated:
+                  description:
+                    LastUpdate is the timestamp when the Operator last processed
+                    this instance.
+                  type: string
+                registryEndpoint:
+                  description:
+                    RegistryEndpoint is the external access point for the Quay
+                    registry.
+                  type: string
+              type: object
+          type: object
 status:
   acceptedNames:
     kind: ""

--- a/bundle/upstream/manifests/quayregistries.crd.yaml
+++ b/bundle/upstream/manifests/quayregistries.crd.yaml
@@ -1,4 +1,5 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -13,110 +14,122 @@ spec:
     plural: quayregistries
     singular: quayregistry
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: QuayRegistry is the Schema for the quayregistries API.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: QuayRegistrySpec defines the desired state of QuayRegistry.
-          properties:
-            components:
-              description: Components declare how the Operator should handle backing
-                Quay services.
-              items:
-                description: Component describes how the Operator should handle a
-                  backing Quay service.
-                properties:
-                  kind:
-                    description: Kind is the unique name of this type of component.
-                    type: string
-                  managed:
-                    description: Managed indicates whether or not the Operator is
-                      responsible for the lifecycle of this component. Default is
-                      true.
-                    type: boolean
-                required:
-                - kind
-                - managed
-                type: object
-              type: array
-            configBundleSecret:
-              description: ConfigBundleSecret is the name of the Kubernetes `Secret`
-                in the same namespace which contains the base Quay config and extra
-                certs.
-              type: string
-          type: object
-        status:
-          description: QuayRegistryStatus defines the observed state of QuayRegistry.
-          properties:
-            conditions:
-              description: Conditions represent the conditions that a QuayRegistry
-                can have.
-              items:
-                description: 'Condition is a single condition of a QuayRegistry. Conditions
-                  should follow the "abnormal-true" principle in order to only bring
-                  the attention of users to "broken" states. Example: a condition
-                  of `type: "Ready", status: "True"`` is less useful and should be
-                  omitted whereas `type: "NotReady", status: "True"` is more useful
-                  when trying to monitor when something is wrong.'
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            configEditorCredentialsSecret:
-              description: ConfigEditorCredentialsSecret is the Kubernetes `Secret`
-                containing the config editor password.
-              type: string
-            configEditorEndpoint:
-              description: ConfigEditorEndpoint is the external access point for a
-                web-based reconfiguration interface for the Quay registry instance.
-              type: string
-            currentVersion:
-              description: CurrentVersion is the actual version of Quay that is actively
-                deployed.
-              type: string
-            lastUpdated:
-              description: LastUpdate is the timestamp when the Operator last processed
-                this instance.
-              type: string
-            registryEndpoint:
-              description: RegistryEndpoint is the external access point for the Quay
-                registry.
-              type: string
-          type: object
-      type: object
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: QuayRegistry is the Schema for the quayregistries API.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: QuayRegistrySpec defines the desired state of QuayRegistry.
+              properties:
+                components:
+                  description:
+                    Components declare how the Operator should handle backing
+                    Quay services.
+                  items:
+                    description:
+                      Component describes how the Operator should handle a
+                      backing Quay service.
+                    properties:
+                      kind:
+                        description: Kind is the unique name of this type of component.
+                        type: string
+                      managed:
+                        description:
+                          Managed indicates whether or not the Operator is
+                          responsible for the lifecycle of this component. Default is
+                          true.
+                        type: boolean
+                    required:
+                      - kind
+                      - managed
+                    type: object
+                  type: array
+                configBundleSecret:
+                  description:
+                    ConfigBundleSecret is the name of the Kubernetes `Secret`
+                    in the same namespace which contains the base Quay config and extra
+                    certs.
+                  type: string
+              type: object
+            status:
+              description: QuayRegistryStatus defines the observed state of QuayRegistry.
+              properties:
+                conditions:
+                  description:
+                    Conditions represent the conditions that a QuayRegistry
+                    can have.
+                  items:
+                    description:
+                      'Condition is a single condition of a QuayRegistry. Conditions
+                      should follow the "abnormal-true" principle in order to only bring
+                      the attention of users to "broken" states. Example: a condition
+                      of `type: "Ready", status: "True"`` is less useful and should be
+                      omitted whereas `type: "NotReady", status: "True"` is more useful
+                      when trying to monitor when something is wrong.'
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                configEditorCredentialsSecret:
+                  description:
+                    ConfigEditorCredentialsSecret is the Kubernetes `Secret`
+                    containing the config editor password.
+                  type: string
+                configEditorEndpoint:
+                  description:
+                    ConfigEditorEndpoint is the external access point for a
+                    web-based reconfiguration interface for the Quay registry instance.
+                  type: string
+                currentVersion:
+                  description:
+                    CurrentVersion is the actual version of Quay that is actively
+                    deployed.
+                  type: string
+                lastUpdated:
+                  description:
+                    LastUpdate is the timestamp when the Operator last processed
+                    this instance.
+                  type: string
+                registryEndpoint:
+                  description:
+                    RegistryEndpoint is the external access point for the Quay
+                    registry.
+                  type: string
+              type: object
+          type: object
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,110 +14,122 @@ spec:
     plural: quayregistries
     singular: quayregistry
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: QuayRegistry is the Schema for the quayregistries API.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: QuayRegistrySpec defines the desired state of QuayRegistry.
-          properties:
-            components:
-              description: Components declare how the Operator should handle backing
-                Quay services.
-              items:
-                description: Component describes how the Operator should handle a
-                  backing Quay service.
-                properties:
-                  kind:
-                    description: Kind is the unique name of this type of component.
-                    type: string
-                  managed:
-                    description: Managed indicates whether or not the Operator is
-                      responsible for the lifecycle of this component. Default is
-                      true.
-                    type: boolean
-                required:
-                - kind
-                - managed
-                type: object
-              type: array
-            configBundleSecret:
-              description: ConfigBundleSecret is the name of the Kubernetes `Secret`
-                in the same namespace which contains the base Quay config and extra
-                certs.
-              type: string
-          type: object
-        status:
-          description: QuayRegistryStatus defines the observed state of QuayRegistry.
-          properties:
-            conditions:
-              description: Conditions represent the conditions that a QuayRegistry
-                can have.
-              items:
-                description: 'Condition is a single condition of a QuayRegistry. Conditions
-                  should follow the "abnormal-true" principle in order to only bring
-                  the attention of users to "broken" states. Example: a condition
-                  of `type: "Ready", status: "True"`` is less useful and should be
-                  omitted whereas `type: "NotReady", status: "True"` is more useful
-                  when trying to monitor when something is wrong.'
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            configEditorCredentialsSecret:
-              description: ConfigEditorCredentialsSecret is the Kubernetes `Secret`
-                containing the config editor password.
-              type: string
-            configEditorEndpoint:
-              description: ConfigEditorEndpoint is the external access point for a
-                web-based reconfiguration interface for the Quay registry instance.
-              type: string
-            currentVersion:
-              description: CurrentVersion is the actual version of Quay that is actively
-                deployed.
-              type: string
-            lastUpdated:
-              description: LastUpdate is the timestamp when the Operator last processed
-                this instance.
-              type: string
-            registryEndpoint:
-              description: RegistryEndpoint is the external access point for the Quay
-                registry.
-              type: string
-          type: object
-      type: object
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: QuayRegistry is the Schema for the quayregistries API.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: QuayRegistrySpec defines the desired state of QuayRegistry.
+              properties:
+                components:
+                  description:
+                    Components declare how the Operator should handle backing
+                    Quay services.
+                  items:
+                    description:
+                      Component describes how the Operator should handle a
+                      backing Quay service.
+                    properties:
+                      kind:
+                        description: Kind is the unique name of this type of component.
+                        type: string
+                      managed:
+                        description:
+                          Managed indicates whether or not the Operator is
+                          responsible for the lifecycle of this component. Default is
+                          true.
+                        type: boolean
+                    required:
+                      - kind
+                      - managed
+                    type: object
+                  type: array
+                configBundleSecret:
+                  description:
+                    ConfigBundleSecret is the name of the Kubernetes `Secret`
+                    in the same namespace which contains the base Quay config and extra
+                    certs.
+                  type: string
+              type: object
+            status:
+              description: QuayRegistryStatus defines the observed state of QuayRegistry.
+              properties:
+                conditions:
+                  description:
+                    Conditions represent the conditions that a QuayRegistry
+                    can have.
+                  items:
+                    description:
+                      'Condition is a single condition of a QuayRegistry. Conditions
+                      should follow the "abnormal-true" principle in order to only bring
+                      the attention of users to "broken" states. Example: a condition
+                      of `type: "Ready", status: "True"`` is less useful and should be
+                      omitted whereas `type: "NotReady", status: "True"` is more useful
+                      when trying to monitor when something is wrong.'
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                configEditorCredentialsSecret:
+                  description:
+                    ConfigEditorCredentialsSecret is the Kubernetes `Secret`
+                    containing the config editor password.
+                  type: string
+                configEditorEndpoint:
+                  description:
+                    ConfigEditorEndpoint is the external access point for a
+                    web-based reconfiguration interface for the Quay registry instance.
+                  type: string
+                currentVersion:
+                  description:
+                    CurrentVersion is the actual version of Quay that is actively
+                    deployed.
+                  type: string
+                lastUpdated:
+                  description:
+                    LastUpdate is the timestamp when the Operator last processed
+                    this instance.
+                  type: string
+                registryEndpoint:
+                  description:
+                    RegistryEndpoint is the external access point for the Quay
+                    registry.
+                  type: string
+              type: object
+          type: object
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
- Update CRD from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1
- Migration guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122