### PR TITLE
workflows: use personal access token to trigger workflow (PROJQUAY-3871)

### DIFF
--- a/.github/workflows/build-schedule.yaml
+++ b/.github/workflows/build-schedule.yaml
@@ -16,7 +16,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repo: 'quay-operator'
         # see https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PAT }}
         workflow_file_name: build-and-publish.yaml
         ref: ${{ env.BRANCH }}
         wait_interval: 30
@@ -36,7 +36,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repo: 'quay-operator'
         # see https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PAT }}
         workflow_file_name: build-and-publish.yaml
         ref: ${{ env.BRANCH }}
         wait_interval: 30
@@ -56,7 +56,7 @@ jobs:
         owner: ${{ github.repository_owner }}
         repo: 'quay-operator'
         # see https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PAT }}
         workflow_file_name: build-and-publish.yaml
         ref: ${{ env.BRANCH }}
         wait_interval: 30


### PR DESCRIPTION
seems like the default GITHUB_TOKEN doesn't work when triggering a
workflow, even within the same repository.

---

PAT was created for the quay-devel user (see bitwarden for credentials), and it expires in 90 days.

I didn't catch this on my own tests because I triggered the build-schedule.yaml manually, and that works but not when the workflow triggers via schedule. 🤷 