### PR TITLE
workflows: improve PR/commit check (PROJQUAY-2623)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,19 +32,3 @@ jobs:
           export PATH=$PATH:/usr/local/kubebuilder/bin
       - name: Tests
         run: go test -v ./...
-
-  commit-check:
-    name: Commit Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: commit check
-        uses: gsactions/commit-message-checker@v1
-        with:
-          pattern: |
-            ^(.*):\s*(.*)\s\(PROJQUAY-[0-9]+\)(\n.*)*$
-          error: 'Commit must begin with <scope>: <subject> (PROJQUAY-####)'
-          flags: 'gm'
-          excludeTitle: true
-          excludeDescription: true
-          checkAllCommitMessages: true
-          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request_linting.yaml
+++ b/.github/workflows/pull_request_linting.yaml
@@ -1,0 +1,36 @@
+name: Pull Request Lint
+
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  ticket-check:
+    name: ticket check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for ticket
+        uses: neofinancial/ticket-check-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://issues.redhat.com/browse/PROJQUAY-%ticketNumber%'
+          ticketPrefix: 'PROJQUAY-'
+          titleRegex: 'PROJQUAY-(?<ticketNumber>\d+)'
+          titleFormat: '%title% (%prefix%%id%)'
+          branchRegex: 'PROJQUAY-(?<ticketNumber>\d+)'
+          bodyRegex: 'PROJQUAY-(?<ticketNumber>\d+)'
+          bodyURLRegex: 'http(s?):\/\/(issues.redhat.com)(\/browse)\/(PROJQUAY\-)(?<ticketNumber>\d+)'
+          exemptUsers: 'dependabot'
+
+  conventional-commit:
+    runs-on: ubuntu-latest
+    name: conventional commit check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: check conventional commit
+        id: check-for-cc
+        uses: agenthunt/conventional-commit-checker-action@v1.0.0
+        with:
+          pr-body-regex: '(.*)?'


### PR DESCRIPTION
the previous commit check, although simple, was a bit unpredictable.
this splits the check into two distinct jobs:

 - JIRA ticket presence check
 - conventional commit format

making the check a lot more robust.