### PR TITLE
kustomize: use Job to run database migrations (PROJQUAY-2121)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -28,7 +28,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/tidwall/sjson"
 	"gopkg.in/yaml.v2"
-	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -339,23 +339,17 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		go func(quayRegistry *v1.QuayRegistry) {
 			err = wait.Poll(upgradePollInterval, upgradePollTimeout, func() (bool, error) {
-				log.Info("checking Quay upgrade deployment readiness")
+				log.Info("checking Quay upgrade `Job` completion")
 
-				var upgradeDeployment appsv1.Deployment
-				err = r.Client.Get(ctx, types.NamespacedName{Name: quayRegistry.GetName() + "-quay-app-upgrade", Namespace: quayRegistry.GetNamespace()}, &upgradeDeployment)
+				var upgradeJob batchv1.Job
+				err = r.Client.Get(ctx, types.NamespacedName{Name: quayRegistry.GetName() + "-quay-app-upgrade", Namespace: quayRegistry.GetNamespace()}, &upgradeJob)
 				if err != nil {
-					log.Error(err, "could not retrieve Quay upgrade deployment during upgrade")
+					log.Error(err, "could not retrieve Quay upgrade `Job`")
 
 					return false, err
 				}
 
-				if upgradeDeployment.Spec.Size() < 1 {
-					log.Info("upgrade deployment scaled down, skipping check")
-
-					return true, nil
-				}
-
-				if upgradeDeployment.Status.ReadyReplicas > 0 {
+				if upgradeJob.Status.Succeeded > 0 {
 					log.Info("Quay upgrade complete, updating `status.currentVersion`")
 
 					updatedQuay, _ := v1.EnsureRegistryEndpoint(quayContext, updatedQuay, userProvidedConfig)
@@ -389,16 +383,16 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 					return true, nil
 				}
+
 				return false, nil
 			})
 
 			if err != nil {
-				log.Error(err, "Quay upgrade deployment never reached ready phase")
+				log.Error(err, "Quay upgrade `Job` never completed")
 			}
 		}(updatedQuay.DeepCopy())
 	}
 
-	// Add finalizer for this CR
 	if !controllerutil.ContainsFinalizer(updatedQuay, QuayOperatorFinalizer) {
 		controllerutil.AddFinalizer(updatedQuay, QuayOperatorFinalizer)
 		err = r.Update(ctx, updatedQuay)

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -101,20 +101,6 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 		Expect(refs[0].Name).To(Equal(quayRegistry.GetName()))
 	}
 
-	// progressUpgradeDeployment sets the `status` manually because `envtest` only runs apiserver, not controllers.
-	progressUpgradeDeployment := func() error {
-		var upgradeDeployment appsv1.Deployment
-		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: quayRegistry.GetName() + "-quay-app-upgrade", Namespace: namespace}, &upgradeDeployment)
-		if err != nil {
-			return err
-		}
-
-		upgradeDeployment.Status.Replicas = 1
-		upgradeDeployment.Status.ReadyReplicas = 1
-
-		return k8sClient.Status().Update(context.Background(), &upgradeDeployment)
-	}
-
 	BeforeEach(func() {
 		namespace = randIdentifier(16)
 
@@ -298,8 +284,6 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 		})
 
 		It("reports the current version in the `status` block", func() {
-			Expect(progressUpgradeDeployment()).Should(Succeed())
-
 			var updatedQuayRegistry v1.QuayRegistry
 
 			Eventually(func() v1.QuayVersion {
@@ -385,7 +369,6 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 		It("successfully performs an upgrade", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-			Expect(progressUpgradeDeployment()).Should(Succeed())
 
 			var updatedQuayRegistry v1.QuayRegistry
 

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ./quay.serviceaccount.yaml
   - ./quay.deployment.yaml
   - ./quay.service.yaml
-  - ./upgrade.deployment.yaml
+  - ./upgrade.job.yaml
   - ./cluster-service-ca.configmap.yaml
   - ./config.deployment.yaml
   - ./config.service.yaml

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -25,6 +25,7 @@ spec:
       containers:
         - name: quay-app
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd
+          args: ["registry-nomigrate"]
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME: Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...

--- a/kustomize/base/upgrade.job.yaml
+++ b/kustomize/base/upgrade.job.yaml
@@ -1,21 +1,17 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: quay-app-upgrade
   labels:
     quay-component: quay-app-upgrade
 spec:
-  replicas: 0
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      quay-component: quay-app-upgrade
   template:
     metadata:
+      name: quay-app-upgrade
       labels:
         quay-component: quay-app-upgrade
     spec:
+      restartPolicy: OnFailure
       serviceAccountName: quay-app
       volumes:
         - name: config
@@ -27,6 +23,7 @@ spec:
       containers:
         - name: quay-app-upgrade
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd
+          args: ["migrate", "head"]
           env:
             - name: QE_K8S_CONFIG_SECRET
               # FIXME: Using `vars` is kinda ugly because it's basically templating, but this needs to be the generated `Secret` name...
@@ -57,24 +54,7 @@ spec:
             limits:
               cpu: 2000m
               memory: 8Gi
-          startupProbe:
-            httpGet:
-              path: /health/instance
-              port: 8080
-              scheme: HTTP
-            timeoutSeconds: 20
-            periodSeconds: 15
-            failureThreshold: 10
-          readinessProbe:
-            httpGet:
-              path: /health/instance
-              port: 8080
-              scheme: HTTP
-          livelinessProbe:
-            httpGet:
-              path: /health/instance
-              port: 8080
-              scheme: HTTP
+          # FIXME(alecmerdler): Need to determine healthcheck for alembic...
           volumeMounts:
             - name: config
               readOnly: false

--- a/kustomize/overlays/current/upgrade/kustomization.yaml
+++ b/kustomize/overlays/current/upgrade/kustomization.yaml
@@ -4,6 +4,5 @@ kind: Kustomization
 bases:
   - ../../../tmp
 patchesStrategicMerge:
-  # Scale the app deployment to 0 pods in order to run all migrations present in the new container image using the "upgrade" deployment.
+  # Scale the app deployment to 0 pods in order to run all migrations present in the new container image using the "upgrade" `Job`.
   - ./quay.deployment.patch.yaml
-  - ./upgrade.deployment.patch.yaml

--- a/kustomize/overlays/current/upgrade/upgrade.deployment.patch.yaml
+++ b/kustomize/overlays/current/upgrade/upgrade.deployment.patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: quay-app-upgrade
-spec:
-  replicas: 1

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -207,7 +207,7 @@ func TestFlattenSecret(t *testing.T) {
 var quayComponents = map[string][]client.Object{
 	"base": {
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-app-upgrade"}},
+		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "quay-app-upgrade"}},
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-editor"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-editor"}},


### PR DESCRIPTION
Switch to use the './quay-entrypoint.sh migrate head' command for
the Quay migration pod, rather than running all the Gunicorn workers.
This prevents the security scanning worker from attempting to scan
images before the registry is running.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>