### PR TITLE
fix: dont override component when managing/unmanaging via config editor

### DIFF
--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -108,13 +108,13 @@ func ReconfigureHandler(k8sClient client.Client) func(w http.ResponseWriter, r *
 				}
 			}
 
+			component.Managed = true
 			if contains {
-				log.Info("marking component as unmanaged", "component", component.Kind)
-				newComponents = append(newComponents, v1.Component{Kind: component.Kind, Managed: false})
-			} else {
-				log.Info("marking component as managed", "component", component.Kind)
-				newComponents = append(newComponents, v1.Component{Kind: component.Kind, Managed: true})
+				log.Info("marking component as unmanaged and removing overrides", "component", component.Kind)
+				component.Managed = false
+				component.Overrides = nil
 			}
+			newComponents = append(newComponents, component)
 		}
 		quay.Spec.Components = newComponents
 		quay.Spec.ConfigBundleSecret = newSecret.GetName()


### PR DESCRIPTION
Overriding the whole component only to set `component.Managed` removes any other attributes set for each component, even when nothing changed.
This wasn't a problem until now since we only ever had `Kind` and `Managed` attributes, but with the introduction of `Overrides` the current solution is no longer acceptable.

Note that if the user manually removes the `overrides.volumeSize` from the CR the same error will occur. This PR does not address this behaviour.

Ensuring that PROJQUAY-2930 cannot be reproduced after this is merged is a good way to test this.
Further tests can be done by unmanaging a component containing overrides. Note that unmanaging a component containing an override will remove the override for the unmanaged component. If a user wants to manage the component again they will have to add the override again by themself.

Example test case:
Deploy Quay via operator overriding both clair and quay volume sizes, i.e:
```
apiVersion: quay.redhat.com/v1
kind: QuayRegistry
metadata:
  name: skynet
spec:
  components:
  - kind: clair
    managed: true
    overrides:
      volumeSize: 75Gi
  - kind: postgres
    managed: true
    overrides:
      volumeSize: 75Gi
```

Observe that the volume size overrides are present in the CR:
```
oc get quayregistry skynet -o json | jq '.spec.components'
```

Open the config-editor then click on "edit" in the database section. The fields will become editable. This alone will make the config editor mark postgres as managed, even if you don't change any of the default settings.
Click on "validate configuration changes", then "reconfigure quay".

Observe that the volume size overrides is _not_ present for the postgres component, but is present for clair:
```
oc get quayregistry skynet -o json | jq '.spec.components'
```

PROJQUAY-2930 #resolve