### PR TITLE
tls: backport removal of SAN requirement (PROJQUAY-1737)

### DIFF
--- a/kustomize/base/quay.service.yaml
+++ b/kustomize/base/quay.service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     quay-component: quay-app
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - protocol: TCP
       name: https


### PR DESCRIPTION
Backport the fix from (#406) to remove the requirement for
provided TLS cert/key pair to be valid for internal k8s
service hostnames as SAN entries.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>