### PR TITLE
init: Refactor mirror worker init script (PROJQUAY-9098)

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - configMap:
                   name: cluster-trusted-ca
               - secret:
-                  name: extra-ca-certs      
+                  name: extra-ca-certs
               - secret:
                   name: quay-config-tls
         - name: postgres-certs
@@ -67,7 +67,7 @@ spec:
           command:
           - sh
           - -c
-          - python -c "import os, requests, sys; host = os.getenv(\"QUAY_APP_SERVICE_HOST\"); sys.exit(0) if requests.get(\"http://\"+host, verify=False, allow_redirects=False) else sys.exit(1);"
+          - python3 mirror-worker-init/mirror-worker-init.py
           env:
             - name: QUAY_APP_SERVICE_HOST
               value: $(QUAY_APP_SERVICE_HOST)


### PR DESCRIPTION
Previous init script did not log anything in the standard output which made it difficult to understand in certain circumstances why the worker was restarting. This script is based on the current init container script but adds logging and some exception trapping. It will ensure that the mirror worker containers do not go into `CrashLoopBackoff` but instead remain in the `init` state until Quay actually responds. 

Related Quay changes: https://github.com/quay/quay/pull/4123

## Summary by Sourcery

Refactor the mirror worker init container to use an external Python3 script with logging and exception handling, and update the deployment configuration accordingly.

Enhancements:
- Replace inline Python one-liner with an external mirror-worker-init.py script for improved logging and error handling
- Ensure mirror worker containers remain in the init state until Quay responds instead of entering CrashLoopBackoff
- Remove trailing whitespace from the extra-ca-certs secret entry in the mirror deployment YAML