### PR TITLE
chore: github workflow to publish container images (PROJQUAY-2556)

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,0 +1,169 @@
+---
+name: Build and Publish Images
+
+on:
+  push:
+    branches:
+      - redhat-3.5
+
+jobs:
+  quay-image:
+    name: Calculate Quay Image Digest
+    runs-on: 'ubuntu-latest'
+    outputs:
+      digest: ${{ steps.set-output.outputs.digest }}
+    env:
+      IMAGE_REGISTRY: quay.io/projectquay
+      TAG: 3.5-unstable
+    steps:
+      - name: Pull Image
+        id: pull-image
+        run: docker pull "${IMAGE_REGISTRY}"/quay:"${TAG}"
+      - name: Set Output
+        id: set-output
+        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay:${TAG})"
+
+  clair-image:
+    name: Calculate Clair Image Digest
+    runs-on: 'ubuntu-latest'
+    outputs:
+      digest: ${{ steps.set-output.outputs.digest }}
+    env:
+      IMAGE_REGISTRY: quay.io/projectquay
+      TAG: 3.5-unstable
+    steps:
+      - name: Pull Image
+        id: pull-image
+        run: docker pull "${IMAGE_REGISTRY}"/clair:"${TAG}"
+      - name: Set Output
+        id: set-output
+        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/clair:${TAG})"
+
+  builder-image:
+    name: Calculate Builder Image Digest
+    runs-on: 'ubuntu-latest'
+    outputs:
+      digest: ${{ steps.set-output.outputs.digest }}
+    env:
+      IMAGE_REGISTRY: quay.io/projectquay
+      TAG: 3.5-unstable
+    steps:
+      - name: Pull Image
+        id: pull-image
+        run: docker pull "${IMAGE_REGISTRY}"/quay-builder:"${TAG}"
+      - name: Set Output
+        id: set-output
+        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder:${TAG})"
+
+  qemu-builder-image:
+    name: Calculate Qemu Builder Image Digest
+    runs-on: 'ubuntu-latest'
+    outputs:
+      digest: ${{ steps.set-output.outputs.digest }}
+    env:
+      IMAGE_REGISTRY: quay.io/projectquay
+    steps:
+      - name: Pull Image
+        id: pull-image
+        run: docker pull "${IMAGE_REGISTRY}"/quay-builder-qemu:latest
+      - name: Set Output
+        id: set-output
+        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder-qemu:latest)"
+
+  operator-image:
+    name: Publish Operator Image
+    runs-on: 'ubuntu-latest'
+    outputs:
+      digest: ${{ steps.set-output.outputs.digest }}
+    env:
+      OPERATOR_IMAGE: quay.io/projectquay/quay-operator:3.5-unstable
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ env.OPERATOR_IMAGE }}
+
+      - name: Set digest output
+        id: set-output
+        run: |
+          docker pull "${OPERATOR_IMAGE}"
+          echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${OPERATOR_IMAGE})"
+
+  operator-index-images:
+    name: Publish Catalog Index Image
+    runs-on: 'ubuntu-latest'
+    needs: [quay-image, clair-image, builder-image, qemu-builder-image, operator-image]
+    env:
+      OPERATOR_NAME: quay-operator-test
+      BUNDLE: quay.io/projectquay/quay-operator-bundle
+      INDEX: quay.io/projectquay/quay-operator-index
+      TAG: 3.5-unstable
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Update CSV Image Versions
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq eval -i '
+              .metadata.name = strenv(OPERATOR_NAME) |
+              .metadata.annotations.quay-version = strenv(TAG) |
+              .metadata.annotations.containerImage = "${{needs.operator-image.outputs.digest}}" |
+              del(.spec.replaces) |
+              .spec.install.spec.deployments[0].name = strenv(OPERATOR_NAME) |
+              .spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "${{needs.operator-image.outputs.digest}}" |
+              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[4].value = "${{needs.quay-image.outputs.digest}}" |
+              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[5].value = "${{needs.clair-image.outputs.digest}}" |
+              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[6].value = "${{needs.builder-image.outputs.digest}}" |
+              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[7].value = "${{needs.qemu-builder-image.outputs.digest}}" |
+              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[8].value = "centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33" |
+              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[9].value = "centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542"
+              ' bundle/downstream/manifests/quay-operator.clusterserviceversion.yaml
+
+      - name: Update Bundle Annotations
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq eval -i '
+              .annotations."operators.operatorframework.io.bundle.channel.default.v1" = "test" |
+              .annotations."operators.operatorframework.io.bundle.channels.v1" = "test" |
+              .annotations."operators.operatorframework.io.bundle.package.v1" = strenv(OPERATOR_NAME)
+              ' bundle/downstream/metadata/annotations.yaml
+
+      - name: Publish Bundle Image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./bundle/downstream
+          file: ./bundle/Dockerfile
+          push: true
+          tags: ${{ env.BUNDLE }}:${{ env.TAG }}
+
+      - name: Publish Catalog Index
+        env:
+          OPM_DOWNLOAD_URL: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.6/
+          OPM_TAR: opm-linux.tar.gz
+        run: |
+          wget -q "${OPM_DOWNLOAD_URL}/${OPM_TAR}"
+          tar xvf "${OPM_TAR}"
+          ./opm index add --build-tool docker --bundles "${BUNDLE}:${TAG}" --tag "${INDEX}:${TAG}"
+          docker push "${INDEX}:${TAG}"


### PR DESCRIPTION
For now this targets branch `redhat-3.5`, but we can reuse it for any branch (as long as we update the image tags accordingly). The end goal is to use the builds produced by this workflow on a nightly job that will deploy Quay using this operator.

One important thing to notice is that related projects (clair, quay-builder, etc) also need to publish an equivalent `3.5` image. I'll have PRs open and merged for these projects before merging this one. 

Example of a [successful workflow](https://github.com/flavianmissi/quay-operator/actions/runs/1257257820) (using my own registry instead of `projectquay`).