### PR TITLE
upgrades: renaming clair certs volume (PROJQUAY-2824)

### DIFF
--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - mountPath: /clair/
               name: config
             - mountPath: /var/run/certs
-              name: certs
+              name: certificates
           startupProbe:
             tcpSocket:
               port: clair-intro
@@ -63,7 +63,7 @@ spec:
           secret:
             secretName: clair-config-secret
         # Mount the public certificate because we are using storage proxying.
-        - name: certs
+        - name: certificates
           projected:
             sources:
               - secret:


### PR DESCRIPTION
If we don't rename the volume the new projected config is merged with
the original config making "certs" an invalid volume, causing an error

The error reported during deployment patch is:

spec.template.spec.volumes[1].projected: Forbidden: may not specify m
ore than 1 volume type

This patch problem does not occur on the most recent version of
kubernetes api.