### PR TITLE
chore: fix scheduled build and publish due to breaking upgrade

### DIFF
--- a/.github/workflows/build-schedule.yaml
+++ b/.github/workflows/build-schedule.yaml
@@ -20,7 +20,7 @@ jobs:
         workflow_file_name: build-and-publish.yaml
         ref: ${{ env.BRANCH }}
         wait_interval: 30
-        inputs: |
+        client_payload: |
           {
             "branch": "${{ env.BRANCH }}"
           }
@@ -40,7 +40,7 @@ jobs:
         workflow_file_name: build-and-publish.yaml
         ref: ${{ env.BRANCH }}
         wait_interval: 30
-        inputs: |
+        client_payload: |
           {
             "branch": "${{ env.BRANCH }}"
           }
@@ -60,7 +60,7 @@ jobs:
         workflow_file_name: build-and-publish.yaml
         ref: ${{ env.BRANCH }}
         wait_interval: 30
-        inputs: |
+        client_payload: |
           {
             "branch": "${{ env.BRANCH }}"
           }


### PR DESCRIPTION
In the action `convictional/trigger-workflow-and-wait` the inputs paramater `inputs` was renamed to `client_payload`. Since last bump to v1.6.5 this was not changed.