### PR TITLE
mirror: fix mirror init command (PROJQUAY-8187)

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -65,9 +65,9 @@ spec:
         - name: quay-mirror-init
           image: quay.io/projectquay/quay:latest
           command:
-            - /bin/sh
-            - -c
-            - curl $QUAY_APP_SERVICE_HOST --connect-timeout 360
+          - sh
+          - -c
+          - python -c "import os, requests, sys; host = os.getenv(\"QUAY_APP_SERVICE_HOST\"); sys.exit(0) if requests.get(\"http://\"+host) else sys.exit(1);"
           env:
             - name: QUAY_APP_SERVICE_HOST
               value: $(QUAY_APP_SERVICE_HOST)


### PR DESCRIPTION
- Mirror init container throws OOM when using curl
- Use requests library instead to hit Quay endpoint