### PR TITLE
postgres: giving postgres room to graceful shutdown (PROJQUAY-2319)

### DIFF
--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         quay-component: clair-postgres
     spec:
+      terminationGracePeriodSeconds: 180
       serviceAccountName: clair-postgres
       volumes:
         - name: postgres-data

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     quay-component: postgres
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       quay-component: postgres
@@ -16,6 +18,7 @@ spec:
       labels:
         quay-component: postgres
     spec:
+      terminationGracePeriodSeconds: 180
       serviceAccountName: quay-database
       volumes:
         - name: postgres-data


### PR DESCRIPTION
Using Recreate strategy to bring postgres pod down before spawn a new
one (we can't have two pods sharing the same PVC) and giving the pods
some room to peacefully shutdown.