### PR TITLE
add resource requests and limits

### DIFF
--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -48,6 +48,13 @@ spec:
             httpGet:
               port: clair-intro
               path: /healthz
+          resources:
+            requests:
+              cpu: 2000m
+              memory: 2Gi
+            limits:
+              cpu: 4000m
+              memory: 16Gi
       restartPolicy: Always
       volumes:
         - name: config

--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -40,3 +40,7 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -89,3 +89,10 @@ spec:
             - name: extra-ca-certs
               readOnly: true
               mountPath: /conf/stack/extra_ca_certs
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -54,3 +54,7 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi

--- a/kustomize/components/redis/redis.deployment.yaml
+++ b/kustomize/components/redis/redis.deployment.yaml
@@ -22,3 +22,10 @@ spec:
           ports:
             - containerPort: 6379
               protocol: TCP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 4000m
+              memory: 16Gi


### PR DESCRIPTION
quay-operator: add resource requests and limits (PROJQUAY-2011)

- adds resource and requests and limits to all Quay components to help placement
- this also enables cluster auto-scaling
- prevent resource starving by setting set sane limits