### PR TITLE
refactor(build-workflow): infer image tag from branch name (PROJQUAY-2612)

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -111,7 +111,8 @@ jobs:
     outputs:
       digest: ${{ steps.set-output.outputs.digest }}
     env:
-      OPERATOR_IMAGE: quay.io/projectquay/quay-operator:3.5-unstable
+      OPERATOR_IMAGE: quay.io/projectquay/quay-operator:${{needs.set-version.outputs.tag}}
+    needs: set-version
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - redhat-** # IMPORTANT! this must match the .jobs.set-version.env.BRANCH_PREFIX env (save the **).
-      - build-workflow-branch-trigger
 
 jobs:
   set-version:

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -139,13 +139,12 @@ jobs:
   operator-index-images:
     name: Publish Catalog Index Image
     runs-on: 'ubuntu-latest'
-    needs: [quay-image, clair-image, builder-image, qemu-builder-image, operator-image]
+    needs: [quay-image, clair-image, builder-image, qemu-builder-image, operator-image, set-version]
     env:
       OPERATOR_NAME: quay-operator-test
       BUNDLE: quay.io/projectquay/quay-operator-bundle
       INDEX: quay.io/projectquay/quay-operator-index
       TAG: ${{needs.set-version.outputs.tag}}
-    needs: set-version
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -4,9 +4,42 @@ name: Build and Publish Images
 on:
   push:
     branches:
-      - redhat-3.5
+      - redhat-** # IMPORTANT! this must match the .jobs.set-version.env.BRANCH_PREFIX env (save the **).
+      - build-workflow-branch-trigger
 
 jobs:
+  set-version:
+    name: Set version from branch name
+    env:
+      BRANCH_PREFIX: redhat- # IMPORTANT! this must match the .on.push.branches prefix!
+      REGISTRY: quay.io/projectquay
+      REPO_NAME: ${{ github.event.repository.name }}
+      TAG_SUFFIX: -unstable
+    outputs:
+      tag: ${{ steps.format-tag.outputs.tag }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Format version
+        id: version-from-branch
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          echo "::set-output name=version::${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}"
+
+      - name: Format tag with version
+        id: format-tag
+        run: echo "::set-output name=tag::${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}"
+
+  echo-job:
+    name: echo tag
+    needs: set-version
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: echo
+        run: echo "${{needs.set-version.outputs.tag}}"
+
   quay-image:
     name: Calculate Quay Image Digest
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -3,6 +3,7 @@ name: Build and Publish Images
 
 on:
   push:
+    # NOTE: if you trigger this on your branch, ensure its name follows the redhat-X.Y format!
     branches:
       - redhat-** # IMPORTANT! this must match the .jobs.set-version.env.BRANCH_PREFIX env (save the **).
 

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -31,14 +31,6 @@ jobs:
         id: format-tag
         run: echo "::set-output name=tag::${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}"
 
-  echo-job:
-    name: echo tag
-    needs: set-version
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: echo
-        run: echo "${{needs.set-version.outputs.tag}}"
-
   quay-image:
     name: Calculate Quay Image Digest
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -46,7 +46,8 @@ jobs:
       digest: ${{ steps.set-output.outputs.digest }}
     env:
       IMAGE_REGISTRY: quay.io/projectquay
-      TAG: 3.5-unstable
+      TAG: ${{needs.set-version.outputs.tag}}
+    needs: set-version
     steps:
       - name: Pull Image
         id: pull-image
@@ -78,7 +79,8 @@ jobs:
       digest: ${{ steps.set-output.outputs.digest }}
     env:
       IMAGE_REGISTRY: quay.io/projectquay
-      TAG: 3.5-unstable
+      TAG: ${{needs.set-version.outputs.tag}}
+    needs: set-version
     steps:
       - name: Pull Image
         id: pull-image
@@ -142,7 +144,8 @@ jobs:
       OPERATOR_NAME: quay-operator-test
       BUNDLE: quay.io/projectquay/quay-operator-bundle
       INDEX: quay.io/projectquay/quay-operator-index
-      TAG: 3.5-unstable
+      TAG: ${{needs.set-version.outputs.tag}}
+    needs: set-version
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This change ties the build workflow to the name of the branches it runs against.
In a future where downstream releases are fully automated, we should probably tag the redhat-* branches (for everything we want built, alpha, release candidates, etc). When we do this, this workflow should be updated to get triggered when new tags are created, so that it's more robust.

Successful workflow run: https://github.com/flavianmissi/quay-operator/actions/runs/1295760888