### PR TITLE
dev: allow quay without requests (PROJQUAY-3054)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -66,12 +66,13 @@ const (
 // QuayRegistryReconciler reconciles a QuayRegistry object
 type QuayRegistryReconciler struct {
 	client.Client
-	Log            logr.Logger
-	Scheme         *runtime.Scheme
-	EventRecorder  record.EventRecorder
-	WatchNamespace string
-	Mtx            *sync.Mutex
-	Requeue        ctrl.Result
+	Log                logr.Logger
+	Scheme             *runtime.Scheme
+	EventRecorder      record.EventRecorder
+	WatchNamespace     string
+	Mtx                *sync.Mutex
+	Requeue            ctrl.Result
+	NoResourceRequests bool
 }
 
 // manageQuayDeletion makes sure that we process a QuayRegistry once it is flagged for
@@ -474,7 +475,9 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	log.Info("inflating QuayRegistry into Kubernetes objects")
-	deploymentObjects, err := kustomize.Inflate(quayContext, updatedQuay, configBundle, log)
+	deploymentObjects, err := kustomize.Inflate(
+		quayContext, updatedQuay, configBundle, log, r.NoResourceRequests,
+	)
 	if err != nil {
 		return r.reconcileWithCondition(
 			ctx,

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -66,13 +66,13 @@ const (
 // QuayRegistryReconciler reconciles a QuayRegistry object
 type QuayRegistryReconciler struct {
 	client.Client
-	Log                logr.Logger
-	Scheme             *runtime.Scheme
-	EventRecorder      record.EventRecorder
-	WatchNamespace     string
-	Mtx                *sync.Mutex
-	Requeue            ctrl.Result
-	NoResourceRequests bool
+	Log                  logr.Logger
+	Scheme               *runtime.Scheme
+	EventRecorder        record.EventRecorder
+	WatchNamespace       string
+	Mtx                  *sync.Mutex
+	Requeue              ctrl.Result
+	SkipResourceRequests bool
 }
 
 // manageQuayDeletion makes sure that we process a QuayRegistry once it is flagged for
@@ -476,7 +476,7 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	log.Info("inflating QuayRegistry into Kubernetes objects")
 	deploymentObjects, err := kustomize.Inflate(
-		quayContext, updatedQuay, configBundle, log, r.NoResourceRequests,
+		quayContext, updatedQuay, configBundle, log, r.SkipResourceRequests,
 	)
 	if err != nil {
 		return r.reconcileWithCondition(

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 
 	// if this environment variable is set the operator removes all resource requirements
 	// (requests and limits), this is useful for development purposes.
-	nores := os.Getenv("NO_RESOURCE_REQUESTS") == "true"
+	skipres := os.Getenv("SKIP_RESOURCE_REQUESTS") == "true"
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -92,14 +92,14 @@ func main() {
 
 	var mtx sync.Mutex
 	if err = (&quaycontroller.QuayRegistryReconciler{
-		Client:             mgr.GetClient(),
-		Log:                ctrl.Log.WithName("controllers").WithName("QuayRegistry"),
-		Scheme:             mgr.GetScheme(),
-		EventRecorder:      mgr.GetEventRecorderFor("quayregistry-controller"),
-		WatchNamespace:     namespace,
-		Mtx:                &mtx,
-		Requeue:            ctrl.Result{RequeueAfter: 10 * time.Second},
-		NoResourceRequests: nores,
+		Client:               mgr.GetClient(),
+		Log:                  ctrl.Log.WithName("controllers").WithName("QuayRegistry"),
+		Scheme:               mgr.GetScheme(),
+		EventRecorder:        mgr.GetEventRecorderFor("quayregistry-controller"),
+		WatchNamespace:       namespace,
+		Mtx:                  &mtx,
+		Requeue:              ctrl.Result{RequeueAfter: 10 * time.Second},
+		SkipResourceRequests: skipres,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "QuayRegistry")
 		os.Exit(1)

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -452,6 +452,7 @@ func Inflate(
 	quay *v1.QuayRegistry,
 	bundle *corev1.Secret,
 	log logr.Logger,
+	nores bool,
 ) ([]client.Object, error) {
 	// Each managed component brings its own generated `config.yaml` fields which are
 	// accumulated under the key <component>.config.yaml and then added to the base `Secret`.
@@ -560,7 +561,7 @@ func Inflate(
 	}
 
 	for index, resource := range resources {
-		obj, err := middleware.Process(quay, resource)
+		obj, err := middleware.Process(quay, resource, nores)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -452,7 +452,7 @@ func Inflate(
 	quay *v1.QuayRegistry,
 	bundle *corev1.Secret,
 	log logr.Logger,
-	nores bool,
+	skipres bool,
 ) ([]client.Object, error) {
 	// Each managed component brings its own generated `config.yaml` fields which are
 	// accumulated under the key <component>.config.yaml and then added to the base `Secret`.
@@ -561,7 +561,7 @@ func Inflate(
 	}
 
 	for index, resource := range resources {
-		obj, err := middleware.Process(quay, resource, nores)
+		obj, err := middleware.Process(quay, resource, skipres)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -483,7 +483,7 @@ func TestInflate(t *testing.T) {
 
 	for _, test := range inflateTests {
 		t.Run(test.name, func(t *testing.T) {
-			pieces, err := Inflate(&test.ctx, test.quayRegistry, test.configBundle, log)
+			pieces, err := Inflate(&test.ctx, test.quayRegistry, test.configBundle, log, false)
 
 			assert.NotNil(pieces, test.name)
 			assert.Equal(len(test.expected), len(pieces), test.name)

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -24,9 +24,9 @@ const (
 )
 
 // Process applies any additional middleware steps to a managed k8s object that cannot be
-// accomplished using the Kustomize toolchain. if nores is set all resource requests are
+// accomplished using the Kustomize toolchain. if skipres is set all resource requests are
 // trimmed from the objects thus deploying quay with a much smaller footprint.
-func Process(quay *v1.QuayRegistry, obj client.Object, nores bool) (client.Object, error) {
+func Process(quay *v1.QuayRegistry, obj client.Object, skipres bool) (client.Object, error) {
 	objectMeta, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func Process(quay *v1.QuayRegistry, obj client.Object, nores bool) (client.Objec
 			}
 		}
 
-		if nores {
+		if skipres {
 			// if we are deploying without resource requests we have to remove them
 			var noresources corev1.ResourceRequirements
 			for i := range dep.Spec.Template.Spec.Containers {
@@ -133,7 +133,7 @@ func Process(quay *v1.QuayRegistry, obj client.Object, nores bool) (client.Objec
 		return pvc, nil
 	}
 
-	if job, ok := obj.(*batchv1.Job); ok && nores {
+	if job, ok := obj.(*batchv1.Job); ok && skipres {
 		// if we are deploying without resource requests we have to remove them
 		var noresources corev1.ResourceRequirements
 		for i := range job.Spec.Template.Spec.Containers {

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -235,7 +235,7 @@ func TestProcess(t *testing.T) {
 	for _, test := range processTests {
 
 		t.Run(test.name, func(t *testing.T) {
-			processedObj, err := Process(test.quay, test.obj)
+			processedObj, err := Process(test.quay, test.obj, false)
 			if test.expectedError != nil {
 				assert.Error(err, test.name)
 			} else {


### PR DESCRIPTION
Allow developers to deploy Quay without Resource Requests and Limits.
This is specially useful during development phase when we have smaller
clusters.

To deploy quay without resource requests and limits the environment
variable SKIP_RESOURCE_REQUESTS must be set to "true".