### PR TITLE
Refactoring Ensure and Remove OwnerReference

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -105,17 +105,20 @@ func (r *QuayRegistryReconciler) checkRoutesAvailable(ctx *quaycontext.QuayRegis
 		ctx.ServerHostname = fieldGroup.ServerHostname
 	}
 
-	fakeRoute, err := v1.EnsureOwnerReference(quay, &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      quay.GetName() + "-test-route",
-			Namespace: quay.GetNamespace(),
+	fakeRoute := v1.EnsureOwnerReference(
+		quay, &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      quay.GetName() + "-test-route",
+				Namespace: quay.GetNamespace(),
+			},
+			Spec: routev1.RouteSpec{
+				To: routev1.RouteTargetReference{
+					Kind: "Service",
+					Name: "none",
+				},
+			},
 		},
-		Spec: routev1.RouteSpec{To: routev1.RouteTargetReference{Kind: "Service", Name: "none"}},
-	})
-
-	if err != nil {
-		return ctx, quay, err
-	}
+	)
 
 	if err := r.Client.Create(context.Background(), fakeRoute); err == nil || errors.IsAlreadyExists(err) {
 		r.Log.Info("cluster supports `Routes` API")

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -518,12 +518,7 @@ func Inflate(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, baseCo
 	}
 
 	for index, resource := range resources {
-		resource, err = v1.EnsureOwnerReference(quay, resource)
-		if err != nil {
-			return nil, err
-		}
-
-		resources[index] = resource
+		resources[index] = v1.EnsureOwnerReference(quay, resource)
 	}
 
 	return resources, err


### PR DESCRIPTION
These functions do not return errors as client.Object implements
meta.Accessor all the times (otherwise we have a compile error).

By removing the returned error we can clean up the code a little bit.