### PR TITLE
pgupgrade: Scale back clair pods when upgrading clair db (PROJQUAY-5235)

### DIFF
--- a/kustomize/overlays/current/pg-upgrade-all/clair.deployment.patch.yaml
+++ b/kustomize/overlays/current/pg-upgrade-all/clair.deployment.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clair-app
+spec:
+  replicas: 0

--- a/kustomize/overlays/current/pg-upgrade-all/kustomization.yaml
+++ b/kustomize/overlays/current/pg-upgrade-all/kustomization.yaml
@@ -8,3 +8,4 @@ patchesStrategicMerge:
   - ./quay.deployment.patch.yaml
   - ./postgres.deployment.patch.yaml
   - ./clair-postgres.deployment.patch.yaml
+  - ./clair.deployment.patch.yaml

--- a/kustomize/overlays/current/pg-upgrade-clair-only/clair.deployment.patch.yaml
+++ b/kustomize/overlays/current/pg-upgrade-clair-only/clair.deployment.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clair-app
+spec:
+  replicas: 0

--- a/kustomize/overlays/current/pg-upgrade-clair-only/kustomization.yaml
+++ b/kustomize/overlays/current/pg-upgrade-clair-only/kustomization.yaml
@@ -5,3 +5,4 @@ bases:
   - ../../../tmp
 patchesStrategicMerge:
   - ./clair-postgres.deployment.patch.yaml
+  - ./clair.deployment.patch.yaml


### PR DESCRIPTION
- When upgrading the clair postgres, scale back the clair pods to prevent further operations
- This will cause the previous postgres deployment to terminate and the upgrade can complete