### PR TITLE
certs-and-proxies: mounting certs in mirror and renaming operator service reference (PROJQUAY-3599)

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -315,9 +315,11 @@ func KustomizationFor(
 	quayConfigTLSSources := []string{}
 	if ctx.ClusterWildcardCert != nil {
 		quayConfigTLSSources = append(quayConfigTLSSources, "ocp-cluster-wildcard.cert="+string(ctx.ClusterWildcardCert))
+		userProvidedCaCerts = append(userProvidedCaCerts, "ocp-cluster-wildcard.crt="+string(ctx.ClusterWildcardCert))
 	}
 	if ctx.TLSCert != nil {
 		quayConfigTLSSources = append(quayConfigTLSSources, "ssl.cert="+string(ctx.TLSCert))
+		userProvidedCaCerts = append(userProvidedCaCerts, "ssl.crt="+string(ctx.TLSCert))
 	}
 	if ctx.TLSKey != nil {
 		quayConfigTLSSources = append(quayConfigTLSSources, "ssl.key="+string(ctx.TLSKey))

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -629,7 +629,7 @@ func operatorServiceEndpoint() string {
 
 	endpoint := "http://quay-operator"
 	if ns := os.Getenv(podNamespaceKey); ns != "" {
-		endpoint = strings.Join([]string{endpoint, ns}, ".")
+		endpoint = fmt.Sprintf("http://quay-operator.%s.svc.cluster.local", ns)
 	}
 
 	return strings.Join([]string{endpoint, "7071"}, ":")

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -124,7 +124,9 @@ func Process(quay *v1.QuayRegistry, obj client.Object, skipres bool) (client.Obj
 		// TODO we must not set annotations in objects where they are not needed. we also
 		// must stop mangling objects in this "middleware" thingy, what is the point of
 		// using kustomize if we keep changing stuff on the fly ?
-		if strings.Contains(dep.GetName(), "quay-database") {
+		isQuayDB := strings.Contains(dep.GetName(), "quay-database")
+		isClairDB := strings.Contains(dep.GetName(), "clair-postgres")
+		if isQuayDB || isClairDB {
 			delete(dep.Spec.Template.Annotations, "quay-registry-hostname")
 			delete(dep.Spec.Template.Annotations, "quay-buildmanager-hostname")
 			delete(dep.Spec.Template.Annotations, "quay-operator-service-endpoint")


### PR DESCRIPTION
As per each individual commit:

**annotations: stop setting annotations on clair db deployment (PROJQUAY-3599)**

These annotations make the database to be rolled out if one of the
annotations is change. As Clair database is not affected by these
annotations we better not set them (as we already do with the Quay
database).

**cert: mount the user provided certs on mirror (PROJQUAY-3599)**

If we don't mount quay-config-tls then mirror is not aware of the
cluster wildcard cert and can't access Quay through its route.

This commits mounts the cluster wildcard cert (or the cert manually
provided by the user) in the extra_ca_certs directory.

**proxy: use the full service name (PROJQUAY-3599)**

If we don't append the "full domain" to the service name it is quite
hard for the users to allow direct traffic to quay operator service
during reconfigure.

We want to allow users to bypass traffic to svc.cluster.local.