### PR TITLE
chore: add QUAY_VERSION to make run command (PROJQUAY-2030)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	QUAY_VERSION=dev go run main.go
 
 # Install CRDs into a cluster
 install: manifests

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ $ kubectl create -f ./bundle/upstream/manifests/*.crd.yaml
 
 **Run the controller**:
 ```sh
-$ go run main.go
+$ make run
 ```
 
 **Tests**:
 ```sh
-$ go test -v ./...
+$ make test
 ```
 
 **Building custom `CatalogSource`**:


### PR DESCRIPTION
The 'QUAY_VERSION' environment variable is required when
running the Operator in order for the upgrade pod to
progress. Adds this to the command in the Makefile.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>