### PR TITLE
reconciler: Prevent unnecessary component enabling/disabling (PROJQUY-2198)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -252,24 +252,15 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 		}
 
-		if component.Managed && contains {
+		if component.Managed && contains && component.Kind != v1.ComponentRoute {
 			msg := fmt.Sprintf("%s component marked as managed, but `configBundleSecret` contains required fields", component.Kind)
 
-			updatedQuay, err = r.updateWithCondition(&quay, v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue, v1.ConditionReasonConfigInvalid, msg)
-			if err != nil {
-				log.Error(err, "failed to update `conditions` of `QuayRegistry`")
+			return r.reconcileWithCondition(&quay, v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue, v1.ConditionReasonConfigInvalid, msg)
 
-				return ctrl.Result{}, nil
-			}
 		} else if !component.Managed && v1.RequiredComponent(component.Kind) && !contains {
 			msg := fmt.Sprintf("required component `%s` marked as unmanaged, but `configBundleSecret` is missing necessary fields", component.Kind)
 
-			updatedQuay, err = r.updateWithCondition(&quay, v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue, v1.ConditionReasonConfigInvalid, msg)
-			if err != nil {
-				log.Error(err, "failed to update `conditions` of `QuayRegistry`")
-
-				return ctrl.Result{}, nil
-			}
+			return r.reconcileWithCondition(&quay, v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue, v1.ConditionReasonConfigInvalid, msg)
 		}
 	}
 

--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -74,6 +74,13 @@ func ReconfigureHandler(k8sClient client.Client) func(w http.ResponseWriter, r *
 		// Infer managed/unmanaged components from the given `config.yaml`.
 		newComponents := []v1.Component{}
 		for _, component := range quay.Spec.Components {
+
+			// HPA and Monitoring don't have fields associated with them so we skip. Route should not change based on config either since fields are optional when managed.
+			if component.Kind == v1.ComponentHPA || component.Kind == v1.ComponentMonitoring || component.Kind == v1.ComponentRoute {
+				newComponents = append(newComponents, component)
+				continue
+			}
+
 			contains, err := kustomize.ContainsComponentConfig(reconfigureRequest.Config, component)
 
 			if err != nil {

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -208,15 +208,6 @@ func ContainsComponentConfig(fullConfig map[string]interface{}, component v1.Com
 		fields = (&repomirror.RepoMirrorFieldGroup{}).Fields()
 	case v1.ComponentRoute:
 		fields = (&hostsettings.HostSettingsFieldGroup{}).Fields()
-
-		if component.Managed {
-			for i, field := range fields {
-				// SERVER_HOSTNAME is a special field which we allow when using managed `route` component.
-				if field == "SERVER_HOSTNAME" {
-					fields = append(fields[:i], fields[i+1:]...)
-				}
-			}
-		}
 	case v1.ComponentMonitoring:
 		return false, nil
 	case v1.ComponentTLS:

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -285,7 +285,7 @@ var containsComponentConfigTests = []struct {
 		"route",
 		true,
 		`SERVER_HOSTNAME: registry.skynet.com`,
-		false,
+		true,
 		nil,
 	},
 	{


### PR DESCRIPTION
- Prevent HPA, Route, and Monitoring components from being enabled/disabled based on received config.
- Block rollout on missing config fields