### PR TITLE
routes: improve error reporting (PROJQUAY-2067)

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -113,7 +113,7 @@ func (r *QuayRegistryReconciler) checkRoutesAvailable(
 	// value is then passed to the created `Route` using a Kustomize variable.
 	var config map[string]interface{}
 	if err := yaml.Unmarshal(bundle.Data["config.yaml"], &config); err != nil {
-		return err
+		return fmt.Errorf("unable to parse config.yaml: %w", err)
 	}
 
 	fieldGroup, err := hostsettings.NewHostSettingsFieldGroup(config)


### PR DESCRIPTION
Adding a proper error message when unable to parse config.yaml during
Route detection.