### PR TITLE
Do not run e2e on deploy.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
 
 test-e2e:
-	mkdir ./bin
+	mkdir -p ./bin
 	curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64 -o ./bin/kuttl;
 	chmod +x ./bin/kuttl;
 	./bin/kuttl test;

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -106,8 +106,6 @@ for n in {1..60}; do
 	break
 done
 
-make test-e2e;
-
 # shellcheck disable=SC2046
 if [ -x $(command -v git >/dev/null 2>&1) ]; then
 	git checkout "${CATALOG_PATH}" >/dev/null 2>&1


### PR DESCRIPTION
Deploy script should worry about deploying the quay operator and not
deploying and running the E2E tests.