### PR TITLE
CRD: Migrating CRDs to apiextensions.k8s.io/v1 (PROJQUAY-1791) 

### DIFF
--- a/config/crd/patches/cainjection_in_quayecosystems.yaml
+++ b/config/crd/patches/cainjection_in_quayecosystems.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/cainjection_in_quayregistries.yaml
+++ b/config/crd/patches/cainjection_in_quayregistries.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_quayecosystems.yaml
+++ b/config/crd/patches/webhook_in_quayecosystems.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: quayecosystems.redhatcop.redhat.io.quay.redhat.com

--- a/config/crd/patches/webhook_in_quayregistries.yaml
+++ b/config/crd/patches/webhook_in_quayregistries.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: quayregistries.quay.redhat.com.quay.redhat.com


### PR DESCRIPTION
Replacing apiextensions.k8s.io/v1beta1 by apiextensions.k8s.io/v1.