### PR TITLE
clair: Fix extra_ca_certs name in projected volume (PROJQUAY-2751)

### DIFF
--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -68,6 +68,6 @@ spec:
             sources:
               - secret:
                   name: quay-config-tls
-              - secret: 
-                  name: extra-ca-certs
+              - configMap: 
+                  name: cluster-service-ca
 


### PR DESCRIPTION
- Use configMap instead of secret to ensure extra_ca_certs is always found