### PR TITLE
status: omit conflict errors (PROJQUAY-2610)

### DIFF
--- a/controllers/quay/quayregistry_status_controller.go
+++ b/controllers/quay/quayregistry_status_controller.go
@@ -111,6 +111,10 @@ func (q *QuayRegistryStatusReconciler) Reconcile(
 
 	reg.Status.UnhealthyComponents = uc
 	if err := q.Client.Status().Update(ctx, &reg); err != nil {
+		if errors.IsConflict(err) {
+			log.Info("skipping status reconcile due to conflict, will retry")
+			return reschedule, nil
+		}
 		log.Error(err, "unexpected error updating component conditions")
 		return reschedule, nil
 	}


### PR DESCRIPTION
These errors happen because we have two concurrent reconcilers operating
with the same resource. This is a design fault that need to be addressed
in the future. This PR omits conflict errors during status updates as
these are constantly retried.