### PR TITLE
PROJQUAY-8703: Read Only Root Filesystem

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -110,6 +110,8 @@ spec:
             limits:
               cpu: 2000m
               memory: 8Gi
+          securityContext:
+            readOnlyRootFilesystem: true
           startupProbe:
             httpGet:
               path: /health/instance

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -90,6 +90,8 @@ spec:
             limits:
               cpu: 4000m
               memory: 16Gi
+          securityContext:
+            readOnlyRootFilesystem: true
       restartPolicy: Always
       volumes:
         - name: cluster-trusted-ca

--- a/kustomize/components/clairpostgres/postgres.deployment.yaml
+++ b/kustomize/components/clairpostgres/postgres.deployment.yaml
@@ -57,3 +57,5 @@ spec:
             requests:
               cpu: 500m
               memory: 2Gi
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/kustomize/components/job/quay.upgrade.job.yaml
+++ b/kustomize/components/job/quay.upgrade.job.yaml
@@ -85,3 +85,5 @@ spec:
               mountPath: /run/secrets/postgresql
             - name: postgres-certs-store
               mountPath: /.postgresql
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -122,3 +122,5 @@ spec:
             limits:
               cpu: 1000m
               memory: 2Gi
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -76,3 +76,5 @@ spec:
             requests:
               cpu: 500m
               memory: 2Gi
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/kustomize/components/redis/redis.deployment.yaml
+++ b/kustomize/components/redis/redis.deployment.yaml
@@ -31,3 +31,5 @@ spec:
             limits:
               cpu: 4000m
               memory: 16Gi
+          securityContext:
+            readOnlyRootFilesystem: true


### PR DESCRIPTION
Add readOnlyRootFilesystem to deployments to comply with product security guidelines.

## Summary by Sourcery

Enhancements:
- Add securityContext.readOnlyRootFilesystem: true to the base Quay deployment, Clair, ClairPostgres, Postgres, Redis, Mirror component deployments, and the Quay upgrade job.