### PR TITLE
workflows: trigger build job on schedule (PROJQUAY-3871)

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -11,8 +11,6 @@ on:
         options:
         - redhat-3.6
         - redhat-3.7
-  schedule:
-    - cron: '30 3 * * *' # run before e2e-nightly to ensure a fresh operator build
   push:
     # NOTE: if you trigger this on your branch, ensure its name follows the redhat-X.Y format!
     branches:

--- a/.github/workflows/build-schedule.yaml
+++ b/.github/workflows/build-schedule.yaml
@@ -1,0 +1,66 @@
+---
+name: Build and Publish Images (scheduled)
+on:
+  schedule:
+    - cron: '0 3 * * *' # run before e2e-nightly to ensure a fresh operator build
+
+jobs:
+  trigger-3.6-build:
+    name: "Build and publish 3.6"
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: redhat-3.6
+    steps:
+    - uses: convictional/trigger-workflow-and-wait@v1.3.0
+      with:
+        owner: ${{ github.repository_owner }}
+        repo: 'quay-operator'
+        # see https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow_file_name: build-and-publish.yaml
+        ref: ${{ env.BRANCH }}
+        wait_interval: 30
+        inputs: |
+          {
+            "branch": "${{ env.BRANCH }}"
+          }
+
+  trigger-3.7-build:
+    name: "Build and publish 3.7"
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: redhat-3.7
+    steps:
+    - uses: convictional/trigger-workflow-and-wait@v1.3.0
+      with:
+        owner: ${{ github.repository_owner }}
+        repo: 'quay-operator'
+        # see https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow_file_name: build-and-publish.yaml
+        ref: ${{ env.BRANCH }}
+        wait_interval: 30
+        inputs: |
+          {
+            "branch": "${{ env.BRANCH }}"
+          }
+
+  trigger-3.8-build:
+    name: "Build and publish 3.8"
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: redhat-3.8
+    steps:
+    - uses: convictional/trigger-workflow-and-wait@v1.3.0
+      with:
+        owner: ${{ github.repository_owner }}
+        repo: 'quay-operator'
+        # see https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow_file_name: build-and-publish.yaml
+        ref: ${{ env.BRANCH }}
+        wait_interval: 30
+        inputs: |
+          {
+            "branch": "${{ env.BRANCH }}"
+          }


### PR DESCRIPTION
The schedule on the `buil-and-publish.yaml` workflow doesn't work because the workflow itself expects to run from a `redhat-*` branch, and that doesn't happen on scheduled workflows (they run from the main branch).

This PR introduces a new workflow, that triggers `buil-and-publish.yaml` via api targeting the correct branch.

I've tested this on my fork, and although the builds themselves failed (due to quay.io credentials missing), the trigger itself worked. See https://github.com/flavianmissi/quay-operator/runs/6687638116 and https://github.com/flavianmissi/quay-operator/actions/runs/2420732153 (you can inspect the output on the first link for the triggered workflow id and check that it matches the id on the second link's URL, proving that the first job triggered the second).