### PR TITLE
chore: remove unused arch matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,6 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container: docker.io/library/golang:latest
-    strategy:
-      matrix:
-        platform: [amd64, ppc64le, s390x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Existing jobs had multiple matrix configured but all were running on amd64. 
Following up from https://github.com/quay/quay-operator/pull/768#issuecomment-1681590048 we can remove the matrix and run tests only on amd64.