### PR TITLE
reconcile: scale deployment to zero during all upgrades (PROJQUAY-2121)

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -470,7 +470,7 @@ func Inflate(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, baseCo
 	var overlay string
 	if rolloutBlocked(quay) {
 		overlay = configEditorOnlyOverlay()
-	} else if quay.Status.CurrentVersion == "" {
+	} else if quay.Status.CurrentVersion != v1.QuayVersionCurrent {
 		overlay = upgradeOverlayDir()
 	} else {
 		overlay = overlayDir()


### PR DESCRIPTION
Fixes bug where we would only scale Quay app 'Deployment' to zero pods
during initial QuayRegistry creation, and not during every upgrade.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>