### PR TITLE
chore: decrease e2e resource usage

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -3,5 +3,6 @@ kind: TestSuite
 testDirs:
   - ./e2e
 timeout: 500
+parallel: 1
 suppress: 
  - "events"


### PR DESCRIPTION
As the number of e2e tests grow it also grows the amount of resources
required to run them successfully. This commit forces the e2e to run
in series. This brings us a couple of advantages and one disadvantage:

Pros:
1. Make possible to estimate the necessary amount of resources
2. Remove flakes related to lack of cluster resources
   2.1 We require too much resources
   2.2 Pods tend to remain in "Pending" for longer
   2.3 With pods in "Pending" the tests tend to fail due to timeout

Cons:
1. Tests take longer to run