### PR TITLE
hack: setup and teardown scripts for e2e envs (#590)

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -27,141 +27,35 @@ jobs:
       OPERATOR_PKG_NAME: quay-operator-test
       NAMESPACE: quay-operator-e2e-nightly
       WAIT_TIMEOUT: 10m
+      KUBECONFIG: ${{ github.workspace }}/kubeconfig
     steps:
-      - name: Check out the repo
+      - name: check out the repo
         uses: actions/checkout@v2
         with:
           ref: ${{ env.BRANCH }}
 
-      - name: Setup catalog source yaml
-        uses: mikefarah/yq@master
+      - name: install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+
+      - name: install yq
+        env:
+          VERSION: v4.14.2
+          BINARY: yq_linux_amd64
+        run: |
+          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
+      - name: setup kubeconfig
+        run: |
+          printf "${{ secrets.KUBE_CONFIG }}" | base64 --decode > "${KUBECONFIG}"
+
+      - name: deploy
         env:
           CATALOG_IMAGE: quay.io/projectquay/quay-operator-index:${{ env.TAG }}
-        with:
-          cmd: |
-            yq e -i '
-              .spec.image = env(CATALOG_IMAGE) |
-              .metadata.name = env(OPERATOR_PKG_NAME)
-              ' ${CATALOG_PATH}
+        run: ./hack/deploy.sh
 
-      - name: Create catalog source
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: create -n openshift-marketplace -f ${{ env.CATALOG_PATH }}
-
-      - name: Setup operator group yaml
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq e -i '.spec.targetNamespaces[0] = env(NAMESPACE)' ${OG_PATH}
-
-      - name: Create operator group
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: create -n ${{ env.NAMESPACE }} -f ${{ env.OG_PATH }}
-
-      - name: Setup subscription yaml
-        uses: mikefarah/yq@master
-        with:
-          cmd: |
-            yq e -i '
-              .spec.channel = "test" |
-              .spec.startingCSV = env(OPERATOR_PKG_NAME) |
-              .spec.name = env(OPERATOR_PKG_NAME) |
-              .spec.source = env(OPERATOR_PKG_NAME)
-              ' ${SUBSCRIPTION_PATH}
-
-      - name: Create subscription
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: create -n ${{ env.NAMESPACE }} -f ${{ env.SUBSCRIPTION_PATH }}
-
-      - name: Deploy Quay
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: create -n ${{ env.NAMESPACE }} -f ${{ env.QUAY_SAMPLE_PATH }}
-
-      - name: Wait for it...
-        run: sleep 30s
-
-      - name: Ensure database rollout
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-database --timeout=${{ env.WAIT_TIMEOUT }}
-
-      - name: Ensure redis rollout
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-redis --timeout=${{ env.WAIT_TIMEOUT }}
-
-      - name: Ensure config editor rollout
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-config-editor --timeout=${{ env.WAIT_TIMEOUT }}
-
-      - name: Ensure Quay rollout
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-app --timeout=${{ env.WAIT_TIMEOUT }}
-
-      - name: Ensure mirror rollout
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: rollout -n ${{ env.NAMESPACE }} status deployment skynet-quay-mirror --timeout=${{ env.WAIT_TIMEOUT }}
-
-      - name: Delete Quay deployment
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+      - name: teardown deployment
         if: always()
-        with:
-          args: delete -n ${{ env.NAMESPACE }} -f ${{ env.QUAY_SAMPLE_PATH }}
-
-      - name: Delete subscription
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        if: always()
-        with:
-          args: delete -n ${{ env.NAMESPACE }} -f ${{ env.SUBSCRIPTION_PATH }}
-
-      - name: Delete operator group
-        uses: actions-hub/kubectl@master
-        if: always()
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: delete -n ${{ env.NAMESPACE }} -f ${{ env.OG_PATH }}
-
-      - name: Delete CSV
-        uses: actions-hub/kubectl@master
-        if: always()
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: delete -n ${{ env.NAMESPACE }} csv ${{ env.OPERATOR_PKG_NAME }}
-
-      - name: Delete catalog source
-        uses: actions-hub/kubectl@master
-        if: always()
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: delete -n openshift-marketplace -f ${{ env.CATALOG_PATH }}
+        run: ./hack/teardown.sh

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# deploys the operator to a cluster from a published version of its catalog
+# index.
+#
+# by default, the deployed operator image is
+# `quay.io/projectquay/quay-operator-index:3.6-unstable`. you can override the
+# tag alone by exporting TAG before exeucting this script, or override the
+# whole thing by setting CATALOG_IMAGE.
+#
+# REQUIREMENTS:
+#  * a valid login session to an OCP cluster, with cluster admin privileges
+#  * the namespace $NAMESPACE exists in the cluster
+#  * noobaa backing storage (TODO: elaborate)
+#  * `curl`
+#  * `docker`
+#  * `yq`
+#  * `jq`
+#  * `oc`
+#
+# NOTE: this script will modify the following files:
+#  - bundle/quay-operator.catalogsource.yaml
+#  - bundle/quay-operator.operator-group.yaml
+#  - bundle/quay-operator.subscription.yaml
+# if `git` is available it will be used to checkout changes to the above files.
+# this means that if you made any changes to them and want them to be persisted,
+# make sure to commit them before running this script.
+
+# prints pre-formatted info output.
+function info {
+	echo "INFO $(date '+%Y-%m-%dT%H:%M:%S') $*"
+}
+
+# prints pre-formatted error output.
+function error {
+	>&2 echo "ERROR $(date '+%Y-%m-%dT%H:%M:%S') $*"
+}
+
+export TAG=${TAG:-'3.6-unstable'}
+export CATALOG_PATH=${CATALOG_PATH:-'./bundle/quay-operator.catalogsource.yaml'}
+export CATALOG_IMAGE=${CATALOG_IMAGE:-"quay.io/projectquay/quay-operator-index:${TAG}"}
+export OG_PATH=${OG_PATH:-'./bundle/quay-operator.operatorgroup.yaml'}
+export SUBSCRIPTION_PATH=${SUBSCRIPTION_PATH:-'./bundle/quay-operator.subscription.yaml'}
+export QUAY_SAMPLE_PATH=${QUAY_SAMPLE_PATH:-'./config/samples/managed.quayregistry.yaml'}
+export OPERATOR_PKG_NAME=${OPERATOR_PKG_NAME:-'quay-operator-test'}
+export NAMESPACE=${NAMESPACE:-'quay-operator-e2e-nightly'}
+export WAIT_TIMEOUT=${WAIT_TIMEOUT:-'10m'}
+
+info 'calculating catalog index image digest'
+
+docker pull "${CATALOG_IMAGE}"
+CAT_IMG_DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' "${CATALOG_IMAGE}")"
+export CAT_IMG_DIGEST
+
+info 'setting up catalog source'
+
+yq e -i '
+	.spec.image = env(CAT_IMG_DIGEST) |
+	.metadata.name = env(OPERATOR_PKG_NAME)
+' "${CATALOG_PATH}"
+
+oc apply -n openshift-marketplace -f "${CATALOG_PATH}"
+info 'waiting for catalog source to become available...'
+for n in {1..60}; do
+	pkgmanifest="$(oc get packagemanifest "${OPERATOR_PKG_NAME}" -n openshift-marketplace -o jsonpath='{.status.catalogSource}' 2> /dev/null)"
+	if [ ! "$pkgmanifest" = "${OPERATOR_PKG_NAME}" ]; then
+		if [ "${n}" = "60" ]; then
+			error 'timed out waiting'
+			info 'catalog source pod yaml:'
+			oc -n openshift-marketplace get pods -l=olm.catalogSource="${OPERATOR_PKG_NAME}"
+			exit 1
+		fi
+		sleep 10
+		continue
+	fi
+	info 'catalog source installed and available'
+	break
+done
+
+info 'installing the operator'
+
+yq e -i '.spec.targetNamespaces[0] = env(NAMESPACE)' "${OG_PATH}"
+oc apply -n "${NAMESPACE}" -f "${OG_PATH}"
+
+yq e -i '
+	.spec.channel = "test" |
+	.spec.startingCSV = env(OPERATOR_PKG_NAME) |
+	.spec.name = env(OPERATOR_PKG_NAME) |
+	.spec.source = env(OPERATOR_PKG_NAME)
+' "${SUBSCRIPTION_PATH}"
+oc apply -n "${NAMESPACE}" -f "${SUBSCRIPTION_PATH}"
+
+info 'waiting for CSV...'
+
+for n in {1..60}; do
+	phase="$(oc get csv "${OPERATOR_PKG_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.phase}' 2> /dev/null)"
+	if [ ! "$phase" = 'Succeeded' ]; then
+		if [ "${n}" = "60" ]; then
+			error 'timed out waiting'
+			info 'csv contents:'
+			oc get csv "${OPERATOR_PKG_NAME}" -n "${NAMESPACE}" -o yaml
+			exit 1
+		fi
+		sleep 10
+		continue
+	fi
+	info 'CSV successfully installed'
+	break
+done
+
+info 'deploy Quay'
+oc apply -n "${NAMESPACE}" -f "${QUAY_SAMPLE_PATH}"
+
+# wait for quay deployment to come up. the next checks will fail if the
+# resources don't exist.
+
+info 'waiting for quay deployment...'
+
+for n in {1..60}; do
+	deploy="$(oc get deploy skynet-quay-app -n "${NAMESPACE}" -o jsonpath='{.metadata.name}' 2> /dev/null)"
+	if [ ! "$deploy" = 'skynet-quay-app' ]; then
+		if [ "${n}" = "60" ]; then
+			error 'timed out waiting'
+			exit 1
+		fi
+		sleep 10
+		continue
+	fi
+	info 'quay deployment created'
+	break
+done
+
+# the reconcile loop recreates resources a few times before stabilising,
+# and the wait command isn't very smart (similar problems exist when waiting
+# for rollouts), so we just sleep a bit before waiting.
+# see https://github.com/kubernetes/kubectl/issues/1120 for details.
+info 'sleeping two minutes before waiting for pods...'
+sleep 120
+
+# the order below matters!
+# the mirror is the last to come up, so after the dependencies are ready
+# we wait for the mirror to be ready, then we check the quay app as it's
+# more likely to have stabilized after the mirror is up and running.
+info 'waiting for postgres pod...'
+oc -n "${NAMESPACE}" wait pods -l=quay-component=postgres --for=condition=Ready --timeout="${WAIT_TIMEOUT}"
+
+info 'waiting for redis pod...'
+oc -n "${NAMESPACE}" wait pods -l=quay-component=redis --for=condition=Ready --timeout="${WAIT_TIMEOUT}"
+
+info 'waiting for mirror pod...'
+oc -n "${NAMESPACE}" wait pods -l=quay-component=quay-mirror --for=condition=Ready --timeout="${WAIT_TIMEOUT}"
+
+info 'waiting for config-editor pod...'
+oc -n "${NAMESPACE}" wait pods -l=quay-component=quay-config-editor --for=condition=Ready --timeout="${WAIT_TIMEOUT}"
+
+info 'waiting for quay pod...'
+oc -n "${NAMESPACE}" wait pods -l=quay-component=quay-app --for=condition=Ready --timeout="${WAIT_TIMEOUT}"
+
+
+# manually check quay's health to ensure it can successfuly connect to its components.
+endpoint="$(oc -n "${NAMESPACE}" get quayregistry skynet -o jsonpath='{.status.registryEndpoint}')"
+result="$(curl -s -k "${endpoint}"/health/instance)"
+
+if [ "$(echo "${result}" | jq '.status_code')" != "200" ]; then
+	error 'quay health check did not return 200'
+	info "${result}"
+	info 'quayregistry CR yaml:'
+	oc -n "${NAMESPACE}" get quayregistry skynet -o yaml
+	info 'quay-app pod logs:'
+	oc -n "${NAMESPACE}" logs -l=quay-component=quay-app
+	exit 1
+fi
+
+if [ "$(echo "${result}" | jq '.data.services.auth')" != "true" ]; then
+	error 'quay auth health check was false'
+	info "${result}"
+	oc -n "${NAMESPACE}" logs -l=quay-component=quay-app
+	exit 1
+fi
+
+if [ "$(echo "${result}" | jq '.data.services.database')" != "true" ]; then
+	error 'quay database health check was false'
+	info "${result}"
+	oc -n "${NAMESPACE}" logs -l=quay-component=postgres
+	exit 1
+fi
+
+if [ "$(echo "${result}" | jq '.data.services.disk_space')" != "true" ]; then
+	error 'quay disk_space health check was false'
+	info "${result}"
+	exit 1
+fi
+
+if [ "$(echo "${result}" | jq '.data.services.registry_gunicorn')" != "true" ]; then
+	error 'quay registry_gunicorn health check was false'
+	info "${result}"
+	oc -n "${NAMESPACE}" logs -l=quay-component=quay-app
+	exit 1
+fi
+
+if [ "$(echo "${result}" | jq '.data.services.service_key')" != "true" ]; then
+	error 'quay service_key health check was false'
+	info "${result}"
+	oc -n "${NAMESPACE}" logs -l=quay-component=quay-app
+	exit 1
+fi
+
+if [ "$(echo "${result}" | jq '.data.services.web_gunicorn')" != "true" ]; then
+	error 'quay web_gunicorn health check was false'
+	info "${result}"
+	oc -n "${NAMESPACE}" logs -l=quay-component=quay-app
+	exit 1
+fi
+
+info 'all healthchecks passed'
+info 'successfully installed Quay!'
+info 'use hack/teardown.sh to remove all created resources'
+
+# shellcheck disable=SC2046
+if [ -x $(command -v git >/dev/null 2>&1) ]; then
+	git checkout "${CATALOG_PATH}" >/dev/null 2>&1
+	git checkout "${SUBSCRIPTION_PATH}" >/dev/null 2>&1
+	git checkout "${OG_PATH}" >/dev/null 2>&1
+fi

--- a/hack/storage.sh
+++ b/hack/storage.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# deploys noobaa via openshift storage operator to a cluster from redhat
+# marketplace.
+#
+# REQUIREMENTS:
+#  * a valid login session to an OCP cluster, with cluster admin privileges
+#  * `oc`
+
+# prints pre-formatted info output.
+function info {
+	echo "INFO $(date '+%Y-%m-%dT%H:%M:%S') $*"
+}
+
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: openshift-storage
+  name: openshift-storage
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+  name: openshift-storage-og
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+  - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/ocs-operator.openshift-storage: ""
+  name: ocs-operator
+  namespace: openshift-storage
+spec:
+  channel: stable-4.8
+  installPlanApproval: Automatic
+  name: ocs-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+NAMESPACE='openshift-storage'
+
+info 'waiting for CSV installation...'
+
+for _ in {1..60}; do
+	phase="$(oc -n "${NAMESPACE}" get csv -l operators.coreos.com/ocs-operator.openshift-storage -o jsonpath='{.items[*].status.phase}')"
+	if [ "$phase" = "Succeeded" ]; then
+		info "operator installed"
+		break
+	fi
+	sleep 10
+done
+
+info 'creating noobaa object storage'
+
+cat <<EOF | oc apply -f -
+apiVersion: noobaa.io/v1alpha1
+kind: NooBaa
+metadata:
+  name: noobaa
+  namespace: openshift-storage
+spec:
+ dbResources:
+   requests:
+     cpu: '0.1'
+     memory: 1Gi
+ dbType: postgres
+ coreResources:
+   requests:
+     cpu: '0.1'
+     memory: 1Gi
+EOF
+
+info 'waiting for object store installation'
+
+for _ in {1..60}; do
+	phase="$(oc get noobaas noobaa -n "${NAMESPACE}" -o jsonpath='{.status.phase}')"
+	if [ "$phase" = "Ready" ]; then
+		info 'object store ready'
+		break
+	fi
+	sleep 10
+done
+
+for _ in {1..60}; do
+	phase="$(oc get backingstore noobaa-default-backing-store -n "${NAMESPACE}" -o jsonpath='{.status.phase}')"
+	if [ "$phase" = "Ready" ]; then
+		info 'backing store ready'
+		break
+	fi
+	sleep 10
+done
+
+info 'install finished'

--- a/hack/teardown.sh
+++ b/hack/teardown.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# teardown the operator deployed by hack/deploy.sh
+#
+# REQUIREMENTS:
+#  * a valid login session to an OCP cluster, with cluster admin privileges
+#  * `yq` cmd line tool
+#  * `oc` cmd line tool
+
+# prints pre-formatted info output.
+function info {
+	echo "INFO $(date '+%Y-%m-%dT%H:%M:%S') $*"
+}
+
+export OPERATOR_PKG_NAME=${OPERATOR_PKG_NAME:-'quay-operator-test'}
+export OG_PATH=${OG_PATH:-'./bundle/quay-operator.operatorgroup.yaml'}
+export SUBSCRIPTION_PATH=${SUBSCRIPTION_PATH:-'./bundle/quay-operator.subscription.yaml'}
+export QUAY_SAMPLE_PATH=${QUAY_SAMPLE_PATH:-'./config/samples/managed.quayregistry.yaml'}
+export NAMESPACE=${NAMESPACE:-'quay-operator-e2e-nightly'}
+
+info 'tearing down created resources...'
+
+info 'uninstall Quay'
+oc delete -n "${NAMESPACE}" -f "${QUAY_SAMPLE_PATH}"
+
+info 'uninstalling operator'
+oc delete -n "${NAMESPACE}" operatorgroup "$(yq e '.metadata.name' "${OG_PATH}")"
+oc delete -n "${NAMESPACE}" subscription "$(yq e '.metadata.name' "${SUBSCRIPTION_PATH}")"
+oc delete -n "${NAMESPACE}" csv "${OPERATOR_PKG_NAME}"
+
+info 'deleting catalog source'
+oc delete catsrc "${OPERATOR_PKG_NAME}" -n openshift-marketplace


### PR DESCRIPTION
* hack/deploy.sh: deploys the operator and a quayregistry instance, and ensures everything is up and running. will exit 1 otherwise
* hack/teardown.sh: removes everything created by deploy.sh
* hack/storage.sh: installs the openshift container storage from the red hat catalog and creates a noobaa instance

Fixes PROJQUAY-2823

----

This is already merged on master. The e2e workflow currently fails because apparently it's using the github workflow yaml from master with the `redhat-3.6` files, and the workflow expects files that do not yet exist in the `redhat-3.6` branch. This PR add these files.