### PR TITLE
fix(bundle): use correct channel and operator name in subscription (PROJQUAY-2556)

### DIFF
--- a/bundle/quay-operator.subscription.yaml
+++ b/bundle/quay-operator.subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: quay-operator-tng
 spec:
-  channel: preview-3.6
+  channel: alpha
   installPlanApproval: Automatic
   name: quay-operator-tng
   source: quay-operator-tng

--- a/bundle/quay-operator.subscription.yaml
+++ b/bundle/quay-operator.subscription.yaml
@@ -1,11 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: quay-tng
+  name: quay-operator-tng
 spec:
-  channel: alpha
+  channel: preview-3.6
   installPlanApproval: Automatic
-  name: quay-tng
-  source: quay-operator
+  name: quay-operator-tng
+  source: quay-operator-tng
   sourceNamespace: openshift-marketplace
-  startingCSV: quay-operator.v0.0.1
+  startingCSV: quay-operator.v3.6.0-alpha.4

--- a/bundle/upstream/metadata/annotations.yaml
+++ b/bundle/upstream/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: preview-3.6
-  operators.operatorframework.io.bundle.channels.v1: preview-3.6
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
the previously used values did not match the ones specified in the upstream manifests.