### PR TITLE
mirrorprobes: removing mirror pod probes (PROJQUAY-2226)

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -56,24 +56,6 @@ spec:
             - name: ENSURE_NO_MIGRATION
               value: "true"
           # TODO: Determine if we need to set resource requirements
-          startupProbe:
-            httpGet:
-              path: /health/instance
-              port: 8080
-              scheme: HTTP
-            timeoutSeconds: 20
-            periodSeconds: 15
-            failureThreshold: 10
-          readinessProbe:
-            httpGet:
-              path: /health/instance
-              port: 8080
-              scheme: HTTP
-          livelinessProbe:
-            httpGet:
-              path: /health/instance
-              port: 8080
-              scheme: HTTP
           volumeMounts:
             - name: config
               readOnly: false


### PR DESCRIPTION
Following feedback there is now ay of getting the health of the mirror
component. This PR removes the checks, essentially rolling back a change
made by https://github.com/quay/quay-operator/pull/427.

As soon as we have a proper way of checking for the mirror health we
will need to re-enable these.