### PR TITLE
routes: fail only when managed (PROJQUAY-3399)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -325,9 +325,10 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		)
 	}
 
+	rtmanaged := v1.ComponentIsManaged(updatedQuay.Spec.Components, v1.ComponentRoute)
 	if err := r.checkRoutesAvailable(
 		ctx, quayContext, updatedQuay, configBundle,
-	); err != nil {
+	); err != nil && rtmanaged {
 		return r.reconcileWithCondition(
 			ctx,
 			&quay,


### PR DESCRIPTION
On v3.6.x we only fail when checking if routes are available if the
route component is managed. This behavior has been lost during the
migration to v3.7.0. This commit restores the old behavior.