### PR TITLE
tls: Check for certs to mark tls as unmanaged (PROJQUAY-2428)

### DIFF
--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -18,8 +18,12 @@ spec:
     spec:
       volumes:
         - name: config
-          secret:
-            secretName: quay-config-secret
+          projected:
+            sources:
+            - secret:
+                name: quay-config-secret
+            - secret: 
+                name: quay-config-tls
         - name: extra-ca-certs
           configMap:
             name: cluster-service-ca

--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -106,7 +106,7 @@ func ReconfigureHandler(k8sClient client.Client) func(w http.ResponseWriter, r *
 				continue
 			}
 
-			contains, err := kustomize.ContainsComponentConfig(reconfigureRequest.Config, component)
+			contains, err := kustomize.ContainsComponentConfig(reconfigureRequest.Config, reconfigureRequest.Certs, component)
 
 			if err != nil {
 				log.Error(err, "failed to check `config.yaml` for component fieldgroup", "component", component.Kind)

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -189,7 +189,7 @@ func EnsureTLSFor(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry) (
 // ContainsComponentConfig accepts a full `config.yaml` and determines if it contains
 // the fieldgroup for the given component by comparing it with the fieldgroup defaults.
 // TODO: Replace this with function from `config-tool` library once implemented.
-func ContainsComponentConfig(fullConfig map[string]interface{}, component v1.Component) (bool, error) {
+func ContainsComponentConfig(fullConfig map[string]interface{}, certs map[string][]byte, component v1.Component) (bool, error) {
 	fields := []string{}
 
 	switch component.Kind {
@@ -211,7 +211,11 @@ func ContainsComponentConfig(fullConfig map[string]interface{}, component v1.Com
 	case v1.ComponentMonitoring:
 		return false, nil
 	case v1.ComponentTLS:
-		fields = []string{"EXTERNAL_TLS_TERMINATION"}
+		_, keyPresent := certs["ssl.key"]
+		_, certPresent := certs["ssl.cert"]
+		if certPresent && keyPresent {
+			return true, nil
+		}
 	default:
 		panic("unknown component: " + component.Kind)
 	}

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -327,10 +327,11 @@ func TestContainsComponentConfig(t *testing.T) {
 
 	for _, test := range containsComponentConfigTests {
 		var fullConfig map[string]interface{}
+		var certs map[string][]byte
 		err := yaml.Unmarshal([]byte(test.rawConfig), &fullConfig)
 		assert.Nil(err, test.name)
 
-		contains, err := ContainsComponentConfig(fullConfig, v1.Component{Kind: test.component, Managed: test.managed})
+		contains, err := ContainsComponentConfig(fullConfig, certs, v1.Component{Kind: test.component, Managed: test.managed})
 
 		if test.expectedError != nil {
 			assert.NotNil(err, test.name)


### PR DESCRIPTION
- TLS should determined to be unmanaged by the presence of tls cert and key, not on any particular field
- Fields from the config.yaml are no longer used to determine this