### PR TITLE
adding soft topology spread constraints

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -14,6 +14,19 @@ spec:
       labels:
         quay-component: quay-app
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            quay-component: quay-app
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            quay-component: quay-app
       serviceAccountName: quay-app
       volumes:
         - name: config

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -15,6 +15,19 @@ spec:
         quay-component: clair-app
     spec:
       serviceAccountName: clair-app
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            quay-component: clair-app
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            quay-component: clair-app
       containers:
         - image: quay.io/projectquay/clair@sha256:77ffab0e44458d5725f2e9e5f2f57bda74b3bd073030611ca7cf5d753130c858
           imagePullPolicy: IfNotPresent

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -17,6 +17,19 @@ spec:
         quay-component: quay-mirror
     spec:
       serviceAccountName: quay-app
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            quay-component: quay-mirror
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            quay-component: quay-mirror
       volumes:
         - name: config
           secret:


### PR DESCRIPTION
Signed-off-by: Daniel Messer <dmesser@redhat.com>

Adding soft topology constraints to drive scheduling as much as possible for Quay and related components to remain available in the event of node or entire zone failures.

## Summary by Sourcery

Enhancements:
- Implement topology spread constraints for Quay, Clair, and Mirror deployments to ensure better distribution across Kubernetes zones and nodes