### PR TITLE
change storage.sh ODF version to user's OC version

### DIFF
--- a/hack/storage.sh
+++ b/hack/storage.sh
@@ -6,6 +6,9 @@
 #  * a valid login session to an OCP cluster, with cluster admin privileges
 #  * `oc`
 
+export TAG=${TAG:-"4"}
+VERSION=$(oc version | grep 'Client Version' | cut -f2 -d ":" | cut -f2 -d ".")
+
 # prints pre-formatted info output.
 function info {
 	echo "INFO $(date '+%Y-%m-%dT%H:%M:%S') $*"
@@ -37,7 +40,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.13
+  channel: stable-${TAG}.${VERSION}
   installPlanApproval: Automatic
   name: odf-operator
   source: redhat-operators

--- a/hack/storage.sh
+++ b/hack/storage.sh
@@ -6,8 +6,7 @@
 #  * a valid login session to an OCP cluster, with cluster admin privileges
 #  * `oc`
 
-export TAG=${TAG:-"4"}
-VERSION=$(oc version | grep 'Client Version' | cut -f2 -d ":" | cut -f2 -d ".")
+VERSION=$(oc get clusterversion version -o jsonpath='{range .status.history[?(@.state=="Completed")]}{.version}{"\n"}{end}' | head -n1 | cut -d. -f1-2)
 
 # prints pre-formatted info output.
 function info {
@@ -40,7 +39,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: stable-${TAG}.${VERSION}
+  channel: stable-${VERSION}
   installPlanApproval: Automatic
   name: odf-operator
   source: redhat-operators

--- a/hack/storage.sh
+++ b/hack/storage.sh
@@ -37,7 +37,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.9
+  channel: stable-4.13
   installPlanApproval: Automatic
   name: odf-operator
   source: redhat-operators
@@ -66,11 +66,11 @@ metadata:
   name: noobaa
   namespace: openshift-storage
 spec:
+ dbType: postgres
  dbResources:
    requests:
      cpu: '0.1'
      memory: 1Gi
- dbType: postgres
  coreResources:
    requests:
      cpu: '0.1'


### PR DESCRIPTION
`./hack/storage.sh` fails as stable-4.9 is no longer supported in OperatorHub. Using latest version 4.13 to successfully build ODF via storage.sh rather than installing manually via OperatorHub