### PR TITLE
fix: dont override component when managing/unmanaging via config editor

### DIFF
--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -108,13 +108,13 @@ func ReconfigureHandler(k8sClient client.Client) func(w http.ResponseWriter, r *
 				}
 			}
 
+			component.Managed = true
 			if contains {
-				log.Info("marking component as unmanaged", "component", component.Kind)
-				newComponents = append(newComponents, v1.Component{Kind: component.Kind, Managed: false})
-			} else {
-				log.Info("marking component as managed", "component", component.Kind)
-				newComponents = append(newComponents, v1.Component{Kind: component.Kind, Managed: true})
+				log.Info("marking component as unmanaged and removing overrides", "component", component.Kind)
+				component.Managed = false
+				component.Overrides = nil
 			}
+			newComponents = append(newComponents, component)
 		}
 		quay.Spec.Components = newComponents
 		quay.Spec.ConfigBundleSecret = newSecret.GetName()


### PR DESCRIPTION
Overriding the whole component only to set component.Managed removes any other attributes set for each component, even when nothing changed.
This wasn't a problem until now since we only ever had Kind and Managed attributes, but with the introduction of Overrides the current solution is no longer acceptable.

Note that if the user manually removes the overrides.volumeSize from the CR the same error will occur. This PR does not address this behaviour.

PROJQUAY-2930 #resolve