### PR TITLE
pgupgrade: Increase backoff limit of upgrade job (PROJQUAY-5631)

### DIFF
--- a/kustomize/components/clairpgupgrade/clair-pg-upgrade.job.yaml
+++ b/kustomize/components/clairpgupgrade/clair-pg-upgrade.job.yaml
@@ -95,3 +95,4 @@ spec:
             - "run-postgresql"
           args:
             - "--version"
+  backoffLimit: 20

--- a/kustomize/components/pgupgrade/pg-upgrade.job.yaml
+++ b/kustomize/components/pgupgrade/pg-upgrade.job.yaml
@@ -134,3 +134,4 @@ spec:
             - "run-postgresql"
           args:
             - "--version"
+  backoffLimit: 20


### PR DESCRIPTION
- Increase the backoff limit of upgrade job to ensure they will keep retrying until previous postgres pods have been terminated