### PR TITLE
chore: stop running operator during e2e (PROJQUAY-3055)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
 
 test-e2e:
-	mkdir ./bin
+ifeq ("$(wildcard ./bin/kuttl)","")
+	mkdir -p ./bin
 	curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64 -o ./bin/kuttl;
 	chmod +x ./bin/kuttl;
+endif
 	./bin/kuttl test;
 
 # Build manager binary

--- a/e2e/min_deployment/00-assert.yaml
+++ b/e2e/min_deployment/00-assert.yaml
@@ -78,4 +78,3 @@ status:
     reason: ComponentsCreationSuccess
     status: "False"
     type: RolloutBlocked
-  currentVersion: dev

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -3,10 +3,5 @@ kind: TestSuite
 testDirs:
   - ./e2e
 timeout: 500
-crdDir: ./bundle/upstream/manifests
 suppress: 
  - "events"
-commands:
-  - command: /bin/bash -c 'QUAY_VERSION=dev go run main.go' 
-    background: true
-


### PR DESCRIPTION
Stop running the operator when we run the e2e tests. These are going to
run agains a cluster where the operator is already installed.