### PR TITLE
database: avoid redeploy postgres during reconcile (PROJQUAY-2603)

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -40,7 +40,6 @@ const (
 	configSecretPrefix                = "quay-config-secret"
 	registryHostnameAnnotation        = "quay-registry-hostname"
 	buildManagerHostnameAnnotation    = "quay-buildmanager-hostname"
-	managedFieldGroupsAnnotation      = "quay-managed-fieldgroups"
 	operatorServiceEndpointAnnotation = "quay-operator-service-endpoint"
 
 	podNamespaceKey = "MY_POD_NAMESPACE"
@@ -331,11 +330,9 @@ func KustomizationFor(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistr
 	}
 
 	componentPaths := []string{}
-	managedFieldGroups := []string{}
 	for _, component := range quay.Spec.Components {
 		if component.Managed {
 			componentPaths = append(componentPaths, filepath.Join("..", "components", string(component.Kind)))
-			managedFieldGroups = append(managedFieldGroups, fieldGroupNameFor(component.Kind))
 
 			componentConfigFiles, err := componentConfigFilesFor(ctx, component.Kind, quay, quayConfigFiles)
 			if componentConfigFiles == nil || err != nil {
@@ -383,7 +380,6 @@ func KustomizationFor(ctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistr
 			QuayRegistryNameLabel: quay.GetName(),
 		},
 		CommonAnnotations: map[string]string{
-			managedFieldGroupsAnnotation:      strings.ReplaceAll(strings.Join(managedFieldGroups, ","), ",,", ","),
 			registryHostnameAnnotation:        ctx.ServerHostname,
 			buildManagerHostnameAnnotation:    strings.Split(ctx.BuildManagerHostname, ":")[0],
 			operatorServiceEndpointAnnotation: operatorServiceEndpoint(),

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -440,10 +440,13 @@ func TestEnsureTLSFor(t *testing.T) {
 				assert.Equal(string(test.providedCertKeyPair[1]), string(tlsKey), test.name)
 			}
 
-			shared.ValidateCertPairWithHostname(tlsCert, tlsKey, test.serverHostname, fieldGroupNameFor("route"))
+			fgn, err := v1.FieldGroupNameFor(v1.ComponentRoute)
+			assert.Nil(err, "error not nil: %s", err)
+
+			shared.ValidateCertPairWithHostname(tlsCert, tlsKey, test.serverHostname, fgn)
 
 			if test.buildManagerHostname != "" {
-				shared.ValidateCertPairWithHostname(tlsCert, tlsKey, test.buildManagerHostname, fieldGroupNameFor("route"))
+				shared.ValidateCertPairWithHostname(tlsCert, tlsKey, test.buildManagerHostname, fgn)
 			}
 		}
 	}


### PR DESCRIPTION
Operator was setting an annotation in all created objects. This
annotation was not useful by anything except by the config tool.

This PR makes the annotation to be created only in the config tool
deployment.