### PR TITLE
monitoring: Fix PrometheusRule (PROJQUAY-4016)

### DIFF
--- a/kustomize/components/monitoring/quay-alerts.prometheusrule.yaml
+++ b/kustomize/components/monitoring/quay-alerts.prometheusrule.yaml
@@ -17,7 +17,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            description: Pod {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} was restarted {{`{{$value}}`}}
+            description: Pod {{$labels.namespace}}/{{$labels.pod}} was restarted {{$value}}
               times within the last hour
             message: Quay Pod is restarting frequently
             severity_level: warning


### PR DESCRIPTION
Fixes [PROJQUAY-4016](https://issues.redhat.com/browse/PROJQUAY-4016)

Removed the backticks as it is treated as string literal (no substitution is made).

Before:
![image](https://user-images.githubusercontent.com/12197954/176316498-32fa643f-ac40-4669-a60f-865affe0073e.png)

Fix:
![image](https://user-images.githubusercontent.com/12197954/176316464-2b5fc608-f314-4011-a8a2-0967e019ab70.png)

You may want to cherry-pick this commit.

Regards