### PR TITLE
postgres: disable huge pages (PROJQUAY-2869)

### DIFF
--- a/kustomize/components/clair/clair-postgres-conf-sample.configmap.yaml
+++ b/kustomize/components/clair/clair-postgres-conf-sample.configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clair-postgres-conf-sample
+data:
+  postgresql.conf.sample: |
+    huge_pages = off
+    logging_collector = on
+    log_filename = 'postgresql-%a.log'
+    log_truncate_on_rotation = on
+    log_rotation_age = 1d
+    log_rotation_size = 0

--- a/kustomize/components/clair/kustomization.yaml
+++ b/kustomize/components/clair/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - ./postgres.persistentvolumeclaim.yaml
   - ./postgres.deployment.yaml
   - ./postgres.service.yaml
+  - ./clair-postgres-conf-sample.configmap.yaml
 secretGenerator:
   - name: clair-config-secret

--- a/kustomize/components/clair/postgres.deployment.yaml
+++ b/kustomize/components/clair/postgres.deployment.yaml
@@ -21,6 +21,9 @@ spec:
       terminationGracePeriodSeconds: 180
       serviceAccountName: clair-postgres
       volumes:
+        - name: clair-postgres-conf-sample
+          configMap:
+            name: clair-postgres-conf-sample
         - name: postgres-data
           persistentVolumeClaim:
             claimName: clair-postgres
@@ -43,6 +46,9 @@ spec:
             - name: POSTGRESQL_MAX_CONNECTIONS
               value: "1000"
           volumeMounts:
+            - name: clair-postgres-conf-sample
+              mountPath: /usr/share/pgsql/postgresql.conf.sample
+              subPath: postgresql.conf.sample
             - name: postgres-data
               mountPath: /var/lib/pgsql/data
           resources:

--- a/kustomize/components/postgres/kustomization.yaml
+++ b/kustomize/components/postgres/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./postgres.deployment.yaml
   - ./postgres.service.yaml
   - ./init.job.yaml
+  - ./postgres-conf-sample.configmap.yaml
 secretGenerator:
   # NOTE: `postgres-config-secret` fields generated in `kustomize.go`.
   - name: postgres-config-secret

--- a/kustomize/components/postgres/postgres-conf-sample.configmap.yaml
+++ b/kustomize/components/postgres/postgres-conf-sample.configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-conf-sample
+data:
+  postgresql.conf.sample: |
+    huge_pages = off
+    logging_collector = on
+    log_filename = 'postgresql-%a.log'
+    log_truncate_on_rotation = on
+    log_rotation_age = 1d
+    log_rotation_size = 0

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -21,6 +21,9 @@ spec:
       terminationGracePeriodSeconds: 180
       serviceAccountName: quay-database
       volumes:
+        - name: postgres-conf-sample
+          configMap:
+            name: postgres-conf-sample
         - name: postgres-data
           persistentVolumeClaim:
             claimName: quay-database
@@ -57,6 +60,9 @@ spec:
             - name: POSTGRESQL_MAX_CONNECTIONS
               value: "2000"
           volumeMounts:
+            - name: postgres-conf-sample
+              mountPath: /usr/share/pgsql/postgresql.conf.sample
+              subPath: postgresql.conf.sample
             - name: postgres-data
               mountPath: /var/lib/pgsql/data
           resources:

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -259,6 +259,7 @@ var quayComponents = map[string][]client.Object{
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres"}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "clair-app"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "clair-postgres-conf-sample"}},
 	},
 	"postgres": {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "postgres-bootstrap"}},
@@ -268,6 +269,7 @@ var quayComponents = map[string][]client.Object{
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-database"}},
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "quay-database-init"}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "quay-database"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "postgres-conf-sample"}},
 	},
 	"redis": {
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-redis"}},


### PR DESCRIPTION
As per https://bugzilla.redhat.com/show_bug.cgi?id=2032811 we can't
deploy postgres in a cluster whose nodes have huge pages enabled.

This PR disables huge pages support in postgres, this is a work around
and can be removed in the future (as soon as the underlying issue is
fixed in the kernel/kubelet).