### PR TITLE
fix: use correct pull syntax on workflow (PROJQUAY-2556)

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -190,7 +190,7 @@ jobs:
       - name: Get bundle image digest
         id: bundle-image
         run: |
-          docker pull ${{ env.BUNDLE }}:${{ env.TAG }})
+          docker pull ${{ env.BUNDLE }}:${{ env.TAG }}
           echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.BUNDLE }}:${{ env.TAG }})"
 
       - name: Publish Catalog Index


### PR DESCRIPTION
TODO:
* backport to redhat-3.5
* backport to redhat-3.6

passing build: https://github.com/flavianmissi/quay-operator/actions/runs/1307924371