### PR TITLE
hack/deploy: increase wait timeout

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -43,7 +43,7 @@ export SUBSCRIPTION_PATH=${SUBSCRIPTION_PATH:-'./bundle/quay-operator.subscripti
 export QUAY_SAMPLE_PATH=${QUAY_SAMPLE_PATH:-'./config/samples/managed.quayregistry.yaml'}
 export OPERATOR_PKG_NAME=${OPERATOR_PKG_NAME:-'quay-operator-test'}
 export NAMESPACE=${NAMESPACE:-'quay-operator-e2e-nightly'}
-export WAIT_TIMEOUT=${WAIT_TIMEOUT:-'10m'}
+export WAIT_TIMEOUT=${WAIT_TIMEOUT:-'20m'}
 
 info 'calculating catalog index image digest'
 


### PR DESCRIPTION
the e2e nightly workflow constantly times out when running this script.
although triggering the same workflow manually doesn't timeout, increase
the timeout anyway to see if it helps the nightly run.