### PR TITLE
fix(build): use bundle image digest instead of tag (PROJQUAY-2556)

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -159,6 +159,12 @@ jobs:
           push: true
           tags: ${{ env.BUNDLE }}:${{ env.TAG }}
 
+      - name: Get bundle image digest
+        id: bundle-image
+        run: |
+          docker pull "${OPERATOR_IMAGE}"
+          echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.BUNDLE }}:${{ env.TAG })"
+
       - name: Publish Catalog Index
         env:
           OPM_DOWNLOAD_URL: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.6/
@@ -166,5 +172,5 @@ jobs:
         run: |
           wget -q "${OPM_DOWNLOAD_URL}/${OPM_TAR}"
           tar xvf "${OPM_TAR}"
-          ./opm index add --build-tool docker --bundles "${BUNDLE}:${TAG}" --tag "${INDEX}:${TAG}"
+          ./opm index add --build-tool docker --bundles "${{steps.bundle-image.outputs.digest}}" --tag "${INDEX}:${TAG}"
           docker push "${INDEX}:${TAG}"

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -26,6 +26,7 @@ jobs:
       QUAY_SAMPLE_PATH: ./config/samples/managed.quayregistry.yaml
       OPERATOR_PKG_NAME: quay-operator-test
       NAMESPACE: quay-operator-e2e-nightly
+      WAIT_TIMEOUT: 10m
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -95,35 +96,35 @@ jobs:
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-database --timeout=3m
+          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-database --timeout=${{ env.WAIT_TIMEOUT }}
 
       - name: Ensure redis rollout
         uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-redis --timeout=3m
+          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-redis --timeout=${{ env.WAIT_TIMEOUT }}
 
       - name: Ensure config editor rollout
         uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-config-editor --timeout=3m
+          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-config-editor --timeout=${{ env.WAIT_TIMEOUT }}
 
       - name: Ensure Quay rollout
         uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-app --timeout=3m
+          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-app --timeout=${{ env.WAIT_TIMEOUT }}
 
       - name: Ensure mirror rollout
         uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-mirror --timeout=3m
+          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-mirror --timeout=${{ env.WAIT_TIMEOUT }}
 
       - name: Delete Quay deployment
         uses: actions-hub/kubectl@master


### PR DESCRIPTION
turns out the image tag isn't always pulled, so we need a digest to always get the newest version of the tag.
also increase e2e checks timeout - the mirror isn't always ready within the previously set 3 minutes.