### PR TITLE
redis: Mark Redis as a required component (PROJQUAY-2455)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -65,6 +65,7 @@ var requiredComponents = []ComponentKind{
 	ComponentPostgres,
 	ComponentObjectStorage,
 	ComponentRoute,
+	ComponentRedis,
 }
 
 const (


### PR DESCRIPTION
- Set Redis as a required component for a QuayRegistry deployment
- Block reconcile when config.yaml is missing fields for unmanaged Redis