### PR TITLE
statefulset: Use stateful sets for posgres deployments (PROJQUAY-6672)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,12 +43,5 @@ jobs:
         uses: actions/checkout@v3
       - name: OS Dependencies
         run: apt-get update && apt-get install -y tar make gcc
-      - name: Install Kubebuilder
-        run: |
-          os=$(go env GOOS)
-          arch=$(go env GOARCH)
-          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
-          mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
-          export PATH=$PATH:/usr/local/kubebuilder/bin
       - name: Tests
-        run: go test -v ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: manager
 
 # Run tests
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./... -coverprofile cover.out
 
 test-e2e:
 	mkdir -p ./bin
@@ -107,7 +107,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
 
 # This target called from the prepare-release github action.
 # CHANNEL         - operator channel (eg. stable-3.6, candidate-3.9)

--- a/kustomize/components/clairpgupgrade/base/clair-pg.statefulset.patch.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg.statefulset.patch.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: quay-database
+  name: clair-postgres
 spec:
   replicas: 0

--- a/kustomize/components/clairpgupgrade/base/kustomization.yaml
+++ b/kustomize/components/clairpgupgrade/base/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
   - ./clair-pg-old.persistentvolumeclaim.yaml
   - ./clair-pg-old.deployment.yaml
 patchesStrategicMerge:
-  - ./clair-pg.deployment.patch.yaml
+  - ./clair-pg.statefulset.patch.yaml

--- a/kustomize/components/clairpostgres/kustomization.yaml
+++ b/kustomize/components/clairpostgres/kustomization.yaml
@@ -1,9 +1,9 @@
 # Clair component adds Clair v4 security scanner and its database.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-resources: 
+resources:
   - ./postgres.serviceaccount.yaml
   - ./postgres.persistentvolumeclaim.yaml
-  - ./postgres.deployment.yaml
+  - ./postgres.statefulset.yaml
   - ./postgres.service.yaml
   - ./clair-postgres-conf-sample.configmap.yaml

--- a/kustomize/components/clairpostgres/postgres.statefulset.yaml
+++ b/kustomize/components/clairpostgres/postgres.statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: clair-postgres
   labels:
@@ -7,9 +7,8 @@ metadata:
   annotations:
     quay-component: clair-postgres
 spec:
+  serviceName: clair-postgres
   replicas: 1
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       quay-component: clair-postgres
@@ -57,3 +56,4 @@ spec:
             requests:
               cpu: 500m
               memory: 2Gi
+  volumeClaimTemplates: []

--- a/kustomize/components/pgupgrade/kustomization.yaml
+++ b/kustomize/components/pgupgrade/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - ./quay-pg-old.deployment.yaml
 patchesStrategicMerge:
   - ./quay.deployment.patch.yaml
-  - ./quay-pg.deployment.patch.yaml
+  - ./quay-pg.statefulset.patch.yaml

--- a/kustomize/components/pgupgrade/quay-pg.statefulset.patch.yaml
+++ b/kustomize/components/pgupgrade/quay-pg.statefulset.patch.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: clair-postgres
+  name: quay-database
 spec:
   replicas: 0

--- a/kustomize/components/postgres/kustomization.yaml
+++ b/kustomize/components/postgres/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 resources:
   - ./postgres.serviceaccount.yaml
   - ./postgres.persistentvolumeclaim.yaml
-  - ./postgres.deployment.yaml
+  - ./postgres.statefulset.yaml
   - ./postgres.service.yaml
   - ./postgres-conf-sample.configmap.yaml
 secretGenerator:

--- a/kustomize/components/postgres/postgres.statefulset.yaml
+++ b/kustomize/components/postgres/postgres.statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: quay-database
   labels:
@@ -7,9 +7,8 @@ metadata:
   annotations:
     quay-component: postgres
 spec:
+  serviceName: quay-database
   replicas: 1
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       quay-component: postgres
@@ -76,3 +75,4 @@ spec:
             requests:
               cpu: 500m
               memory: 2Gi
+  volumeClaimTemplates: []

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -221,6 +221,8 @@ func ModelFor(gvk schema.GroupVersionKind) client.Object {
 		return &prometheusv1.ServiceMonitor{}
 	case schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "PrometheusRule"}.String():
 		return &prometheusv1.PrometheusRule{}
+	case schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}.String():
+		return &apps.StatefulSet{}
 	default:
 		panic(fmt.Sprintf("Missing model for GVK %s", gvk.String()))
 	}


### PR DESCRIPTION
- Swap Postgres and Clair Postgres Deployments to StatefulSets

## Summary by Sourcery

Convert Postgres deployments for Quay and Clair from Deployments to StatefulSets to improve database management and persistence

Enhancements:
- Migrate Postgres and Clair Postgres configurations from Deployments to StatefulSets to provide better stateful application management

CI:
- Update CI workflow to simplify test command
- Remove manual Kubebuilder installation step

Chores:
- Update Kustomize configurations and patches to reflect StatefulSet changes
- Modify Kubernetes resource management to use StatefulSet kind