### PR TITLE
reconfigure: Remove ca-bundle.crt and service-ca.crt (PROJQUAY-5233)

### DIFF
--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -178,6 +178,10 @@ func createUpdatedSecret(reconfigureRequest request, oldSecret corev1.Secret) co
 
 	for fullFilePathname, encodedCert := range reconfigureRequest.Certs {
 		certName := strings.Split(fullFilePathname, "/")[len(strings.Split(fullFilePathname, "/"))-1]
+		// We must strip out cluster provisioned CA certs, as they will be mounted into the pod from separate config maps
+		if certName == "service-ca.crt" || certName == "ca-bundle.crt" {
+			continue
+		}
 		if strings.HasPrefix(fullFilePathname, "extra_ca_certs/") {
 			certName = "extra_ca_cert_" + strings.ReplaceAll(certName, "extra_ca_cert_", "")
 		}


### PR DESCRIPTION
- We need to strip out the cluster provided certs from the reconfigure rrequest to avoid duplication.
- This resolves JSON encoding/decoding issues found in passing this cert through the config editor