### PR TITLE
route: increasing route timeout to 5min (PROJQUAY-2679)

### DIFF
--- a/kustomize/components/route/quay.route.yaml
+++ b/kustomize/components/route/quay.route.yaml
@@ -6,7 +6,7 @@ metadata:
     quay-component: quay-app-route
   annotations:
     quay-component: route
-    haproxy.router.openshift.io/timeout: 60s
+    haproxy.router.openshift.io/timeout: 5m
 spec:
   host: $(SERVER_HOSTNAME)
   to:


### PR DESCRIPTION
Pushes to IBM storage fail for larger image layers (10gb) due to timeout of the route.