### PR TITLE
clair: Consume ca certs starting with clair_extra_ca_cert_ (PROJQUAY-3589)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 tmp
 cover.out
 kubeconfig
+.DS_Store

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -25,8 +25,12 @@ spec:
             - secret: 
                 name: quay-config-tls
         - name: extra-ca-certs
-          configMap:
-            name: cluster-service-ca
+          projected:
+            sources:
+              - configMap:
+                  name: cluster-service-ca
+              - configMap:
+                  name: cluster-trusted-ca
       containers:
         - name: quay-config-editor
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -25,8 +25,12 @@ spec:
             - secret:
                 name: quay-config-tls
         - name: extra-ca-certs
-          configMap:
-            name: cluster-service-ca
+          projected:
+            sources:
+              - configMap:
+                  name: cluster-service-ca
+              - configMap:
+                  name: cluster-trusted-ca
       containers:
         - name: quay-app
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -40,6 +40,8 @@ spec:
                 secretKeyRef:
                   name: quay-proxy-config
                   key: NO_PROXY
+            - name: SSL_CERT_DIR
+              value: $SSL_CERT_DIR:/clair/
           ports:
             - containerPort: 8080
               name: clair-http
@@ -93,4 +95,6 @@ spec:
                   name: quay-config-tls
               - configMap: 
                   name: cluster-service-ca
+              - configMap:
+                  name: cluster-trusted-ca
 

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -31,8 +31,8 @@ spec:
             sources:
               - configMap:
                   name: cluster-service-ca
-              - secret:
-                  name: quay-config-tls
+              - configMap:
+                  name: cluster-trusted-ca
       initContainers:
         - name: quay-mirror-init
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd


### PR DESCRIPTION
- Add ca cert to mounted secret in clair config
- This is required to connect to external db behind custom tls