### PR TITLE
rbac: Backport rbac upgrade to 3.5 branch (PROJQUAY-2531)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           os=$(go env GOOS)
           arch=$(go env GOARCH)
-          curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
           mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
       - name: Tests

--- a/kustomize/base/quay.role.yaml
+++ b/kustomize/base/quay.role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: quay-serviceaccount

--- a/kustomize/base/quay.rolebinding.yaml
+++ b/kustomize/base/quay.rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: quay-secret-writer

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -11,7 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbac "k8s.io/api/rbac/v1beta1"
+	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
- Update rbac kind from v1beta1 to v1
- Backport https://github.com/quay/quay-operator/pull/519 to 3.5 branch