### PR TITLE
chore: update ClusterServiceVersion annotations

### DIFF
--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -6,7 +6,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/projectquay/quay-operator:v3.6.1
-    createdAt: 2021-04-23 10:04 UTC
+    createdAt: 2021-04-23T10:04:00Z
+    support: Project Quay
     description: Opinionated deployment of Quay on Kubernetes.
     quay-version: v3.6.1
     repository: https://github.com/quay/quay-operator

--- a/hack/prepare-upstream.sh
+++ b/hack/prepare-upstream.sh
@@ -29,7 +29,7 @@ export POSTGRES_PREVIOUS_DIGEST
 export REDIS_DIGEST
 
 yq eval -i '
-    .metadata.annotations.createdAt = (now | tz("UTC") | format_datetime("2006-01-02 15:04 UTC")) |
+    .metadata.annotations.createdAt = (now | tz("UTC")) |
     .metadata.annotations["olm.skipRange"] = (">=3.6.x <${RELEASE}" | envsubst) |
     .metadata.annotations["quay-version"] = strenv(RELEASE) |
     .metadata.annotations.containerImage = ("quay.io/projectquay/quay-operator:${RELEASE}" | envsubst) |


### PR DESCRIPTION
OperatorHub has [requirements for annotations][1]. "createdAt" should use the format "yyyy-mm-ddThh:mm:ssZ", "support" should have the name of the company that maintains the operator. This PR should fix issues that are found by [redhat-openshift-ecosystem/community-operators-prod tests][2].

[1]: https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/packaging-required-fields.md
[2]: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/3899