### PR TITLE
reconciler: Do not infer clairpostgres state from config editor (PROJQUAY-4328)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -185,7 +185,7 @@ const (
 
 // Condition is a single condition of a QuayRegistry.
 // Conditions should follow the "abnormal-true" principle in order to only bring the attention of users to "broken" states.
-// Example: a condition of `type: "Ready", status: "True"`` is less useful and should be omitted whereas `type: "NotReady", status: "True"`
+// Example: a condition of `type: "Ready", status: "True"“ is less useful and should be omitted whereas `type: "NotReady", status: "True"`
 // is more useful when trying to monitor when something is wrong.
 type Condition struct {
 	Type               ConditionType          `json:"type,omitempty"`

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -674,7 +674,7 @@ func Test_hasNecessaryConfig(t *testing.T) {
 			quay: quayWithUnmanagedComponents(v1.ComponentClairPostgres),
 		},
 		{
-			name: "managed clair with unmanaged clairpostgres without	 config",
+			name:   "managed clair with unmanaged clairpostgres without	 config",
 			experr: true,
 			cfg:    map[string][]byte{},
 			quay:   quayWithUnmanagedComponents(v1.ComponentClairPostgres),

--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -105,8 +105,8 @@ func ReconfigureHandler(k8sClient client.Client) func(w http.ResponseWriter, r *
 		for _, component := range quay.Spec.Components {
 
 			var contains bool
-			// HPA and Monitoring don't have fields associated with them so we skip. Route should not change based on config either since fields are optional when managed.
-			if component.Kind == v1.ComponentHPA || component.Kind == v1.ComponentMonitoring || component.Kind == v1.ComponentRoute {
+			// HPA and Monitoring don't have fields associated with them so we skip. Route should not change based on config either since fields are optional when managed. ClairPostgres cannot be set through the config editor
+			if component.Kind == v1.ComponentHPA || component.Kind == v1.ComponentMonitoring || component.Kind == v1.ComponentRoute || component.Kind == v1.ComponentClairPostgres {
 				newComponents = append(newComponents, component)
 				continue
 			}

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -3,7 +3,7 @@ package kustomize
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"runtime"
@@ -203,7 +203,7 @@ func generate(
 				return nil
 			}
 
-			f, err := ioutil.ReadFile(path)
+			f, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- The reconfigure endpoint is setting ClairPostgres as managed if it does not contain configuration values for it
- This should not happen here, since the config editor does not expose this configuration