### PR TITLE
controller: correctly update registry endpoint in registry status

### DIFF
--- a/apis/quay/v1/quayregistry_types_test.go
+++ b/apis/quay/v1/quayregistry_types_test.go
@@ -370,24 +370,24 @@ var ensureRegistryEndpointTests = []struct {
 	expectedOk bool
 }{
 	{
-		"SupportsRoutesChanged",
-		QuayRegistry{
+		name: "SupportsRoutesChanged",
+		quay: QuayRegistry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "ns-1",
 			},
 		},
-		quaycontext.QuayRegistryContext{
+		ctx: quaycontext.QuayRegistryContext{
 			SupportsRoutes:  true,
 			ClusterHostname: "apps.example.com",
 		},
-		nil,
-		"https://test-quay-ns-1.apps.example.com",
-		false,
+		config:     nil,
+		expected:   "https://test-quay-ns-1.apps.example.com",
+		expectedOk: false,
 	},
 	{
-		"SupportsRoutesSame",
-		QuayRegistry{
+		name: "SupportsRoutesSame",
+		quay: QuayRegistry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "ns-1",
@@ -396,45 +396,45 @@ var ensureRegistryEndpointTests = []struct {
 				RegistryEndpoint: "https://test-quay-ns-1.apps.example.com",
 			},
 		},
-		quaycontext.QuayRegistryContext{
+		ctx: quaycontext.QuayRegistryContext{
 			SupportsRoutes:  true,
 			ClusterHostname: "apps.example.com",
 		},
-		map[string]interface{}{},
-		"https://test-quay-ns-1.apps.example.com",
-		true,
+		config:     map[string]interface{}{},
+		expected:   "https://test-quay-ns-1.apps.example.com",
+		expectedOk: true,
 	},
 	{
-		"DoesNotSupportRoutes",
-		QuayRegistry{
+		name: "DoesNotSupportRoutes",
+		quay: QuayRegistry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "ns-1",
 			},
 		},
-		quaycontext.QuayRegistryContext{},
-		map[string]interface{}{},
-		"",
-		true,
+		ctx:        quaycontext.QuayRegistryContext{},
+		config:     map[string]interface{}{},
+		expected:   "",
+		expectedOk: true,
 	},
 	{
-		"ServerHostnameInConfigChanged",
-		QuayRegistry{
+		name: "ServerHostnameInConfigChanged",
+		quay: QuayRegistry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "ns-1",
 			},
 		},
-		quaycontext.QuayRegistryContext{},
-		map[string]interface{}{
+		ctx: quaycontext.QuayRegistryContext{},
+		config: map[string]interface{}{
 			"SERVER_HOSTNAME": "registry.example.com",
 		},
-		"https://registry.example.com",
-		false,
+		expected:   "https://registry.example.com",
+		expectedOk: false,
 	},
 	{
-		"ServerHostnameInConfigSame",
-		QuayRegistry{
+		name: "ServerHostnameInConfigSame",
+		quay: QuayRegistry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "ns-1",
@@ -443,12 +443,12 @@ var ensureRegistryEndpointTests = []struct {
 				RegistryEndpoint: "https://registry.example.com",
 			},
 		},
-		quaycontext.QuayRegistryContext{},
-		map[string]interface{}{
+		ctx: quaycontext.QuayRegistryContext{},
+		config: map[string]interface{}{
 			"SERVER_HOSTNAME": "registry.example.com",
 		},
-		"https://registry.example.com",
-		true,
+		expected:   "https://registry.example.com",
+		expectedOk: true,
 	},
 }
 


### PR DESCRIPTION
also name EnsureRegistryEndpoint test struct fields.

fixes PROJQUAY-1936

### Testing

Prerequisites: running operator against an openshift cluster using the `master` branch; deployed quay registry.

Check the initial `status.registryEndpoint`:
```
oc get quayregistry skynet -o jsonpath='{.status.registryEndpoint}'
```

Create a new config bundle secret:
```
$ echo "apiVersion: v1
data:
  config.yaml: QUxMT1dfUFVMTFNfV0lUSE9VVF9TVFJJQ1RfTE9HR0lORzogZmFsc2UKQVVUSEVOVElDQVRJT05fVFlQRTogRGF0YWJhc2UKREVGQVVMVF9UQUdfRVhQSVJBVElPTjogMncKRU5URVJQUklTRV9MT0dPX1VSTDogL3N0YXRpYy9pbWcvcXVheS1ob3Jpem9udGFsLWNvbG9yLnN2ZwpGRUFUVVJFX0JVSUxEX1NVUFBPUlQ6IGZhbHNlCkZFQVRVUkVfRElSRUNUX0xPR0lOOiB0cnVlCkZFQVRVUkVfTUFJTElORzogZmFsc2UKUkVHSVNUUllfVElUTEU6IFF1YXkKUkVHSVNUUllfVElUTEVfU0hPUlQ6IFF1YXkKU0VUVVBfQ09NUExFVEU6IHRydWUKVEFHX0VYUElSQVRJT05fT1BUSU9OUzoKLSAydwpURUFNX1JFU1lOQ19TVEFMRV9USU1FOiA2MG0KVEVTVElORzogZmFsc2UKU0VSVkVSX0hPU1ROQU1FOiBza2FpbmV0LXF1YXktdGVzdC5hcHBzLmZtaXNzaS1kZXYucXVheS5kZXZjbHVzdGVyLm9wZW5zaGlmdC5jb20K
kind: Secret
metadata:
  name: skynet-config-bundle-666
type: Opaque" > secret.yaml
$ oc create -f secret.yaml
```
Now update the quay registry `spec.configBundleSecret` with the secret we created above:
```
$ oc edit quayregistry skynet
  [...]
  configBundleSecret: skynet-config-bundle-666
  [...]
```
Save and quit.
Wait several seconds, then check the `status.registryEndpoint` again:
```
oc get quayregistry skynet -o jsonpath='{.status.registryEndpoint}'
```
You'll see that nothing changed.

Now switch back to the previous config bundle secret. 
Checkout this PR and switch to the new config bundle secret. This time, the `status.registryEndpoint` will have been updated 🎉 