### PR TITLE
overrides: Allow nullable replicas (PROJQUAY-6474)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -136,12 +136,13 @@ type Component struct {
 
 // Override describes configuration overrides for the given managed component
 type Override struct {
-	VolumeSize  *resource.Quantity `json:"volumeSize,omitempty"`
-	Env         []corev1.EnvVar    `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
-	Replicas    *int32             `json:"replicas,omitempty"`
-	Affinity    *corev1.Affinity   `json:"affinity,omitempty"`
-	Labels      map[string]string  `json:"labels,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
+	VolumeSize *resource.Quantity `json:"volumeSize,omitempty"`
+	Env        []corev1.EnvVar    `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// +nullable
+	Replicas    *int32            `json:"replicas,omitempty"`
+	Affinity    *corev1.Affinity  `json:"affinity,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 type ConditionType string

--- a/bundle/manifests/quayregistries.crd.yaml
+++ b/bundle/manifests/quayregistries.crd.yaml
@@ -1103,6 +1103,7 @@ spec:
                           type: object
                         replicas:
                           format: int32
+                          nullable: true
                           type: integer
                         volumeSize:
                           anyOf:

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -1103,6 +1103,7 @@ spec:
                           type: object
                         replicas:
                           format: int32
+                          nullable: true
                           type: integer
                         volumeSize:
                           anyOf:


### PR DESCRIPTION
- Allow user to set overrides for replicas to null in order to completely remove default value
- This prevents conflicts with HPA in the event that a user wants to use an unmanaged HPA