### PR TITLE
pgupgrade: Block rollout when pgupgrade job fails (PROJQUAY-5235)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -302,7 +302,7 @@ func PostgresUpgradeRunning(quay *QuayRegistry) bool {
 	if created == nil {
 		return false
 	}
-	return created.Reason == ConditionReasonPostgresUpgradeInProgress
+	return created.Reason == ConditionReasonPostgresUpgradeInProgress || created.Reason == ConditionReasonPostgresUpgradeFailed
 }
 
 // FlaggedForDeletion returns a boolean indicating if provided QuayRegistry object has


### PR DESCRIPTION
- This PR adds ConditionReasonPostgresUpgradeFailed as a potential to detect when the upgrade is still running
- Since a failure will keep the QuayRegistry in the upgrade running status, it will block rollout if the upgrade failed