### PR TITLE
tls: mounting config tls under extra_ca_certs (PROJQUAY-2575)

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -28,8 +28,12 @@ spec:
               - secret:
                   name: quay-config-tls
         - name: extra-ca-certs
-          configMap:
-            name: cluster-service-ca
+          projected:
+            sources:
+              - configMap:
+                  name: cluster-service-ca
+              - secret:
+                  name: quay-config-tls
       initContainers:
         - name: quay-mirror-init
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd


### PR DESCRIPTION
Secret quay-config-tls contains the cluster wildcart certs and must be
mounted also under /conf/stack/extra_ca_certs.