### PR TITLE
kustomize: remove startupProbes from Postgres pods (PROJQUAY-2010)

### DIFF
--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -37,21 +37,6 @@ spec:
               value: postgres
             - name: POSTGRESQL_ADMIN_PASSWORD
               value: postgres
-          startupProbe:
-            exec:
-              command: 
-                - /usr/libexec/check-container
-            periodSeconds: 10
-            failureThreshold: 20
-          readinessProbe:
-            exec:
-              command: 
-                - /usr/libexec/check-container
-          livelinessProbe:
-            exec:
-              command: 
-                - /usr/libexec/check-container
-                - --live
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -51,21 +51,6 @@ spec:
               value: 256MB
             - name: POSTGRESQL_MAX_CONNECTIONS
               value: "2000"
-          startupProbe:
-            exec:
-              command: 
-                - /usr/libexec/check-container
-            periodSeconds: 10
-            failureThreshold: 20
-          readinessProbe:
-            exec:
-              command: 
-                - /usr/libexec/check-container
-          livelinessProbe:
-            exec:
-              command: 
-                - /usr/libexec/check-container
-                - --live
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data


### PR DESCRIPTION
The startup probes seem to timeout and fail intermittently during
the lifetime of the Postgres container, even though the
container logs no problems.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>