### PR TITLE
fix(workflow): use correct clair and builder-qemu tags

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -30,7 +30,7 @@ jobs:
       digest: ${{ steps.set-output.outputs.digest }}
     env:
       IMAGE_REGISTRY: quay.io/projectquay
-      TAG: 3.5-unstable
+      TAG: nightly
     steps:
       - name: Pull Image
         id: pull-image

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -62,13 +62,14 @@ jobs:
       digest: ${{ steps.set-output.outputs.digest }}
     env:
       IMAGE_REGISTRY: quay.io/projectquay
+      TAG: main
     steps:
       - name: Pull Image
         id: pull-image
-        run: docker pull "${IMAGE_REGISTRY}"/quay-builder-qemu:latest
+        run: docker pull "${IMAGE_REGISTRY}"/quay-builder-qemu:"${TAG}"
       - name: Set Output
         id: set-output
-        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder-qemu:latest)"
+        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder-qemu:${TAG})"
 
   operator-image:
     name: Publish Operator Image


### PR DESCRIPTION
clair is in the process of removing their redhat-* branches, and asked
us to use their nightly instead.

I expected some builds to fail at first, but clair and builder-qemu are the exception - clair is removing their redhat-* branches, and the builder-qemu uses main instead of latest.
The rest of the expected tags will shortly be built manually so that we don't  depend on pushes to our various redhat-3.5 branches.

Hope this makes sense, hit me up on slack otherwise.