### PR TITLE
ci: updating branch sync to use var

### DIFF
--- a/.github/workflows/branch-sync.yaml
+++ b/.github/workflows/branch-sync.yaml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Merge master into release
         run: |
-          BRANCH_NAME="redhat-3.15"
+          BRANCH_NAME="${{ vars.BRANCH_SYNC_TARGET }}"
+          if [ -z "$BRANCH_NAME" ]; then echo "BRANCH_SYNC_TARGET variable is not set" && exit 1; fi
           echo "Syncing master to $BRANCH_NAME"
           git checkout master
           git pull origin master


### PR DESCRIPTION
## Summary by Sourcery

Use a GitHub Actions variable for the branch-sync target and enforce its presence

CI:
- Read the branch-sync target from vars.BRANCH_SYNC_TARGET instead of a hardcoded name
- Add a check to error out when BRANCH_SYNC_TARGET is not defined