### PR TITLE
pgupgrade: Decrease termination grace period to pod shuts down sooner (PROJQUAY-5631)

### DIFF
--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         quay-component: clair-app
     spec:
+      terminationGracePeriodSeconds: 0
       serviceAccountName: clair-app
       affinity:
         podAntiAffinity:

--- a/kustomize/components/clairpgupgrade/clair-pg-upgrade.job.yaml
+++ b/kustomize/components/clairpgupgrade/clair-pg-upgrade.job.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   template:
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       terminationGracePeriodSeconds: 180
       serviceAccountName: clair-postgres
       volumes:
@@ -95,4 +95,4 @@ spec:
             - "run-postgresql"
           args:
             - "--version"
-  backoffLimit: 20
+  backoffLimit: 50

--- a/kustomize/components/pgupgrade/pg-upgrade.job.yaml
+++ b/kustomize/components/pgupgrade/pg-upgrade.job.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   template:
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       terminationGracePeriodSeconds: 180
       serviceAccountName: quay-database
       volumes:
@@ -134,4 +134,4 @@ spec:
             - "run-postgresql"
           args:
             - "--version"
-  backoffLimit: 20
+  backoffLimit: 50


### PR DESCRIPTION
- Termination grace period of 180 seconds is too long, causes delays in shutdown