### PR TITLE
ppc64le support for Quay Operator (PROJQUAY-5372)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container: docker.io/library/golang:latest
+    strategy:
+      matrix:
+        platform: ['amd64','ppc64le']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,22 +33,41 @@ jobs:
       - name: Git Diff
         run: git diff --exit-code
       - name: Go Build
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o manager main.go
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.platform }} GO111MODULE=on go build -mod vendor -o manager main.go
   tests:
     name: Tests
     runs-on: ubuntu-latest
     container: docker.io/library/golang:latest
+    strategy:
+      matrix:
+        go-version: ['1.20']
+        platform: ['amd64','ppc64le']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: OS Dependencies
-        run: apt-get update && apt-get install -y tar make gcc
-      - name: Install Kubebuilder
+        run: apt-get update && apt-get install -y tar make gcc docker.io
+      - name: Install Required Packages
         run: |
-          os=$(go env GOOS)
-          arch=$(go env GOARCH)
-          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
-          mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
-          export PATH=$PATH:/usr/local/kubebuilder/bin
-      - name: Tests
-        run: go test -v ./...
+          arch=${{ matrix.platform }}
+          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_${arch}.tar.gz | tar -xz -C /tmp/
+          curl -L https://github.com/etcd-io/etcd/releases/download/v3.4.26/etcd-v3.4.26-linux-${arch}.tar.gz | tar -xz -C /tmp/
+          curl -L https://dl.k8s.io/v1.24.13/kubernetes-server-linux-${arch}.tar.gz | tar -xz -C /tmp/
+          mkdir kubebuilder
+          mkdir kubebuilder/bin
+          mv /tmp/kubebuilder_2.3.1_linux_${arch}/bin/kubebuilder kubebuilder/bin
+          mv /tmp/etcd-v3.4.26-linux-${arch}/etcd kubebuilder/bin
+          mv /tmp/kubernetes/server/bin/kubectl kubebuilder/bin
+          mv /tmp/kubernetes/server/bin/kube-apiserver kubebuilder/bin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Test on ${{ matrix.platform }} 
+        run: >-
+          docker run
+          --rm
+          --platform linux/${{ matrix.platform }} 
+          -v ${{ github.workspace }}:/build
+          -v ${{ github.workspace }}/kubebuilder/bin:/usr/local/kubebuilder/bin
+          -w /build
+          quay.io/projectquay/golang:${{ matrix.go-version }}
+          go test ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,27 +47,12 @@ jobs:
         uses: actions/checkout@v3
       - name: OS Dependencies
         run: apt-get update && apt-get install -y tar make gcc docker.io
-      - name: Install Required Packages
+      - name: Install Kubebuilder
         run: |
-          arch=${{ matrix.platform }}
-          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_${arch}.tar.gz | tar -xz -C /tmp/
-          curl -L https://github.com/etcd-io/etcd/releases/download/v3.4.26/etcd-v3.4.26-linux-${arch}.tar.gz | tar -xz -C /tmp/
-          curl -L https://dl.k8s.io/v1.24.13/kubernetes-server-linux-${arch}.tar.gz | tar -xz -C /tmp/
-          mkdir kubebuilder
-          mkdir kubebuilder/bin
-          mv /tmp/kubebuilder_2.3.1_linux_${arch}/bin/kubebuilder kubebuilder/bin
-          mv /tmp/etcd-v3.4.26-linux-${arch}/etcd kubebuilder/bin
-          mv /tmp/kubernetes/server/bin/kubectl kubebuilder/bin
-          mv /tmp/kubernetes/server/bin/kube-apiserver kubebuilder/bin
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Test on ${{ matrix.platform }} 
-        run: >-
-          docker run
-          --rm
-          --platform linux/${{ matrix.platform }} 
-          -v ${{ github.workspace }}:/build
-          -v ${{ github.workspace }}/kubebuilder/bin:/usr/local/kubebuilder/bin
-          -w /build
-          quay.io/projectquay/golang:${{ matrix.go-version }}
-          go test ./...
+          os=$(go env GOOS)
+          arch=$(go env GOARCH)
+          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
+          mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+          export PATH=$PATH:/usr/local/kubebuilder/bin
+      - name: Tests
+        run: go test -v ./...

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -28,7 +28,7 @@ jobs:
       id: push
       uses: docker/build-push-action@v2
       with:
-        platforms: linux/amd64, linux/s390x, linux/ppc64le
+        platforms: linux/amd64, linux/ppc64le
         push: true
         context: ./
         tags: quay.io/projectquay/quay-operator:${{ github.event.inputs.tag || github.event.number }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -28,6 +28,7 @@ jobs:
       id: push
       uses: docker/build-push-action@v2
       with:
+        platforms: linux/amd64, linux/s390x, linux/ppc64le
         push: true
         context: ./
         tags: quay.io/projectquay/quay-operator:${{ github.event.inputs.tag || github.event.number }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
 
+ARG TARGETOS TARGETARCH
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -10,7 +11,7 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 go build -mod vendor -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod vendor -o manager main.go
 
 FROM scratch
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -10,8 +10,7 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-RUN ARCH=$(uname -m) ; if [[ $ARCH == "x86_64" ]] ; then ARCH = "amd64" ; fi
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH GO111MODULE=on go build -mod vendor -o manager main.go
+RUN CGO_ENABLED=0 go build -mod vendor -o manager main.go
 
 FROM scratch
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o manager main.go
+RUN ARCH=$(uname -m) ; if [[ $ARCH == "x86_64" ]] ; then ARCH = "amd64" ; fi
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH GO111MODULE=on go build -mod vendor -o manager main.go
 
 FROM scratch
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -19,7 +18,7 @@ test: generate fmt vet manifests
 
 test-e2e:
 	mkdir -p ./bin
-	curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64 -o ./bin/kuttl;
+	curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_$(shell uname -m) -o ./bin/kuttl;
 	chmod +x ./bin/kuttl;
 	./bin/kuttl test;
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -26,7 +26,7 @@ set -e
 export OPERATOR_NAME='quay-operator-test'
 export REGISTRY=${REGISTRY:-'quay.io'}
 export NAMESPACE=${NAMESPACE:-'projectquay'}
-export TAG=${TAG:-'3.6-unstable'}
+export TAG=${TAG:-'3.9-unstable'}
 export CSV_PATH=${CSV_PATH:-'bundle/manifests/quay-operator.clusterserviceversion.yaml'}
 export ANNOTATIONS_PATH=${ANNOTATIONS_PATH:-'bundle/metadata/annotations.yaml'}
 
@@ -65,13 +65,13 @@ digest "${REGISTRY}/${NAMESPACE}/quay-operator:${TAG}" OPERATOR_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/quay:${TAG}" QUAY_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/clair:nightly" CLAIR_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/quay-builder:${TAG}" BUILDER_DIGEST
-digest "${REGISTRY}/${NAMESPACE}/quay-builder-qemu:main" BUILDER_QEMU_DIGEST
+digest "${REGISTRY}/${NAMESPACE}/quay-builder-qemu:3.9.0" BUILDER_QEMU_DIGEST
 # shellcheck disable=SC2034
-POSTGRES_DIGEST='centos/postgresql-13-centos7@sha256:71b24684d64da46f960682cc4216222a7e4ed8b1a31dd5a865b3e71afdea20d2'
+POSTGRES_DIGEST='quay.io/sclorg/postgresql-15-c9s@sha256:593910f2d4b895f4924261a3b8b2aa6457892100a01a0c0ad661cd378d810d65'
 # shellcheck disable=SC2034
-POSTGRES_UPGRADE_DIGEST='centos/postgresql-12-centos7@sha256:be8803d45d64870f8dfd018f3110af62e2e1558d64191faea461005e1bd03243'
+POSTGRES_UPGRADE_DIGEST='quay.io/sclorg/postgresql-15-c9s@sha256:593910f2d4b895f4924261a3b8b2aa6457892100a01a0c0ad661cd378d810d65'
 # shellcheck disable=SC2034
-REDIS_DIGEST='centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542'
+digest "docker.io/redis:7.0" REDIS_DIGEST
 
 # need exporting so that yq can see them
 export OPERATOR_DIGEST


### PR DESCRIPTION
Builds and deploys successfully on ppc64le OCP clusters by running `./hack/build.sh` and then `./hack/deploy.sh`
e2e tests pass for all quay-registry builds

Dockerfile supports amd64, ppc64le image operator builds
Makefile runs e2e tests for amd64, ppc64le environments
build.sh has updated amd64, ppc64le supported tag dependencies (quay, quay-builder, quay-builder-qemu clair, redis, postgres)