### PR TITLE
fix(Dockerfile): upgrade golang in upstream Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 COPY go.mod go.mod


### PR DESCRIPTION
This matches the golang version with [Dockerfile @ master](https://github.com/quay/quay-operator/). Project doesn't build with with golang 1.13, see https://github.com/kubernetes-sigs/cluster-api/issues/4096

FTR, here's the error:
```
Step 10/15 : RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o manager main.go
 ---> Running in 7b4f402b9966
# sigs.k8s.io/controller-runtime/pkg/manager
vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go:53:2: duplicate method Start
The command '/bin/sh -c CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o manager main.go' returned a non-zero code: 2

Error: Process completed with exit code 2.
```