### PR TITLE
state: use the same secret to store managed keys (PROJQUAY-3358)

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -348,6 +348,9 @@ func KustomizationFor(
 		{
 			GeneratorArgs: types.GeneratorArgs{
 				Name: v1.ManagedKeysName,
+				Options: &types.GeneratorOptions{
+					DisableNameSuffixHash: true,
+				},
 				KvPairSources: types.KvPairSources{
 					LiteralSources: []string{
 						"DATABASE_SECRET_KEY=" + ctx.DatabaseSecretKey,


### PR DESCRIPTION
This PR stops appending the hash to the "managed keys" secret name. By
doing so we stop creating a new secret every time a reconcile runs and
we use always the same.