### PR TITLE
hack: add script to build and publish the operator index

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,3 +1,5 @@
+# NOTE: set the REGISTRY secret to your own quay.io account in your fork to
+# test this workflow!
 ---
 name: Build and Publish Images
 
@@ -24,8 +26,6 @@ jobs:
     name: Set version from branch name
     env:
       BRANCH_PREFIX: redhat- # IMPORTANT! this must match the .on.push.branches prefix!
-      REGISTRY: quay.io/projectquay
-      REPO_NAME: ${{ github.event.repository.name }}
       TAG_SUFFIX: -unstable
     outputs:
       tag: ${{ steps.format-tag.outputs.tag }}
@@ -46,84 +46,16 @@ jobs:
         id: format-tag
         run: echo "::set-output name=tag::${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}"
 
-  quay-image:
+  build-and-publish:
     if: ${{ contains(github.ref, 'redhat-') }}
-    name: Calculate Quay Image Digest
+    name: Build and publish operator catalog index
     runs-on: 'ubuntu-latest'
     outputs:
       digest: ${{ steps.set-output.outputs.digest }}
     env:
-      IMAGE_REGISTRY: quay.io/projectquay
+      REGISTRY: ${{ secrets.REGISTRY || 'quay.io' }}
+      NAMESPACE: ${{ secrets.NAMESPACE || 'projectquay' }}
       TAG: ${{needs.set-version.outputs.tag}}
-    needs: set-version
-    steps:
-      - name: Pull Image
-        id: pull-image
-        run: docker pull "${IMAGE_REGISTRY}"/quay:"${TAG}"
-      - name: Set Output
-        id: set-output
-        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay:${TAG})"
-
-  clair-image:
-    if: ${{ contains(github.ref, 'redhat-') }}
-    name: Calculate Clair Image Digest
-    runs-on: 'ubuntu-latest'
-    outputs:
-      digest: ${{ steps.set-output.outputs.digest }}
-    env:
-      IMAGE_REGISTRY: quay.io/projectquay
-      TAG: nightly
-    steps:
-      - name: Pull Image
-        id: pull-image
-        run: docker pull "${IMAGE_REGISTRY}"/clair:"${TAG}"
-      - name: Set Output
-        id: set-output
-        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/clair:${TAG})"
-
-  builder-image:
-    if: ${{ contains(github.ref, 'redhat-') }}
-    name: Calculate Builder Image Digest
-    runs-on: 'ubuntu-latest'
-    outputs:
-      digest: ${{ steps.set-output.outputs.digest }}
-    env:
-      IMAGE_REGISTRY: quay.io/projectquay
-      TAG: ${{needs.set-version.outputs.tag}}
-    needs: set-version
-    steps:
-      - name: Pull Image
-        id: pull-image
-        run: docker pull "${IMAGE_REGISTRY}"/quay-builder:"${TAG}"
-      - name: Set Output
-        id: set-output
-        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder:${TAG})"
-
-  qemu-builder-image:
-    if: ${{ contains(github.ref, 'redhat-') }}
-    name: Calculate Qemu Builder Image Digest
-    runs-on: 'ubuntu-latest'
-    outputs:
-      digest: ${{ steps.set-output.outputs.digest }}
-    env:
-      IMAGE_REGISTRY: quay.io/projectquay
-      TAG: main
-    steps:
-      - name: Pull Image
-        id: pull-image
-        run: docker pull "${IMAGE_REGISTRY}"/quay-builder-qemu:"${TAG}"
-      - name: Set Output
-        id: set-output
-        run: echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_REGISTRY}/quay-builder-qemu:${TAG})"
-
-  operator-image:
-    if: ${{ contains(github.ref, 'redhat-') }}
-    name: Publish Operator Image
-    runs-on: 'ubuntu-latest'
-    outputs:
-      digest: ${{ steps.set-output.outputs.digest }}
-    env:
-      OPERATOR_IMAGE: quay.io/projectquay/quay-operator:${{needs.set-version.outputs.tag}}
     needs: set-version
     steps:
       - name: Check out the repo
@@ -131,100 +63,28 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref_name }}
 
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
+      - name: Install opm from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
+          opm: "latest"
 
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: ${{ env.OPERATOR_IMAGE }}
-
-      - name: Set digest output
-        id: set-output
-        run: |
-          docker pull "${OPERATOR_IMAGE}"
-          echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${OPERATOR_IMAGE})"
-
-  operator-index-images:
-    if: ${{ contains(github.ref, 'redhat-') }}
-    name: Publish Catalog Index Image
-    runs-on: 'ubuntu-latest'
-    needs: [quay-image, clair-image, builder-image, qemu-builder-image, operator-image, set-version]
-    env:
-      OPERATOR_NAME: quay-operator-test
-      BUNDLE: quay.io/projectquay/quay-operator-bundle
-      INDEX: quay.io/projectquay/quay-operator-index
-      TAG: ${{needs.set-version.outputs.tag}}
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref_name }}
-
-      - name: Login to Quay.io
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Update CSV Image Versions
-        uses: mikefarah/yq@master
-        with:
-          cmd: |
-            yq eval -i '
-              .metadata.name = strenv(OPERATOR_NAME) |
-              .metadata.annotations.quay-version = strenv(TAG) |
-              .metadata.annotations.containerImage = "${{needs.operator-image.outputs.digest}}" |
-              del(.spec.replaces) |
-              .spec.install.spec.deployments[0].name = strenv(OPERATOR_NAME) |
-              .spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "${{needs.operator-image.outputs.digest}}" |
-              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_QUAY") .value = "${{needs.quay-image.outputs.digest}}" |
-              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_CLAIR") .value = "${{needs.clair-image.outputs.digest}}" |
-              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_BUILDER") .value = "${{needs.builder-image.outputs.digest}}" |
-              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_BUILDER_QEMU") .value = "${{needs.qemu-builder-image.outputs.digest}}" |
-              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_POSTGRES") .value = "centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33" |
-              .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_REDIS") .value = "centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542"
-              ' bundle/manifests/quay-operator.clusterserviceversion.yaml
-
-      - name: Update Bundle Annotations
-        uses: mikefarah/yq@master
-        with:
-          cmd: |
-            yq eval -i '
-              .annotations."operators.operatorframework.io.bundle.channel.default.v1" = "test" |
-              .annotations."operators.operatorframework.io.bundle.channels.v1" = "test"
-              ' bundle/metadata/annotations.yaml
-
-      - name: Publish Bundle Image
-        uses: docker/build-push-action@v2
-        with:
-          context: ./bundle
-          file: ./bundle/Dockerfile
-          push: true
-          tags: ${{ env.BUNDLE }}:${{ env.TAG }}
-
-      - name: Get bundle image digest
-        id: bundle-image
-        run: |
-          docker pull ${{ env.BUNDLE }}:${{ env.TAG }}
-          echo "::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.BUNDLE }}:${{ env.TAG }})"
-
-      - name: Publish Catalog Index
+      - name: Install yq
         env:
-          OPM_DOWNLOAD_URL: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.6
-          OPM_TAR: opm-linux.tar.gz
+          VERSION: v4.14.2
+          BINARY: yq_linux_amd64
         run: |
-          wget "${OPM_DOWNLOAD_URL}/${OPM_TAR}"
-          tar xvf "${OPM_TAR}"
-          ./opm index add --build-tool docker --bundles "${{steps.bundle-image.outputs.digest}}" --tag "${INDEX}:${TAG}"
-          docker push "${INDEX}:${TAG}"
+          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.REGISTRY || 'quay.io' }}
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - id: build-and-publish
+        run: ./hack/build.sh
 
       - name: Notify slack
         if: ${{ contains(github.ref, 'redhat-') && always() }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ The original version of the quay-operator is available on the _v1_ branch. The n
 
 This Operator can be installed on any Kubernetes cluster running the [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager). Simply create the provided `CatalogSource` to make the package available on the cluster, then create the `Subscription` to install it.
 
+You can find the latest operator release on [operatorhub.io](https://operatorhub.io/operator/project-quay).
+
+The fastest way to get started is by deploying the operator in an OCP/OKD cluster
+using the setup scripts provided in the `hack` directory:
+
+```sh
+./hack/storage.sh  # install noobaa via ODF operator
+./hack/deploy.sh
+oc create -n <your-namespace> -f ./config/samples/managed.quayregistry.yaml
+```
+
+Or run the steps one by one.
+
+### Step by step
+
 **Create the `CatalogSource`**:
 ```sh
 $ kubectl create -n openshift-marketplace -f ./bundle/quay-operator.catalogsource.yaml
@@ -29,8 +44,6 @@ $ kubectl get packagemanifest --all-namespaces | grep quay
 ```
 
 **Create the `OperatorGroup`**:
-
-NOTE: By default, the `targetNamespaces` field is specified to target the _quay-enterprise_ namespace. Update this value if the namespace the operator is deployed within differs. 
 
 ```sh
 $ kubectl create -n <your-namespace> -f ./bundle/quay-operator.operatorgroup.yaml

--- a/bundle/quay-operator.operatorgroup.yaml
+++ b/bundle/quay-operator.operatorgroup.yaml
@@ -2,6 +2,4 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: quay-operator
-spec:
-  targetNamespaces:
-    - quay-enterprise
+spec: {}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# builds the operator and its OLM catalog index and pushes it to quay.io.
+#
+# by default, the built catalog index is tagged with
+# `quay.io/projectquay/quay-operator-index:3.6-unstable`. you can override the
+# tag alone by exporting TAG before executing this script.
+#
+# To push to your own registry, override the REGISTRY and NAMESPACE env vars,
+# i.e:
+#   $ REGISTRY=quay.io NAMESPACE=yourusername ./hack/build.sh
+#
+# REQUIREMENTS:
+#  * a valid login session to a container registry.
+#  * `docker`
+#  * `yq`
+#  * `opm`
+#
+# NOTE: this script will modify the following files:
+#  - bundle/manifests/quay-operator.clusterserviceversion.yaml
+#  - bundle/metadata/annotations.yaml
+# if `git` is available it will be used to checkout changes to the above files.
+# this means that if you made any changes to them and want them to be persisted,
+# make sure to commit them before running this script.
+set -e
+
+export OPERATOR_NAME='quay-operator-test'
+export REGISTRY=${REGISTRY:-'quay.io'}
+export NAMESPACE=${NAMESPACE:-'projectquay'}
+export TAG=${TAG:-'3.6-unstable'}
+export CSV_PATH=${CSV_PATH:-'bundle/manifests/quay-operator.clusterserviceversion.yaml'}
+export ANNOTATIONS_PATH=${ANNOTATIONS_PATH:-'bundle/metadata/annotations.yaml'}
+
+function cleanup {
+	# shellcheck disable=SC2046
+	if [ -x $(command -v git >/dev/null 2>&1) ]; then
+		git checkout "${CSV_PATH}" >/dev/null 2>&1
+		git checkout "${ANNOTATIONS_PATH}" >/dev/null 2>&1
+	fi
+}
+
+trap cleanup EXIT
+
+# prints pre-formatted info output.
+function info {
+	echo "INFO $(date '+%Y-%m-%dT%H:%M:%S') $*"
+}
+
+# prints pre-formatted error output.
+function error {
+	>&2 echo "ERROR $(date '+%Y-%m-%dT%H:%M:%S') $*"
+}
+
+function digest() {
+	declare -n ret=$2
+	IMAGE=$1
+	docker pull "${IMAGE}"
+	# shellcheck disable=SC2034
+	ret=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE}")
+}
+
+docker build -t "${REGISTRY}/${NAMESPACE}/quay-operator:${TAG}" .
+docker push "${REGISTRY}/${NAMESPACE}/quay-operator:${TAG}"
+digest "${REGISTRY}/${NAMESPACE}/quay-operator:${TAG}" OPERATOR_DIGEST
+
+digest "${REGISTRY}/${NAMESPACE}/quay:${TAG}" QUAY_DIGEST
+digest "${REGISTRY}/${NAMESPACE}/clair:nightly" CLAIR_DIGEST
+digest "${REGISTRY}/${NAMESPACE}/quay-builder:${TAG}" BUILDER_DIGEST
+digest "${REGISTRY}/${NAMESPACE}/quay-builder-qemu:main" BUILDER_QEMU_DIGEST
+# shellcheck disable=SC2034
+POSTGRES_DIGEST='centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33'
+# shellcheck disable=SC2034
+REDIS_DIGEST='centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542'
+
+# need exporting so that yq can see them
+export OPERATOR_DIGEST
+export QUAY_DIGEST
+export CLAIR_DIGEST
+export BUILDER_DIGEST
+export BUILDER_QEMU_DIGEST
+export POSTGRES_DIGEST
+export REDIS_DIGEST
+
+
+# prepare operator files, then build and push operator bundle and catalog
+# index images.
+
+yq eval -i '
+	.metadata.name = strenv(OPERATOR_NAME) |
+	.metadata.annotations.quay-version = strenv(TAG) |
+	.metadata.annotations.containerImage = strenv(OPERATOR_DIGEST) |
+	del(.spec.replaces) |
+	.spec.install.spec.deployments[0].name = strenv(OPERATOR_NAME) |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = strenv(OPERATOR_DIGEST) |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_QUAY") .value = strenv(QUAY_DIGEST) |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_CLAIR") .value = strenv(CLAIR_DIGEST) |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_BUILDER") .value = strenv(BUILDER_DIGEST) |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_BUILDER_QEMU") .value = strenv(BUILDER_QEMU_DIGEST) |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_POSTGRES") .value = strenv(POSTGRES_DIGEST) |
+	.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= select(.name == "RELATED_IMAGE_COMPONENT_REDIS") .value = strenv(REDIS_DIGEST)
+	' "${CSV_PATH}"
+
+yq eval -i '
+	.annotations."operators.operatorframework.io.bundle.channel.default.v1" = "test" |
+	.annotations."operators.operatorframework.io.bundle.channels.v1" = "test"
+	' "${ANNOTATIONS_PATH}"
+
+docker build -f ./bundle/Dockerfile -t "${REGISTRY}/${NAMESPACE}/quay-operator-bundle:${TAG}" ./bundle
+docker push "${REGISTRY}/${NAMESPACE}/quay-operator-bundle:${TAG}"
+digest "${REGISTRY}/${NAMESPACE}/quay-operator-bundle:${TAG}" BUNDLE_DIGEST
+
+opm index add --build-tool docker --bundles "${BUNDLE_DIGEST}" --tag "${REGISTRY}/${NAMESPACE}/quay-operator-index:${TAG}"
+docker push "${REGISTRY}/${NAMESPACE}/quay-operator-index:${TAG}"

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -39,6 +39,17 @@ export OG_PATH=${OG_PATH:-'./bundle/quay-operator.operatorgroup.yaml'}
 export SUBSCRIPTION_PATH=${SUBSCRIPTION_PATH:-'./bundle/quay-operator.subscription.yaml'}
 export OPERATOR_PKG_NAME=${OPERATOR_PKG_NAME:-'quay-operator-test'}
 
+function cleanup {
+	# shellcheck disable=SC2046
+	if [ -x $(command -v git >/dev/null 2>&1) ]; then
+		git checkout "${CATALOG_PATH}" >/dev/null 2>&1
+		git checkout "${SUBSCRIPTION_PATH}" >/dev/null 2>&1
+		git checkout "${OG_PATH}" >/dev/null 2>&1
+	fi
+}
+
+trap cleanup EXIT
+
 info 'calculating catalog index image digest'
 
 docker pull "${CATALOG_IMAGE}"
@@ -83,10 +94,3 @@ for n in {1..60}; do
 	info 'CSV successfully installed'
 	break
 done
-
-# shellcheck disable=SC2046
-if [ -x $(command -v git >/dev/null 2>&1) ]; then
-	git checkout "${CATALOG_PATH}" >/dev/null 2>&1
-	git checkout "${SUBSCRIPTION_PATH}" >/dev/null 2>&1
-	git checkout "${OG_PATH}" >/dev/null 2>&1
-fi


### PR DESCRIPTION
also use it in the build-and-publish github workflow.

---

Test build https://github.com/flavianmissi/quay-operator/runs/6653959789?check_suite_focus=true
(it's red because the notification to slack fails).
I've deployed the operator built with the new script with `hack/deploy.sh` and ran the kuttle e2e tests against that and it worked 🎉 .