### PR TITLE
tls: fix wrong cert bundle index (PROJQUAY-3582)

### DIFF
--- a/pkg/cmpstatus/tls.go
+++ b/pkg/cmpstatus/tls.go
@@ -58,10 +58,10 @@ func (t *TLS) Check(ctx context.Context, reg qv1.QuayRegistry) (qv1.Condition, e
 		return zero, err
 	}
 
-	_, hasCRT := secret.Data["ssl.crt"]
+	_, hasCRT := secret.Data["ssl.cert"]
 	_, hasKey := secret.Data["ssl.key"]
 
-	// if tls is managed we do not expect to find entries for ssl.key and ssl.crt in the
+	// if tls is managed we do not expect to find entries for ssl.key and ssl.cert in the
 	// config bundle secret.
 	if qv1.ComponentIsManaged(reg.Spec.Components, qv1.ComponentTLS) {
 		if hasCRT || hasKey {

--- a/pkg/cmpstatus/tls_test.go
+++ b/pkg/cmpstatus/tls_test.go
@@ -91,8 +91,8 @@ func TestTLSCheck(t *testing.T) {
 						Name: "config-bundle",
 					},
 					Data: map[string][]byte{
-						"ssl.key": []byte(""),
-						"ssl.crt": []byte(""),
+						"ssl.key":  []byte(""),
+						"ssl.cert": []byte(""),
 					},
 				},
 			},
@@ -160,8 +160,8 @@ func TestTLSCheck(t *testing.T) {
 						Name: "config-bundle",
 					},
 					Data: map[string][]byte{
-						"ssl.key": []byte(""),
-						"ssl.crt": []byte(""),
+						"ssl.key":  []byte(""),
+						"ssl.cert": []byte(""),
 					},
 				},
 			},


### PR DESCRIPTION
When checking TLS status the index ssl.crt was being read instead of
ssl.cert. This PR renames the checked index.