### PR TITLE
pgupgrade: Use different service for postgres old (PROJQUAY-6672)

### DIFF
--- a/kustomize/components/clairpgupgrade/base/clair-pg-old.deployment.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg-old.deployment.yaml
@@ -3,20 +3,20 @@ kind: Deployment
 metadata:
   name: clair-postgres-old
   labels:
-    quay-component: clair-postgres
+    quay-component: clair-postgres-old
   annotations:
-    quay-component: clair-postgres
+    quay-component: clair-postgres-old
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      quay-component: clair-postgres
+      quay-component: clair-postgres-old
   template:
     metadata:
       labels:
-        quay-component: clair-postgres
+        quay-component: clair-postgres-old
     spec:
       terminationGracePeriodSeconds: 180
       serviceAccountName: clair-postgres

--- a/kustomize/components/clairpgupgrade/base/clair-pg-old.service.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg-old.service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: clair-postgres-old
+  labels:
+    quay-component: clair-postgres-old
+  annotations:
+    quay-component: clair-postgres-old
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      protocol: TCP
+      name: postgres
+      targetPort: 5432
+  selector:
+    quay-component: clair-postgres-old

--- a/kustomize/components/clairpgupgrade/base/clair-pg-upgrade.job.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg-upgrade.job.yaml
@@ -31,7 +31,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: clair-config-secret
-                  key: clair-db-host
+                  key: clair-db-old-host
             - name: POSTGRESQL_MIGRATION_ADMIN_PASSWORD
               value: postgres
             - name: POSTGRESQL_SHARED_BUFFERS
@@ -49,9 +49,9 @@ spec:
               cpu: 500m
               memory: 2Gi
           command:
-          - "/bin/sh"
-          - "-c"
+            - "/bin/sh"
+            - "-c"
           args:
-          - >
-            run-postgresql --version || (echo "postgres migration command failed, cleaning up..." && rm -rf /var/lib/pgsql/data/* && exit 1)
+            - >
+              run-postgresql --version || (echo "postgres migration command failed, cleaning up..." && rm -rf /var/lib/pgsql/data/* && exit 1)
   backoffLimit: 50

--- a/kustomize/components/clairpgupgrade/base/kustomization.yaml
+++ b/kustomize/components/clairpgupgrade/base/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - ./clair-pg-upgrade.job.yaml
   - ./clair-pg-old.persistentvolumeclaim.yaml
   - ./clair-pg-old.deployment.yaml
+  - ./clair-pg-old.service.yaml
 patchesStrategicMerge:
   - ./clair-pg.deployment.patch.yaml

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -377,6 +377,7 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 		cfgFiles["config.yaml"] = cfg
 		cfgFiles["01_user_config.yaml"] = configFiles["clair-config.yaml"]
 		cfgFiles["clair-db-host"] = []byte(strings.TrimSpace(strings.Join([]string{quay.GetName(), "clair-postgres"}, "-")))
+		cfgFiles["clair-db-old-host"] = []byte(strings.TrimSpace(strings.Join([]string{quay.GetName(), "clair-postgres-old"}, "-")))
 
 		return cfgFiles, nil
 	default:


### PR DESCRIPTION
- Use a different service for the old postgres deployment during the upgrade process
- This ensures that the service will not point to the terminating deployment