### PR TITLE
hpa: Do not set replicas to 2 when override set to null (PROJQUAY-6474)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	quaycontext "github.com/quay/quay-operator/pkg/context"
@@ -762,6 +763,10 @@ func GetReplicasOverrideForComponent(quay *QuayRegistry, kind ComponentKind) *in
 		}
 
 		if cmp.Overrides == nil {
+			return ptr.To[int32](2)
+		}
+
+		if cmp.Overrides.Replicas == nil {
 			return nil
 		}
 

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/pem"
+	err "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -373,7 +374,7 @@ func (r *QuayRegistryReconciler) checkMonitoringAvailable(
 	if len(r.WatchNamespace) > 0 {
 		msg := "Monitoring is only supported in AllNamespaces mode. Disabling."
 		r.Log.Info(msg)
-		return fmt.Errorf(msg)
+		return err.New(msg)
 	}
 
 	var serviceMonitors prometheusv1.ServiceMonitorList

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -122,12 +121,11 @@ func Process(quay *v1.QuayRegistry, qctx *quaycontext.QuayRegistryContext, obj c
 				// if no number of replicas has been set in kustomization files
 				// we set its value to two or to the value provided by the user
 				// as an override (if provided).
-				desired := ptr.To[int32](2)
+
 				if r := v1.GetReplicasOverrideForComponent(quay, kind); r != nil {
-					desired = r
+					dep.Spec.Replicas = r
 				}
 
-				dep.Spec.Replicas = desired
 				break
 			}
 		}


### PR DESCRIPTION
- When replicas override is set to null, the deployment should not be edited