### PR TITLE
config: unset config endpoint/unmanaged route (PROJQUAY-2049)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -532,7 +532,7 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	updatedQuay, _ = v1.EnsureConfigEditorEndpoint(quayContext, updatedQuay)
+	v1.EnsureConfigEditorEndpoint(quayContext, updatedQuay)
 	cfgsecret := configEditorCredentialsSecretFrom(deploymentObjects)
 	updatedQuay.Status.ConfigEditorCredentialsSecret = cfgsecret
 


### PR DESCRIPTION
Only sets status.configEditorEndpoint if cluster supports Routes and the
Route component is managed.