### PR TITLE
env: Add QUAY_VERSION env to quay deployment (PROJQUAY-3514)

### DIFF
--- a/e2e/environment_vars_overwrite/00-assert.yaml
+++ b/e2e/environment_vars_overwrite/00-assert.yaml
@@ -18,6 +18,7 @@ spec:
         - name: NO_PROXY
         - name: TESTING
           value: TESTING
+        - name: QUAY_VERSION
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -75,6 +75,15 @@ func Process(quay *v1.QuayRegistry, obj client.Object, skipres bool) (client.Obj
 					UpsertContainerEnv(ref, oenv)
 				}
 			}
+
+			// Add additional default environment variables to Quay deployment
+			if kind == v1.ComponentQuay {
+				oenv := corev1.EnvVar{Name: "QUAY_VERSION", Value: string(v1.QuayVersionCurrent)}
+				for i := range dep.Spec.Template.Spec.Containers {
+					ref := &dep.Spec.Template.Spec.Containers[i]
+					UpsertContainerEnv(ref, oenv)
+				}
+			}
 		}
 
 		// here we do an attempt to setting the default or overwriten number of replicas


### PR DESCRIPTION
* Passes in `QUAY_VERSION` env variable from operator to quay pods