### PR TITLE
chore: runs build-and-publish workflow on schedule

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -2,6 +2,17 @@
 name: Build and Publish Images
 
 on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from (make sure to use workflow from the same branch).'
+        required: true
+        type: choice
+        options:
+        - redhat-3.6
+        - redhat-3.7
+  schedule:
+    - cron: '30 3 * * *' # run before e2e-nightly to ensure a fresh operator build
   push:
     # NOTE: if you trigger this on your branch, ensure its name follows the redhat-X.Y format!
     branches:
@@ -9,6 +20,7 @@ on:
 
 jobs:
   set-version:
+    if: ${{ contains(github.ref, 'redhat-') }}
     name: Set version from branch name
     env:
       BRANCH_PREFIX: redhat- # IMPORTANT! this must match the .on.push.branches prefix!
@@ -19,20 +31,23 @@ jobs:
       tag: ${{ steps.format-tag.outputs.tag }}
     runs-on: 'ubuntu-latest'
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-
       - name: Format version
         id: version-from-branch
         run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=version::${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}"
+          # use the given branch name when the workflow is manually run,
+          # or the GITHUB_REF_NAME otherwise (the branch that triggered the workflow)
+          INPUT_BRANCH=${{ github.event.inputs.branch }}
+          BRANCH_NAME=${INPUT_BRANCH:-$GITHUB_REF_NAME}
+          # remove the prefix from the branch name
+          VERSION=${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}
+          echo "::set-output name=version::${VERSION}"
 
       - name: Format tag with version
         id: format-tag
         run: echo "::set-output name=tag::${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}"
 
   quay-image:
+    if: ${{ contains(github.ref, 'redhat-') }}
     name: Calculate Quay Image Digest
     runs-on: 'ubuntu-latest'
     outputs:
@@ -50,6 +65,7 @@ jobs:
         run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay:${TAG})"
 
   clair-image:
+    if: ${{ contains(github.ref, 'redhat-') }}
     name: Calculate Clair Image Digest
     runs-on: 'ubuntu-latest'
     outputs:
@@ -66,6 +82,7 @@ jobs:
         run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/clair:${TAG})"
 
   builder-image:
+    if: ${{ contains(github.ref, 'redhat-') }}
     name: Calculate Builder Image Digest
     runs-on: 'ubuntu-latest'
     outputs:
@@ -83,6 +100,7 @@ jobs:
         run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder:${TAG})"
 
   qemu-builder-image:
+    if: ${{ contains(github.ref, 'redhat-') }}
     name: Calculate Qemu Builder Image Digest
     runs-on: 'ubuntu-latest'
     outputs:
@@ -99,6 +117,7 @@ jobs:
         run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder-qemu:${TAG})"
 
   operator-image:
+    if: ${{ contains(github.ref, 'redhat-') }}
     name: Publish Operator Image
     runs-on: 'ubuntu-latest'
     outputs:
@@ -109,6 +128,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Login to Quay.io
         uses: docker/login-action@v1
@@ -131,6 +152,7 @@ jobs:
           echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${OPERATOR_IMAGE})"
 
   operator-index-images:
+    if: ${{ contains(github.ref, 'redhat-') }}
     name: Publish Catalog Index Image
     runs-on: 'ubuntu-latest'
     needs: [quay-image, clair-image, builder-image, qemu-builder-image, operator-image, set-version]
@@ -142,6 +164,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Login to Quay.io
         uses: docker/login-action@v1
@@ -204,7 +228,7 @@ jobs:
           docker push "${INDEX}:${TAG}"
 
       - name: Notify slack
-        if: ${{ always() }}
+        if: ${{ contains(github.ref, 'redhat-') && always() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: team-quay-bots

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to attach to image'     
+        description: 'Tag to attach to image'
         required: true
 jobs:
   image:

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -9,7 +9,6 @@
 #
 # REQUIREMENTS:
 #  * a valid login session to an OCP cluster, with cluster admin privileges
-#  * the namespace $NAMESPACE exists in the cluster
 #  * noobaa backing storage (TODO: elaborate)
 #  * `curl`
 #  * `docker`
@@ -42,7 +41,6 @@ export OG_PATH=${OG_PATH:-'./bundle/quay-operator.operatorgroup.yaml'}
 export SUBSCRIPTION_PATH=${SUBSCRIPTION_PATH:-'./bundle/quay-operator.subscription.yaml'}
 export QUAY_SAMPLE_PATH=${QUAY_SAMPLE_PATH:-'./config/samples/managed.quayregistry.yaml'}
 export OPERATOR_PKG_NAME=${OPERATOR_PKG_NAME:-'quay-operator-test'}
-export NAMESPACE=${NAMESPACE:-'quay-operator-e2e-nightly'}
 export WAIT_TIMEOUT=${WAIT_TIMEOUT:-'20m'}
 
 info 'calculating catalog index image digest'

--- a/hack/storage.sh
+++ b/hack/storage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# deploys noobaa via openshift storage operator to a cluster from redhat
+# deploys noobaa via openshift data foundation operator to a cluster from redhat
 # marketplace.
 #
 # REQUIREMENTS:
@@ -23,7 +23,7 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   annotations:
-  name: openshift-storage-og
+  name: odf-og
   namespace: openshift-storage
 spec:
   targetNamespaces:
@@ -33,13 +33,13 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   labels:
-    operators.coreos.com/ocs-operator.openshift-storage: ""
-  name: ocs-operator
+    operators.coreos.com/odf-operator.openshift-storage: ""
+  name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.8
+  channel: stable-4.9
   installPlanApproval: Automatic
-  name: ocs-operator
+  name: odf-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF
@@ -49,7 +49,7 @@ NAMESPACE='openshift-storage'
 info 'waiting for CSV installation...'
 
 for _ in {1..60}; do
-	phase="$(oc -n "${NAMESPACE}" get csv -l operators.coreos.com/ocs-operator.openshift-storage -o jsonpath='{.items[*].status.phase}')"
+	phase="$(oc -n "${NAMESPACE}" get csv -l operators.coreos.com/odf-operator.openshift-storage -o jsonpath='{.items[*].status.phase}')"
 	if [ "$phase" = "Succeeded" ]; then
 		info "operator installed"
 		break

--- a/hack/teardown.sh
+++ b/hack/teardown.sh
@@ -14,6 +14,10 @@ function info {
 export OPERATOR_PKG_NAME=${OPERATOR_PKG_NAME:-'quay-operator-test'}
 export OG_PATH=${OG_PATH:-'./bundle/quay-operator.operatorgroup.yaml'}
 export SUBSCRIPTION_PATH=${SUBSCRIPTION_PATH:-'./bundle/quay-operator.subscription.yaml'}
+export QUAY_SAMPLE_PATH=${QUAY_SAMPLE_PATH:-'./config/samples/managed.quayregistry.yaml'}
+
+info 'deleting quay registry'
+oc delete $(yq '.metadata.name' ${QUAY_SAMPLE_PATH})
 
 info 'uninstalling operator'
 oc delete operatorgroup "$(yq e '.metadata.name' "${OG_PATH}")"


### PR DESCRIPTION
* adds option to run it manually against supported branches
* ensure workflow jobs will only run against redhat branches
* updates hack/storage.sh to use ODF operator
* cleanup registry deployment on hack/teardown.sh script