### PR TITLE
proxy: adding proxy support (PROJQUAY-1579)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/quay/config-tool v0.1.9
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/sjson v1.2.3
+	golang.org/x/net v0.0.0-20210825183410-e898025ed96a
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.23.0
@@ -102,7 +103,6 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect

--- a/kustomize/base/cluster-trusted-ca.configmap.yaml
+++ b/kustomize/base/cluster-trusted-ca.configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-trusted-ca
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./cluster-service-ca.configmap.yaml
   - ./config.deployment.yaml
   - ./config.service.yaml
+  - ./cluster-trusted-ca.configmap.yaml

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -47,6 +47,21 @@ spec:
               value: "2"
             - name: WORKER_COUNT_REGISTRY
               value: "8"
+            - name: HTTP_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: HTTP_PROXY
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: HTTPS_PROXY
+            - name: NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: NO_PROXY
           ports:
             - containerPort: 8443
               protocol: TCP

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -25,6 +25,21 @@ spec:
               value: /clair/config.yaml
             - name: CLAIR_MODE
               value: combo
+            - name: HTTP_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: HTTP_PROXY
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: HTTPS_PROXY
+            - name: NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: NO_PROXY
           ports:
             - containerPort: 8080
               name: clair-http
@@ -33,6 +48,9 @@ spec:
               name: clair-intro
               protocol: TCP
           volumeMounts:
+            - name: cluster-trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
             - mountPath: /clair/
               name: config
             - mountPath: /var/run/certs
@@ -58,6 +76,12 @@ spec:
               memory: 16Gi
       restartPolicy: Always
       volumes:
+        - name: cluster-trusted-ca
+          configMap:
+            name: cluster-trusted-ca
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
         - name: config
           secret:
             secretName: clair-config-secret

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -60,6 +60,21 @@ spec:
               value: "false"
             - name: ENSURE_NO_MIGRATION
               value: "true"
+            - name: HTTP_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: HTTP_PROXY
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: HTTPS_PROXY
+            - name: NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: quay-proxy-config
+                  key: NO_PROXY
           # TODO: Determine if we need to set resource requirements
           volumeMounts:
             - name: config

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -318,8 +318,11 @@ func KustomizationFor(
 	// read the proxy configuration from the environment. makes sure we add the quay server
 	// host name to the list of addresses reachable without proxy (NO_PROXY).
 	proxyenv := httpproxy.FromEnvironment()
-	addrs := strings.Split(proxyenv.NoProxy, ",")
-	addrs = append(addrs, ctx.ServerHostname)
+	addrs := []string{ctx.ServerHostname}
+	if len(proxyenv.NoProxy) > 0 {
+		noproxy := strings.Split(proxyenv.NoProxy, ",")
+		addrs = append(addrs, noproxy...)
+	}
 
 	generatedSecrets := []types.SecretArgs{
 		{

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -250,6 +250,8 @@ var quayComponents = map[string][]client.Object{
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-config-editor-credentials"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-registry-managed-secret-keys"}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-service-ca"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-proxy-config"}},
 	},
 	"clair": {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "clair-config-secret"}},

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -53,7 +53,9 @@ func FieldGroupFor(
 
 		fieldGroup.FeatureSecurityScanner = true
 		fieldGroup.SecurityScannerV4Endpoint = fmt.Sprintf(
-			"http://%s-clair-app:80", quay.GetName(),
+			"http://%s-clair-app.%s.svc.cluster.local",
+			quay.GetName(),
+			quay.GetNamespace(),
 		)
 		fieldGroup.SecurityScannerV4NamespaceWhitelist = []string{"admin"}
 		fieldGroup.SecurityScannerNotifications = true

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -54,7 +54,7 @@ var fieldGroupForTests = []struct {
 			FeatureSecurityScanner:              true,
 			SecurityScannerIndexingInterval:     30,
 			SecurityScannerNotifications:        true,
-			SecurityScannerV4Endpoint:           "http://test-clair-app:80",
+			SecurityScannerV4Endpoint:           "http://test-clair-app.ns.svc.cluster.local",
 			SecurityScannerV4NamespaceWhitelist: []string{"admin"},
 			SecurityScannerV4PSK:                "abc123",
 		},


### PR DESCRIPTION
Passing through proxy configuration received through OLM operator. This
PR passes HTTP_PROXY, HTTPS_PROXY and NO_PROXY from the operator env and
into operand env.

NO_PROXY, as passed by OLM, already contain rules to allow direct
connection to kubernetes internal services therefore this PR only adds a
rule allowing Clair to directly connect to Quay through its Route.