### PR TITLE
clair: use Lint instead of Validate

### DIFF
--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -374,7 +374,7 @@ func clairConfigFor(log logr.Logger, quay *v1.QuayRegistry, quayHostname, preSha
 			Name: "prometheus",
 		},
 	}
-	ws, err := config.Validate(&cfg)
+	ws, err := config.Lint(&cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Accidentally used the Validate function, which sets defaults, instead of
Lint, which simply reports warnings.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>