### PR TITLE
Updating the name of the catalogSource image

### DIFF
--- a/bundle/quay-operator.catalogsource.yaml
+++ b/bundle/quay-operator.catalogsource.yaml
@@ -4,4 +4,4 @@ metadata:
   name: quay-operator-tng
 spec:
   sourceType: grpc
-  image: quay.io/projectquay/quay-operator-index
+  image: quay.io/projectquay/quay-operator-catalog


### PR DESCRIPTION
I was working my way through the README and this image appears to have changed names on quay.io, it's also possible that I don't have access to something

Signed-off-by: crozzy <joseph.crosland@gmail.com>