### PR TITLE
fix: remove invalid characters from dashboard variable queries (PROJQUAY-9386)

### DIFF
--- a/kustomize/components/monitoring/quay-grafana-dashboard.configmap.yaml
+++ b/kustomize/components/monitoring/quay-grafana-dashboard.configmap.yaml
@@ -974,7 +974,7 @@ data:
                 "value": "quay-namespace"
               }
             ],
-            "query": "namespace,",
+            "query": "namespace",
             "refresh": 0,
             "regex": "",
             "skipUrlSync": false,
@@ -1000,7 +1000,7 @@ data:
                 "value": "quay-metrics"
               }
             ],
-            "query": "service,",
+            "query": "service",
             "refresh": 0,
             "regex": "",
             "skipUrlSync": false,


### PR DESCRIPTION
[OU-672](https://issues.redhat.com/browse/OU-672)

## Summary by Sourcery

Fix invalid characters in Grafana dashboard variable queries by removing trailing commas from 'namespace' and 'service' filters.

Bug Fixes:
- Remove trailing commas from 'namespace' variable query in monitoring dashboard config.
- Remove trailing commas from 'service' variable query in monitoring dashboard config.