### PR TITLE
clair: Ignore unpatched vulns by default (PROJQUAY-5954)

### DIFF
--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -440,6 +440,13 @@ func clairConfigFor(log logr.Logger, quay *v1.QuayRegistry, quayHostname, preSha
 		"metrics": map[string]interface{}{
 			"name": "prometheus",
 		},
+		"updaters": map[string]interface{}{
+			"config": map[string]interface{}{
+				"rhel": map[string]interface{}{
+					"ignore_unpatched": true,
+				},
+			},
+		},
 	}
 
 	return yaml.Marshal(cfg)


### PR DESCRIPTION
- In the default Clair config, set ignore_unpatched: true