### PR TITLE
pgupgrade: Use latest images for development (PROJQUAY-5631)

### DIFF
--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -160,11 +160,11 @@ spec:
                       - name: RELATED_IMAGE_COMPONENT_BUILDER_QEMU
                         value: quay.io/projectquay/quay-builder-qemu:main
                       - name: RELATED_IMAGE_COMPONENT_POSTGRES
-                        value: centos/postgresql-13-centos7@sha256:71b24684d64da46f960682cc4216222a7e4ed8b1a31dd5a865b3e71afdea20d2
-                      - name: RELATED_IMAGE_COMPONENT_POSTGRES_UPGRADE
-                        value: centos/postgresql-12-centos7@sha256:be8803d45d64870f8dfd018f3110af62e2e1558d64191faea461005e1bd03243
+                        value: quay.io/sclorg/postgresql-13-c9s:latest
+                      - name: RELATED_IMAGE_COMPONENT_POSTGRES_PREVIOUS
+                        value: centos/postgresql-10-centos7:latest
                       - name: RELATED_IMAGE_COMPONENT_REDIS
-                        value: centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542
+                        value: docker.io/library/redis:7.0
                 serviceAccountName: quay-operator
       permissions:
         - rules:

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -380,7 +380,13 @@ func (r *QuayRegistryReconciler) checkNeedsPostgresUpgradeForComponent(
 	} else {
 		expectedName = expectedImage.Name
 	}
-	if strings.Split(deployedImageName, "@")[0] != expectedName {
+	currentName := deployedImageName
+	if len(strings.Split(currentName, "@")) == 2 {
+		currentName = strings.Split(currentName, "@")[0]
+	} else if len(strings.Split(currentName, ":")) == 2 {
+		currentName = strings.Split(currentName, ":")[0]
+	}
+	if currentName != expectedName {
 		if component == v1.ComponentClairPostgres {
 			r.Log.Info("clair-postgres needs to perform an upgrade, marking in context")
 			qctx.NeedsClairPgUpgrade = true

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -67,11 +67,9 @@ digest "${REGISTRY}/${NAMESPACE}/quay:${TAG}" QUAY_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/clair:nightly" CLAIR_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/quay-builder:${TAG}" BUILDER_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/quay-builder-qemu:3.9.0" BUILDER_QEMU_DIGEST
-digest docker.io/redis:7.0 REDIS_DIGEST
-# shellcheck disable=SC2034
-POSTGRES_DIGEST='quay.io/sclorg/postgresql-13-c9s@sha256:efe7ca31ff169cc8d5f458cc0da4e844b6646a7c1fe76ac4d61a79dcc749f5d1'
-# shellcheck disable=SC2034
-POSTGRES_OLD_DIGEST='centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33'
+digest quay.io/sclorg/postgresql-13-c9s:latest POSTGRES_DIGEST
+digest centos/postgresql-10-centos7:latest POSTGRES_OLD_DIGEST
+digest docker.io/library/redis:7.0 REDIS_DIGEST
 
 # need exporting so that yq can see them
 export OPERATOR_DIGEST
@@ -80,6 +78,7 @@ export CLAIR_DIGEST
 export BUILDER_DIGEST
 export BUILDER_QEMU_DIGEST
 export POSTGRES_DIGEST
+export POSTGRES_OLD_DIGEST
 export REDIS_DIGEST
 
 

--- a/hack/prepare-upstream.sh
+++ b/hack/prepare-upstream.sh
@@ -4,6 +4,30 @@
 # substitution to yq.
 # shellcheck disable=SC2016
 
+current_image() {
+    export YQ_COMPONENT="$1"
+    yq eval '
+        .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |
+            select(.name == ("RELATED_IMAGE_COMPONENT_${YQ_COMPONENT}" | envsubst)).value
+    ' ./bundle/manifests/quay-operator.clusterserviceversion.yaml
+}
+
+digest() {
+    local image
+    image=$(current_image "$1")
+    docker pull "$image" >/dev/null
+    docker inspect --format='{{index .RepoDigests 0}}' "$image"
+}
+
+POSTGRES_DIGEST=$(digest POSTGRES)
+POSTGRES_PREVIOUS_DIGEST=$(digest POSTGRES_PREVIOUS)
+REDIS_DIGEST=$(digest REDIS)
+
+# export variables for yq
+export POSTGRES_DIGEST
+export POSTGRES_PREVIOUS_DIGEST
+export REDIS_DIGEST
+
 yq eval -i '
     .metadata.annotations.createdAt = (now | tz("UTC") | format_datetime("2006-01-02 15:04 UTC")) |
     .metadata.annotations["olm.skipRange"] = (">=3.6.x <${RELEASE}" | envsubst) |
@@ -14,14 +38,17 @@ yq eval -i '
     .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] |= (
         select(.name == "RELATED_IMAGE_COMPONENT_BUILDER").value = ("quay.io/projectquay/quay-builder:${RELEASE}" | envsubst) |
         select(.name == "RELATED_IMAGE_COMPONENT_CLAIR").value = ("quay.io/projectquay/clair:${CLAIR_RELEASE}" | envsubst) |
-        select(.name == "RELATED_IMAGE_COMPONENT_QUAY").value = ("quay.io/projectquay/quay:${RELEASE}" | envsubst)
+        select(.name == "RELATED_IMAGE_COMPONENT_QUAY").value = ("quay.io/projectquay/quay:${RELEASE}" | envsubst) |
+        select(.name == "RELATED_IMAGE_COMPONENT_POSTGRES").value = strenv(POSTGRES_DIGEST) |
+        select(.name == "RELATED_IMAGE_COMPONENT_POSTGRES_PREVIOUS").value = strenv(POSTGRES_PREVIOUS_DIGEST) |
+        select(.name == "RELATED_IMAGE_COMPONENT_REDIS").value = strenv(REDIS_DIGEST)
     ) |
     .spec.version = strenv(RELEASE) |
     .spec.replaces = strenv(REPLACES)
-' bundle/manifests/quay-operator.clusterserviceversion.yaml
+' ./bundle/manifests/quay-operator.clusterserviceversion.yaml
 
 yq eval -i '
     .annotations["operators.operatorframework.io.bundle.channel.default.v1"] = strenv(DEFAULT_CHANNEL) |
     .annotations["operators.operatorframework.io.bundle.channels.v1"] = strenv(CHANNEL) |
     .annotations["operators.operatorframework.io.bundle.package.v1"] = "project-quay"
-' bundle/metadata/annotations.yaml
+' ./bundle/metadata/annotations.yaml

--- a/kustomize/base/config.deployment.yaml
+++ b/kustomize/base/config.deployment.yaml
@@ -35,7 +35,7 @@ spec:
                   name: extra-ca-certs
       containers:
         - name: quay-config-editor
-          image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd
+          image: quay.io/projectquay/quay:latest
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -47,7 +47,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: quay-app
-          image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd
+          image: quay.io/projectquay/quay:latest
           args: ["registry-nomigrate"]
           env:
             - name: QE_K8S_CONFIG_SECRET

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -29,7 +29,7 @@ spec:
                   - clair-app
               topologyKey: "kubernetes.io/hostname"
       containers:
-        - image: quay.io/projectquay/clair@sha256:77ffab0e44458d5725f2e9e5f2f57bda74b3bd073030611ca7cf5d753130c858
+        - image: quay.io/projectquay/clair:nightly
           imagePullPolicy: IfNotPresent
           name: clair-app
           env:

--- a/kustomize/components/clairpgupgrade/clair-pg-old.deployment.yaml
+++ b/kustomize/components/clairpgupgrade/clair-pg-old.deployment.yaml
@@ -29,7 +29,7 @@ spec:
             claimName: clair-postgres
       containers:
         - name: postgres
-          image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33
+          image: centos/postgresql-10-centos7:latest
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432

--- a/kustomize/components/clairpgupgrade/clair-pg-upgrade.job.yaml
+++ b/kustomize/components/clairpgupgrade/clair-pg-upgrade.job.yaml
@@ -21,7 +21,7 @@ spec:
             claimName: clair-postgres-13
       containers:
         - name: clair-postgres-13
-          image: centos/postgresql-13-centos7@sha256:71b24684d64da46f960682cc4216222a7e4ed8b1a31dd5a865b3e71afdea20d2
+          image: quay.io/sclorg/postgresql-13-c9s:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432

--- a/kustomize/components/clairpostgres/postgres.deployment.yaml
+++ b/kustomize/components/clairpostgres/postgres.deployment.yaml
@@ -29,7 +29,7 @@ spec:
             claimName: clair-postgres-13
       containers:
         - name: clair-postgres
-          image: centos/postgresql-13-centos7@sha256:71b24684d64da46f960682cc4216222a7e4ed8b1a31dd5a865b3e71afdea20d2
+          image: quay.io/sclorg/postgresql-13-c9s:latest
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432

--- a/kustomize/components/job/quay.upgrade.job.yaml
+++ b/kustomize/components/job/quay.upgrade.job.yaml
@@ -30,7 +30,7 @@ spec:
                   name: extra-ca-certs  
       containers:
         - name: quay-app-upgrade
-          image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd
+          image: quay.io/projectquay/quay:latest
           args: ["migrate", "head"]
           env:
             - name: QE_K8S_CONFIG_SECRET

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -51,7 +51,7 @@ spec:
                   name: quay-config-tls
       initContainers:
         - name: quay-mirror-init
-          image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd
+          image: quay.io/projectquay/quay:latest
           command:
             - /bin/sh
             - -c
@@ -61,7 +61,7 @@ spec:
               value: $(QUAY_APP_SERVICE_HOST)
       containers:
         - name: quay-mirror
-          image: quay.io/projectquay/quay@sha256:5660d7174218e1cb21bf6ef406602dbe8c01c878c630a9f310fe3e5560d4c2cd
+          image: quay.io/projectquay/quay:latest
           command: ["/quay-registry/quay-entrypoint.sh"]
           args: ["repomirror-nomigrate"]
           env:

--- a/kustomize/components/pgupgrade/quay-pg-old.deployment.yaml
+++ b/kustomize/components/pgupgrade/quay-pg-old.deployment.yaml
@@ -32,7 +32,7 @@ spec:
             claimName: quay-database
       containers:
         - name: postgres
-          image: centos/postgresql-10-centos7@sha256:de1560cb35e5ec643e7b3a772ebaac8e3a7a2a8e8271d9e91ff023539b4dfb33
+          image: centos/postgresql-10-centos7:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432

--- a/kustomize/components/pgupgrade/quay-pg-upgrade.job.yaml
+++ b/kustomize/components/pgupgrade/quay-pg-upgrade.job.yaml
@@ -24,7 +24,7 @@ spec:
             claimName: quay-postgres-13
       containers:
         - name: postgres-upgrade
-          image: centos/postgresql-13-centos7@sha256:71b24684d64da46f960682cc4216222a7e4ed8b1a31dd5a865b3e71afdea20d2
+          image: quay.io/sclorg/postgresql-13-c9s:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -32,7 +32,7 @@ spec:
             claimName: quay-postgres-13
       containers:
         - name: postgres
-          image: centos/postgresql-13-centos7@sha256:71b24684d64da46f960682cc4216222a7e4ed8b1a31dd5a865b3e71afdea20d2
+          image: quay.io/sclorg/postgresql-13-c9s:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432

--- a/kustomize/components/redis/redis.deployment.yaml
+++ b/kustomize/components/redis/redis.deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: quay-redis
       containers:
         - name: redis-master
-          image: centos/redis-32-centos7@sha256:06dbb609484330ec6be6090109f1fa16e936afcf975d1cbc5fff3e6c7cae7542
+          image: docker.io/library/redis:7.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -63,8 +63,8 @@ func ComponentImageFor(component v1.ComponentKind) (types.Image, error) {
 	defaultImagesFor := map[v1.ComponentKind]string{
 		v1.ComponentQuay:     "quay.io/projectquay/quay",
 		v1.ComponentClair:    "quay.io/projectquay/clair",
-		v1.ComponentRedis:    "centos/redis-32-centos7",
-		v1.ComponentPostgres: "centos/postgresql-13-centos7",
+		v1.ComponentRedis:    "docker.io/library/redis",
+		v1.ComponentPostgres: "quay.io/sclorg/postgresql-13-c9s",
 	}
 
 	imageOverride := types.Image{

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -94,8 +94,8 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", Digest: "sha256:abc123"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", Digest: "sha256:abc123"},
-				{Name: "centos/redis-32-centos7", NewName: "redis", Digest: "sha256:abc123"},
-				{Name: "centos/postgresql-13-centos7", NewName: "postgres", Digest: "sha256:abc123"},
+				{Name: "docker.io/library/redis", NewName: "redis", Digest: "sha256:abc123"},
+				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", Digest: "sha256:abc123"},
 			},
 			SecretGenerator: []types.SecretArgs{},
 		},
@@ -127,8 +127,8 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", NewTag: "latest"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", NewTag: "alpine"},
-				{Name: "centos/redis-32-centos7", NewName: "redis", NewTag: "buster"},
-				{Name: "centos/postgresql-13-centos7", NewName: "postgres", NewTag: "latest"},
+				{Name: "docker.io/library/redis", NewName: "redis", NewTag: "buster"},
+				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", NewTag: "latest"},
 			},
 			SecretGenerator: []types.SecretArgs{},
 		},
@@ -159,8 +159,8 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", NewTag: "latest"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", NewTag: "alpine"},
-				{Name: "centos/redis-32-centos7", NewName: "redis", NewTag: "buster"},
-				{Name: "centos/postgresql-13-centos7", NewName: "postgres", NewTag: "latest"},
+				{Name: "docker.io/library/redis", NewName: "redis", NewTag: "buster"},
+				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", NewTag: "latest"},
 			},
 			SecretGenerator: []types.SecretArgs{},
 		},
@@ -194,8 +194,8 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", NewTag: "latest"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", NewTag: "alpine"},
-				{Name: "centos/redis-32-centos7", NewName: "redis", NewTag: "buster"},
-				{Name: "centos/postgresql-13-centos7", NewName: "postgres", NewTag: "latest"},
+				{Name: "docker.io/library/redis", NewName: "redis", NewTag: "buster"},
+				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", NewTag: "latest"},
 				{Name: "centos/postgresql-10-centos7", NewName: "postgres_previous", NewTag: "latest"},
 			},
 			SecretGenerator: []types.SecretArgs{},


### PR DESCRIPTION
It also addresses inconsistencies with environment variables and repository names.