### PR TITLE
upgrades: Fix CRD schema validation during upgrade (PROJQUAY-2587)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -156,7 +156,7 @@ type QuayRegistryStatus struct {
 	// Conditions represent the conditions that a QuayRegistry can have.
 	Conditions []Condition `json:"conditions,omitempty"`
 	// ComponentConditions holds the current condition for all component objects.
-	UnhealthyComponents UnhealthyComponents `json:"unhealthyComponents"`
+	UnhealthyComponents UnhealthyComponents `json:"unhealthyComponents,omitempty"`
 }
 
 // GetCondition retrieves the condition with the matching type from the given list.

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -295,8 +295,6 @@ spec:
                       type: object
                     type: array
                 type: object
-            required:
-            - unhealthyComponents
             type: object
         type: object
     served: true

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,8 +2,8 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/quay.redhat.com.quay.redhat.com_quayregistries.yaml
-- bases/redhatcop.redhat.io.quay.redhat.com_quayecosystems.yaml
+  - bases/quay.redhat.com_quayregistries.yaml
+  - bases/redhatcop.redhat.io.quay.redhat.com_quayecosystems.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
@@ -21,4 +21,4 @@ patchesStrategicMerge:
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
-- kustomizeconfig.yaml
+  - kustomizeconfig.yaml

--- a/config/crd/patches/cainjection_in_quayregistries.yaml
+++ b/config/crd/patches/cainjection_in_quayregistries.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: quayregistries.quay.redhat.com.quay.redhat.com
+  name: quayregistries.quay.redhat.com

--- a/config/crd/patches/webhook_in_quayregistries.yaml
+++ b/config/crd/patches/webhook_in_quayregistries.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: quayregistries.quay.redhat.com.quay.redhat.com
+  name: quayregistries.quay.redhat.com
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/quayregistry_editor_role.yaml
+++ b/config/rbac/quayregistry_editor_role.yaml
@@ -4,21 +4,21 @@ kind: ClusterRole
 metadata:
   name: quayregistry-editor-role
 rules:
-- apiGroups:
-  - quay.redhat.com.quay.redhat.com
-  resources:
-  - quayregistries
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - quay.redhat.com.quay.redhat.com
-  resources:
-  - quayregistries/status
-  verbs:
-  - get
+  - apiGroups:
+      - quay.redhat.com
+    resources:
+      - quayregistries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - quay.redhat.com
+    resources:
+      - quayregistries/status
+    verbs:
+      - get

--- a/config/rbac/quayregistry_viewer_role.yaml
+++ b/config/rbac/quayregistry_viewer_role.yaml
@@ -4,17 +4,17 @@ kind: ClusterRole
 metadata:
   name: quayregistry-viewer-role
 rules:
-- apiGroups:
-  - quay.redhat.com.quay.redhat.com
-  resources:
-  - quayregistries
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - quay.redhat.com.quay.redhat.com
-  resources:
-  - quayregistries/status
-  verbs:
-  - get
+  - apiGroups:
+      - quay.redhat.com
+    resources:
+      - quayregistries
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - quay.redhat.com
+    resources:
+      - quayregistries/status
+    verbs:
+      - get


### PR DESCRIPTION
- Remove unhealthyComponents as a required field to allow for pre-3.6 CRs to be valid during upgrade procedure
- Fix incorrect api group declarations