### PR TITLE
database: avoid regenerating password (PROJQUAY-2319)

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -38,6 +38,7 @@ const (
 	databaseSecretKey = "DATABASE_SECRET_KEY"
 	secretKey         = "SECRET_KEY"
 	dbURI             = "DB_URI"
+	dbRootPw          = "DB_ROOT_PW"
 
 	GrafanaDashboardConfigNamespace = "openshift-config-managed"
 )
@@ -64,6 +65,7 @@ func (r *QuayRegistryReconciler) checkManagedKeys(ctx *quaycontext.QuayRegistryC
 			ctx.DatabaseSecretKey = string(secret.Data[databaseSecretKey])
 			ctx.SecretKey = string(secret.Data[secretKey])
 			ctx.DbUri = string(secret.Data[dbURI])
+			ctx.DbRootPw = string(secret.Data[dbRootPw])
 			break
 		}
 	}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -29,7 +29,8 @@ type QuayRegistryContext struct {
 	SecretKey         string
 
 	// Database
-	DbUri string
+	DbUri    string
+	DbRootPw string
 }
 
 // NewQuayRegistryContext returns a fresh context for reconciling a `QuayRegistry`.

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -264,6 +264,14 @@ func KustomizationFor(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistr
 		return nil, err
 	}
 
+	if ctx.DbRootPw == "" {
+		rootpw, err := generateRandomString(32)
+		if err != nil {
+			return nil, err
+		}
+		ctx.DbRootPw = rootpw
+	}
+
 	quayConfigTLSSources := []string{}
 	if ctx.ClusterWildcardCert != nil {
 		quayConfigTLSSources = append(quayConfigTLSSources, "ocp-cluster-wildcard.cert="+string(ctx.ClusterWildcardCert))
@@ -292,6 +300,7 @@ func KustomizationFor(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistr
 						"DATABASE_SECRET_KEY=" + ctx.DatabaseSecretKey,
 						"SECRET_KEY=" + ctx.SecretKey,
 						"DB_URI=" + ctx.DbUri,
+						"DB_ROOT_PW=" + ctx.DbRootPw,
 					},
 				},
 			},
@@ -324,7 +333,7 @@ func KustomizationFor(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistr
 			componentPaths = append(componentPaths, filepath.Join("..", "components", string(component.Kind)))
 			managedFieldGroups = append(managedFieldGroups, fieldGroupNameFor(component.Kind))
 
-			componentConfigFiles, err := componentConfigFilesFor(component.Kind, quay, quayConfigFiles)
+			componentConfigFiles, err := componentConfigFilesFor(ctx, component.Kind, quay, quayConfigFiles)
 			if componentConfigFiles == nil || err != nil {
 				continue
 			}

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -252,7 +252,7 @@ func fieldGroupNameFor(component v1.ComponentKind) string {
 }
 
 // componentConfigFilesFor returns specific config files for managed components of a Quay registry.
-func componentConfigFilesFor(component v1.ComponentKind, quay *v1.QuayRegistry, configFiles map[string][]byte) (map[string][]byte, error) {
+func componentConfigFilesFor(qctx *quaycontext.QuayRegistryContext, component v1.ComponentKind, quay *v1.QuayRegistry, configFiles map[string][]byte) (map[string][]byte, error) {
 	switch component {
 	case v1.ComponentPostgres:
 		dbConfig, ok := configFiles["postgres.config.yaml"]
@@ -273,10 +273,7 @@ func componentConfigFilesFor(component v1.ComponentKind, quay *v1.QuayRegistry, 
 		databaseUsername := dbURI.User.Username()
 		databasePassword, _ := dbURI.User.Password()
 		databaseName := dbURI.Path[1:]
-		databaseRootPassword, err := generateRandomString(32)
-		if err != nil {
-			return nil, err
-		}
+		databaseRootPassword := qctx.DbRootPw
 
 		return map[string][]byte{
 			"database-username":      []byte(databaseUsername),


### PR DESCRIPTION
Proceed to store database root password the same way we do for the
DB_URI. By doing that we avoid postgres redeployment during every
reconcile cycle.