### PR TITLE
tls: Mark TLS as required component (PROJQUAY-2696)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -67,6 +67,7 @@ var requiredComponents = []ComponentKind{
 	ComponentObjectStorage,
 	ComponentRoute,
 	ComponentRedis,
+	ComponentTLS,
 }
 
 var supportsVolumeOverride = []ComponentKind{


### PR DESCRIPTION
- Set ComponentTLS as a required component
- This will prevent Quay from being deployed when tls marked as unmanaged as custom tls certs are not provided