### PR TITLE
postgres: Use SHA-256 in password auth (PROJQUAY-4529)

### DIFF
--- a/kustomize/components/clairpostgres/clair-postgres-conf-sample.configmap.yaml
+++ b/kustomize/components/clairpostgres/clair-postgres-conf-sample.configmap.yaml
@@ -10,3 +10,4 @@ data:
     log_truncate_on_rotation = on
     log_rotation_age = 1d
     log_rotation_size = 0
+    password_encryption = scram-sha-256


### PR DESCRIPTION
- The current upstream image for Postgres is using MD5 which is blocked on FIPS
- This switches the default password auth to SHA-256
- Migration path for upstream fips users is needed