### PR TITLE
fix: increase quay route timeout to 30m

### DIFF
--- a/kustomize/components/route/quay.route.yaml
+++ b/kustomize/components/route/quay.route.yaml
@@ -6,7 +6,7 @@ metadata:
     quay-component: quay-app-route
   annotations:
     quay-component: route
-    haproxy.router.openshift.io/timeout: 10m
+    haproxy.router.openshift.io/timeout: 30m
 spec:
   host: $(SERVER_HOSTNAME)
   to:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Extended the HAProxy router timeout to allow longer-running operations