### PR TITLE
overrides: Allow nullable replicas (PROJQUAY-6474)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -144,13 +144,14 @@ type Component struct {
 
 // Override describes configuration overrides for the given managed component
 type Override struct {
-	VolumeSize  *resource.Quantity `json:"volumeSize,omitempty"`
-	Env         []corev1.EnvVar    `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
-	Replicas    *int32             `json:"replicas,omitempty"`
-	Affinity    *corev1.Affinity   `json:"affinity,omitempty"`
-	Labels      map[string]string  `json:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
-	Resources   *Resources         `json:"resources,omitempty"`
+	VolumeSize *resource.Quantity `json:"volumeSize,omitempty"`
+	Env        []corev1.EnvVar    `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// +nullable
+	Replicas    *int32            `json:"replicas,omitempty"`
+	Affinity    *corev1.Affinity  `json:"affinity,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Resources   *Resources        `json:"resources,omitempty"`
 }
 
 // Resources describes the resource limits and requests for a component.

--- a/bundle/manifests/quayregistries.crd.yaml
+++ b/bundle/manifests/quayregistries.crd.yaml
@@ -1107,6 +1107,7 @@ spec:
                           type: object
                         replicas:
                           format: int32
+                          nullable: true
                           type: integer
                         resources:
                           description: Resources describes the resource limits and

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -1107,6 +1107,7 @@ spec:
                           type: object
                         replicas:
                           format: int32
+                          nullable: true
                           type: integer
                         resources:
                           description: Resources describes the resource limits and


### PR DESCRIPTION
- Allow user to set overrides for replicas to null in order to completely remove default value
- This prevents conflicts with HPA in the event that a user wants to use an unmanaged HPA