### PR TITLE
adding verify false to mirror check (PROJQUAY-8577)

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -67,7 +67,7 @@ spec:
           command:
           - sh
           - -c
-          - python -c "import os, requests, sys; host = os.getenv(\"QUAY_APP_SERVICE_HOST\"); sys.exit(0) if requests.get(\"http://\"+host) else sys.exit(1);"
+          - python -c "import os, requests, sys; host = os.getenv(\"QUAY_APP_SERVICE_HOST\"); sys.exit(0) if requests.get(\"http://\"+host, verify=False) else sys.exit(1);"
           env:
             - name: QUAY_APP_SERVICE_HOST
               value: $(QUAY_APP_SERVICE_HOST)

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -67,7 +67,7 @@ spec:
           command:
           - sh
           - -c
-          - python -c "import os, requests, sys; host = os.getenv(\"QUAY_APP_SERVICE_HOST\"); sys.exit(0) if requests.get(\"http://\"+host, verify=False) else sys.exit(1);"
+          - python -c "import os, requests, sys; host = os.getenv(\"QUAY_APP_SERVICE_HOST\"); sys.exit(0) if requests.get(\"http://\"+host, verify=False, allow_redirects=False) else sys.exit(1);"
           env:
             - name: QUAY_APP_SERVICE_HOST
               value: $(QUAY_APP_SERVICE_HOST)


### PR DESCRIPTION
The init check in the mirror container previously did not verify TLS, nor does it need to. It just needs to ensure that Quay is responding. When we switched to python TLS was still being verified. We disable this and allow redirects which only checks the connection. 