### PR TITLE
timeout: increase timeout of haproxy (PROJQUAY-8771)

### DIFF
--- a/kustomize/components/route/builder.route.yaml
+++ b/kustomize/components/route/builder.route.yaml
@@ -6,6 +6,7 @@ metadata:
     quay-component: quay-builder-route
   annotations:
     quay-component: route
+    haproxy.router.openshift.io/timeout: 30m
 spec:
   host: $(BUILDMAN_HOSTNAME)
   to:


### PR DESCRIPTION
- We want to support larger uploads for AI model support
- Increase timeout of pushes to allow for larger files

## Summary by Sourcery

Enhancements:
- Extended HAProxy timeout to 30 minutes to accommodate larger file uploads