### PR TITLE
enhancement: Increase the minimum number of replicas for Quay and Clair to 2 (PROJQUAY-2767)

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     quay-component: base
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       quay-component: quay-app

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     quay-component: clair
   name: clair-app
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       quay-component: clair-app


### PR DESCRIPTION
The current default template sets the number of replicas for both Quay and Clair to 1. If HPA is not used, this means deploying only 1 pod of each. This PR increases the default number of replicas to 2, thereby ensuring high availability.