### PR TITLE
reconcile: scale deployment to zero during all upgrades (PROJQUAY-2121)

### DIFF
--- a/kustomize/base/upgrade.job.yaml
+++ b/kustomize/base/upgrade.job.yaml
@@ -54,7 +54,6 @@ spec:
             limits:
               cpu: 2000m
               memory: 8Gi
-          # FIXME(alecmerdler): Need to determine healthcheck for alembic...
           volumeMounts:
             - name: config
               readOnly: false

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -498,7 +498,7 @@ func Inflate(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, baseCo
 	var overlay string
 	if rolloutBlocked(quay) {
 		overlay = configEditorOnlyOverlay()
-	} else if quay.Status.CurrentVersion == "" {
+	} else if quay.Status.CurrentVersion != v1.QuayVersionCurrent {
 		overlay = upgradeOverlayDir()
 	} else {
 		overlay = overlayDir()

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -267,6 +267,7 @@ func withComponents(components []string) []client.Object {
 	return selectedComponents
 }
 
+// TODO(alecmerdler): Test image overrides...
 var inflateTests = []struct {
 	name         string
 	quayRegistry *v1.QuayRegistry


### PR DESCRIPTION
Fixes bug where we would only scale Quay app 'Deployment' to zero pods
during initial QuayRegistry creation, and not during every upgrade.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>