### PR TITLE
mirrorcerts: mount provided tls (PROJQUAY-3764)

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -35,6 +35,8 @@ spec:
                   name: cluster-trusted-ca
               - secret:
                   name: extra-ca-certs      
+              - secret:
+                  name: quay-config-tls
       initContainers:
         - name: quay-mirror-init
           image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd


### PR DESCRIPTION
Mount the quay-config-tls volume inside the mirror pods