### PR TITLE
upgradejob: decrease resource requests (PROJQUAY-2688)

### DIFF
--- a/kustomize/base/upgrade.job.yaml
+++ b/kustomize/base/upgrade.job.yaml
@@ -51,8 +51,8 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: 2000m
-              memory: 8Gi
+              cpu: 1000m
+              memory: 3Gi
             limits:
               cpu: 2000m
               memory: 8Gi


### PR DESCRIPTION
Decreased resource.requests for the upgrade job. As it runs python
alembic the bulk of the load is in Postgres anyways. This pr does not
decrease the resource.limits for conservative purposes.