### PR TITLE
pgupgrade: updating pvc reference (PROJQUAY-8092)

### DIFF
--- a/kustomize/components/clairpgupgrade/base/clair-pg-old.deployment.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg-old.deployment.yaml
@@ -26,7 +26,7 @@ spec:
             name: clair-postgres-conf-sample
         - name: postgres-data
           persistentVolumeClaim:
-            claimName: clair-postgres
+            claimName: clair-postgres-13
       containers:
         - name: postgres
           image: quay.io/sclorg/postgresql-13-c9s:latest

--- a/kustomize/components/clairpgupgrade/base/clair-pg-old.persistentvolumeclaim.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg-old.persistentvolumeclaim.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: clair-postgres
+  name: clair-postgres-13
   labels:
     quay-component: clair-postgres
   annotations:


### PR DESCRIPTION
The "old" clair postgres deployment needs to refer to the correct PVC. In this case the upgrade was referring to `clair-postgres` instead of `clair-postgres-13` which caused the migration to run with no data.