### PR TITLE
chore: add QUAY_VERSION to make run command (PROJQUAY-2030)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -84,8 +84,10 @@ roleRef:
   name: edit
 ```
 
-3. The `spec.configBundleSecret` must include the following field (from legacy behavior requiring a user to exist in the database before startup):
+3. The `config.yaml` entry supplied in `spec.configBundleSecret` must include the following field (from legacy behavior requiring a user to exist in the database before startup):
 
 ```yaml
 SERVICE_LOG_ACCOUNT_ID: 12345
 ```
+
+4. With managed `objectstorage` using RHOCS, the cluster service CA certificate needs to be included manually in `spec.configBundleSecret` (due to legacy behavior of Quay) under the key `extra_ca_certs_cluster-service-ca.crt`.


### PR DESCRIPTION
The 'QUAY_VERSION' environment variable is required when
running the Operator in order for the upgrade pod to
progress. Adds this to the command in the Makefile.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>