### PR TITLE
route: Make sure router name is removed from cluster hostname in OCP …

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -128,7 +128,10 @@ func (r *QuayRegistryReconciler) checkRoutesAvailable(ctx *quaycontext.QuayRegis
 
 			if len(fakeRoute.(*routev1.Route).Status.Ingress) > 0 {
 				ctx.SupportsRoutes = true
-				ctx.ClusterHostname = fakeRoute.(*routev1.Route).Status.Ingress[0].RouterCanonicalHostname
+				routerName := fakeRoute.(*routev1.Route).Status.Ingress[0].RouterName
+				routerCanonicalHostname := fakeRoute.(*routev1.Route).Status.Ingress[0].RouterCanonicalHostname
+				ctx.ClusterHostname = strings.TrimPrefix(routerCanonicalHostname, "router-"+routerName+".")
+				r.Log.Info("Detected cluster hostname " + ctx.ClusterHostname)
 
 				return true, nil
 			}


### PR DESCRIPTION
…4.8 (PROJQUAY-2306)

- Remove router name prefix from cluster hostname (this happens in OCP 4.8)

(cherry picked from commit 654f2c533824a120fb6b57b4158415b5d6b2dc54)