### PR TITLE
ci: adding job to sync master with release branches

### DIFF
--- a/.github/workflows/branch-sync.yaml
+++ b/.github/workflows/branch-sync.yaml
@@ -1,0 +1,40 @@
+name: Sync Master to Release Branch
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync_master_to_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions-bot@users.noreply.github.com"
+
+      - name: Merge master into release
+        run: |
+          BRANCH_NAME="redhat-3.15"
+          echo "Syncing master to $BRANCH_NAME"
+          git checkout master
+          git pull origin master
+          MASTER_COMMIT=$(git rev-parse HEAD)
+
+          git fetch origin $BRANCH_NAME
+          git checkout $BRANCH_NAME
+          git pull origin $BRANCH_NAME
+          RELEASE_COMMIT=$(git rev-parse HEAD)
+          echo "Rebasing $BRANCH_NAME ($RELEASE_COMMIT) onto master ($MASTER_COMMIT)"
+          git rebase master
+          git push origin $BRANCH_NAME
+
+          echo "Merged master ($MASTER_COMMIT) into $BRANCH_NAME ($RELEASE_COMMIT)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow to automatically rebase and push the redhat-3.15 release branch onto master on each master push

CI:
- Introduce branch-sync.yaml workflow triggered on master pushes
- Check out the repository with full history and configure Git user
- Fetch, rebase the redhat-3.15 branch onto the latest master, and push updates