### PR TITLE
tls: executing pod termination (PROJQUAY-2428)

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -19,8 +19,12 @@ spec:
       serviceAccountName: quay-app
       volumes:
         - name: config
-          secret:
-            secretName: quay-config-secret
+          projected:
+            sources:
+            - secret:
+                name: quay-config-secret
+            - secret:
+                name: quay-config-tls
         - name: extra-ca-certs
           configMap:
             name: cluster-service-ca

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -21,15 +21,15 @@ spec:
       serviceAccountName: quay-app
       volumes:
         - name: config
-          secret:
-            secretName: quay-config-secret
-        - name: extra-ca-certs
           projected:
             sources:
-              - configMap:
-                  name: cluster-service-ca
+              - secret:
+                  name: quay-config-secret
               - secret:
                   name: quay-config-tls
+        - name: extra-ca-certs
+          configMap:
+            name: cluster-service-ca
       initContainers:
         - name: quay-mirror-init
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd

--- a/kustomize/overlays/current/unmanaged-tls/kustomization.yaml
+++ b/kustomize/overlays/current/unmanaged-tls/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../tmp
+patchesStrategicMerge:
+  - ./quay.deployment.patch.yaml

--- a/kustomize/overlays/current/unmanaged-tls/quay.deployment.patch.yaml
+++ b/kustomize/overlays/current/unmanaged-tls/quay.deployment.patch.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quay-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: quay-app
+          startupProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS
+          livelinessProbe:
+            httpGet:
+              path: /health/instance
+              port: 8443
+              scheme: HTTPS

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -104,6 +104,10 @@ func upgradeOverlayDir() string {
 	return filepath.Join(kustomizeDir(), "overlays", "current", "upgrade")
 }
 
+func unmanagedTLSOverlayDir() string {
+	return filepath.Join(kustomizeDir(), "overlays", "current", "unmanaged-tls")
+}
+
 func configEditorOnlyOverlay() string {
 	return filepath.Join(kustomizeDir(), "overlays", "current", "config-only")
 }
@@ -495,6 +499,8 @@ func Inflate(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, baseCo
 		overlay = configEditorOnlyOverlay()
 	} else if quay.Status.CurrentVersion != v1.QuayVersionCurrent {
 		overlay = upgradeOverlayDir()
+	} else if !v1.ComponentIsManaged(quay.Spec.Components, v1.ComponentTLS) {
+		overlay = unmanagedTLSOverlayDir()
 	} else {
 		overlay = overlayDir()
 	}

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -105,8 +105,10 @@ func FieldGroupFor(ctx *quaycontext.QuayRegistryContext, component v1.ComponentK
 
 		return fieldGroup, nil
 	case v1.ComponentRoute:
+		// sets tls termination in the load balancer if no cert has been provided.
+		terminateExternally := len(ctx.TLSCert) == 0 && len(ctx.TLSKey) == 0
 		fieldGroup := &hostsettings.HostSettingsFieldGroup{
-			ExternalTlsTermination: true,
+			ExternalTlsTermination: terminateExternally,
 			PreferredUrlScheme:     "https",
 			ServerHostname:         ctx.ServerHostname,
 		}

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/quay/quay-operator/apis/quay/v1"
@@ -68,9 +69,12 @@ var processTests = []struct {
 				Labels: map[string]string{"quay-component": "quay-app-route"},
 			},
 			Spec: route.RouteSpec{
+				Port: &route.RoutePort{
+					TargetPort: intstr.Parse("https"),
+				},
 				TLS: &route.TLSConfig{
-					Certificate: tlsCert,
-					Key:         tlsKey,
+					Termination:                   route.TLSTerminationPassthrough,
+					InsecureEdgeTerminationPolicy: route.InsecureEdgeTerminationPolicyRedirect,
 				},
 			},
 		},
@@ -92,17 +96,17 @@ var processTests = []struct {
 		},
 		&route.Route{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"quay-component": "quay-app-route"},
+				Labels: map[string]string{"quay-component": "quay-builder-route"},
 			},
 		},
 		&route.Route{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"quay-component": "quay-app-route"},
+				Labels: map[string]string{"quay-component": "quay-builder-route"},
 			},
 			Spec: route.RouteSpec{
 				TLS: &route.TLSConfig{
-					Certificate: tlsCert,
-					Key:         tlsKey,
+					Termination:                   route.TLSTerminationPassthrough,
+					InsecureEdgeTerminationPolicy: route.InsecureEdgeTerminationPolicyRedirect,
 				},
 			},
 		},


### PR DESCRIPTION
If TLS is unmanaged we expect the user to provide its own cert and key.
This PR changes the route to 'passthrough' and mounts the certificates
inside quay pod if TLS is unmanaged.