### PR TITLE
tls: Create secret for shared ca certs (PROJQUAY-3593)

### DIFF
--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -31,6 +31,8 @@ spec:
                   name: cluster-service-ca
               - configMap:
                   name: cluster-trusted-ca
+              - secret:
+                  name: extra-ca-certs
       containers:
         - name: quay-config-editor
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -31,6 +31,8 @@ spec:
                   name: cluster-service-ca
               - configMap:
                   name: cluster-trusted-ca
+              - secret:
+                  name: extra-ca-certs
       containers:
         - name: quay-app
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -40,8 +40,6 @@ spec:
                 secretKeyRef:
                   name: quay-proxy-config
                   key: NO_PROXY
-            - name: SSL_CERT_DIR
-              value: $SSL_CERT_DIR:/clair/
           ports:
             - containerPort: 8080
               name: clair-http
@@ -91,6 +89,8 @@ spec:
         - name: certificates
           projected:
             sources:
+              - secret:
+                  name: extra-ca-certs
               - secret:
                   name: quay-config-tls
               - configMap: 

--- a/kustomize/components/job/quay.upgrade.job.yaml
+++ b/kustomize/components/job/quay.upgrade.job.yaml
@@ -20,8 +20,14 @@ spec:
           secret:
             secretName: quay-config-secret
         - name: extra-ca-certs
-          configMap:
-            name: cluster-service-ca
+          projected:
+            sources:
+              - configMap:
+                  name: cluster-service-ca
+              - configMap:
+                  name: cluster-trusted-ca
+              - secret:
+                  name: extra-ca-certs  
       containers:
         - name: quay-app-upgrade
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -33,6 +33,8 @@ spec:
                   name: cluster-service-ca
               - configMap:
                   name: cluster-trusted-ca
+              - secret:
+                  name: extra-ca-certs      
       initContainers:
         - name: quay-mirror-init
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -304,6 +304,14 @@ func KustomizationFor(
 		ctx.DbRootPw = rootpw
 	}
 
+	userProvidedCaCerts := []string{}
+	for key, val := range quayConfigFiles {
+		if !strings.HasPrefix(key, "extra_ca_cert_") {
+			continue
+		}
+		userProvidedCaCerts = append(userProvidedCaCerts, strings.TrimPrefix(key, "extra_ca_cert_")+"="+string(val))
+	}
+
 	quayConfigTLSSources := []string{}
 	if ctx.ClusterWildcardCert != nil {
 		quayConfigTLSSources = append(quayConfigTLSSources, "ocp-cluster-wildcard.cert="+string(ctx.ClusterWildcardCert))
@@ -342,6 +350,14 @@ func KustomizationFor(
 				Name: configSecretPrefix,
 				KvPairSources: types.KvPairSources{
 					FileSources: configFiles,
+				},
+			},
+		},
+		{
+			GeneratorArgs: types.GeneratorArgs{
+				Name: "extra-ca-certs",
+				KvPairSources: types.KvPairSources{
+					LiteralSources: userProvidedCaCerts,
 				},
 			},
 		},

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -251,6 +251,7 @@ var quayComponents = map[string][]client.Object{
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-registry-managed-secret-keys"}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-service-ca"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "extra-ca-certs"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "quay-proxy-config"}},
 	},
 	"clair": {

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -352,10 +352,12 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 			}
 		}
 
-		for key, val := range configFiles {
-			if strings.HasPrefix(key, "clair_extra_ca_cert_") {
-				cfgFiles["clair_extra_ca_cert_"] = val
-			}
+		// Add ssl key and cert to bundle
+		if val, ok := configFiles["clair-ssl.crt"]; ok {
+			cfgFiles["clair-ssl.crt"] = val
+		}
+		if val, ok := configFiles["clair-ssl.key"]; ok {
+			cfgFiles["clair-ssl.key"] = val
 		}
 
 		if quayHostname == "" {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -46,6 +46,15 @@ func Process(quay *v1.QuayRegistry, obj client.Object, skipres bool) (client.Obj
 		// `/conf/stack`, otherwise it will affect Quay's generated NGINX config
 		delete(configBundleSecret.Data, "ssl.cert")
 		delete(configBundleSecret.Data, "ssl.key")
+		delete(configBundleSecret.Data, "clair-ssl.key")
+		delete(configBundleSecret.Data, "clair-ssl.crt")
+
+		// Remove the ca certs since they are being mounted by extra-ca-certs
+		for key := range configBundleSecret.Data {
+			if strings.HasPrefix(key, "extra_ca_cert_") {
+				delete(configBundleSecret.Data, key)
+			}
+		}
 
 		return configBundleSecret, nil
 	}


### PR DESCRIPTION
- Any key in the provided configBundleSecret that starts with the prefix 'extra_ca_cert_*' will be put in a shared secret called extra-ca-certs
- This will be mounted inside the pods and enables proxy certs to be shared