### PR TITLE
fix: Use autoscaling/v2 (PROJQUAY-5079)

### DIFF
--- a/kustomize/components/horizontalpodautoscaler/clair.horizontalpodautoscaler.yaml
+++ b/kustomize/components/horizontalpodautoscaler/clair.horizontalpodautoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: clair-app

--- a/kustomize/components/horizontalpodautoscaler/mirror.horizontalpodautoscaler.yaml
+++ b/kustomize/components/horizontalpodautoscaler/mirror.horizontalpodautoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: quay-mirror

--- a/kustomize/components/horizontalpodautoscaler/quay.horizontalpodautoscalar.yaml
+++ b/kustomize/components/horizontalpodautoscaler/quay.horizontalpodautoscalar.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: quay-app

--- a/pkg/cmpstatus/evaluator_test.go
+++ b/pkg/cmpstatus/evaluator_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	asv2b2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -237,7 +237,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-app",
 						OwnerReferences: []metav1.OwnerReference{
@@ -250,7 +250,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-mirror",
 						OwnerReferences: []metav1.OwnerReference{
@@ -263,7 +263,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-clair-app",
 						OwnerReferences: []metav1.OwnerReference{
@@ -570,7 +570,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-app",
 						OwnerReferences: []metav1.OwnerReference{
@@ -583,7 +583,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-mirror",
 						OwnerReferences: []metav1.OwnerReference{
@@ -596,7 +596,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-clair-app",
 						OwnerReferences: []metav1.OwnerReference{
@@ -949,7 +949,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-app",
 						OwnerReferences: []metav1.OwnerReference{
@@ -962,7 +962,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-mirror",
 						OwnerReferences: []metav1.OwnerReference{
@@ -975,7 +975,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-clair-app",
 						OwnerReferences: []metav1.OwnerReference{
@@ -1277,7 +1277,7 @@ func TestEvaluate(t *testing.T) {
 			if err := ocsv1a1.AddToScheme(scheme); err != nil {
 				t.Fatalf("unexpected error adding ocs to scheme: %s", err)
 			}
-			if err := asv2b2.AddToScheme(scheme); err != nil {
+			if err := asv2.AddToScheme(scheme); err != nil {
 				t.Fatalf("unexpected error adding hpa to scheme: %s", err)
 			}
 			if err := appsv1.AddToScheme(scheme); err != nil {

--- a/pkg/cmpstatus/hpa.go
+++ b/pkg/cmpstatus/hpa.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	asv2b2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -45,7 +45,7 @@ func (h *HPA) Check(ctx context.Context, reg qv1.QuayRegistry) (qv1.Condition, e
 			Name:      fmt.Sprintf("%s-%s", reg.Name, hpasuffix),
 		}
 
-		var hpa asv2b2.HorizontalPodAutoscaler
+		var hpa asv2.HorizontalPodAutoscaler
 		if err := h.Client.Get(ctx, nsn, &hpa); err != nil {
 			if errors.IsNotFound(err) {
 				return qv1.Condition{

--- a/pkg/cmpstatus/hpa_test.go
+++ b/pkg/cmpstatus/hpa_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	asv2b2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -87,7 +87,7 @@ func TestHPACheck(t *testing.T) {
 				},
 			},
 			objs: []client.Object{
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-app",
 					},
@@ -118,7 +118,7 @@ func TestHPACheck(t *testing.T) {
 				},
 			},
 			objs: []client.Object{
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-app",
 						OwnerReferences: []metav1.OwnerReference{
@@ -131,7 +131,7 @@ func TestHPACheck(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-quay-mirror",
 						OwnerReferences: []metav1.OwnerReference{
@@ -144,7 +144,7 @@ func TestHPACheck(t *testing.T) {
 						},
 					},
 				},
-				&asv2b2.HorizontalPodAutoscaler{
+				&asv2.HorizontalPodAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "registry-clair-app",
 						OwnerReferences: []metav1.OwnerReference{

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -16,7 +16,7 @@ import (
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"golang.org/x/net/http/httpproxy"
 	apps "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -213,7 +213,7 @@ func ModelFor(gvk schema.GroupVersionKind) client.Object {
 		return &route.Route{}
 	case schema.GroupVersionKind{Group: "objectbucket.io", Version: "v1alpha1", Kind: "ObjectBucketClaim"}.String():
 		return &objectbucket.ObjectBucketClaim{}
-	case schema.GroupVersionKind{Group: "autoscaling", Version: "v2beta2", Kind: "HorizontalPodAutoscaler"}.String():
+	case schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"}.String():
 		return &autoscaling.HorizontalPodAutoscaler{}
 	case schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}.String():
 		return &batchv1.Job{}

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -10,7 +10,7 @@ import (
 	objectbucket "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"


### PR DESCRIPTION
autoscaling/v2beta2 isn't available on OCP 4.13, so we have to migrate to autoscaling/v2.