### PR TITLE
builds: add missing port to deployment (PROJQUAY-3453)

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -71,6 +71,8 @@ spec:
               protocol: TCP
             - containerPort: 9091
               protocol: TCP
+            - containerPort: 55443
+              protocol: TCP
           resources:
             requests:
               cpu: 2000m


### PR DESCRIPTION
Add a missing port in quay-app deployment.