### PR TITLE
chore: Increase the maximum number of PostgreSQL connections for Clair (PROJQUAY-2739)

### DIFF
--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: postgres
             - name: POSTGRESQL_ADMIN_PASSWORD
               value: postgres
+            - name: POSTGRESQL_MAX_CONNECTIONS
+              value: "1000"
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data


### PR DESCRIPTION
Previously, the number of PostgreSQL connections was set to 100 which is the default value. This value is too low and sometimes the pool gets exhausted pretty quickly. This PR will increase the number of max. connections to 1000 for the Clair PostgreSQL deployment which will allow new pods to connect.