### PR TITLE
migration: moving strategy to Recreate before upgrading (PROJQUAY-2586)

### DIFF
--- a/controllers/redhatcop/quayecosystem_controller.go
+++ b/controllers/redhatcop/quayecosystem_controller.go
@@ -208,6 +208,9 @@ func (r *QuayEcosystemReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 		}
 		postgresDeployment.Spec.Template.Spec.Containers[0].Env = envVars
+		postgresDeployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		}
 
 		if err := r.Client.Update(ctx, &postgresDeployment); err != nil {
 			msg := "failed to update managed Postgres `Deployment` with `POSTGRESQL_ADMIN_PASSWORD` environment variable"


### PR DESCRIPTION
During upgrade from QuayEcosystem into QuayRegistry postgres deployment
is updated to include an extra env variable:

- POSTGRESQL_ADMIN_PASSWORD

Once the deployment is updated a new replica for the database is created
but it fails to roll out due to PVC not allowing multiple attachments.

This PR forces the deployment to adopt Recreate strategy as it is the
default in 3.6 postgres deployment.