### PR TITLE
chore(deps): update go version to 1.24.8 (PROJQUAY-9823)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.21 as builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.24 as builder
 
 ARG TARGETOS TARGETARCH
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/quay/quay-operator
 
-go 1.23
+go 1.24
 
-toolchain go1.23.10
+toolchain go1.24.8
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
Update go version 1.24.8
Fix for CVE-2025-58183

## Summary by Sourcery

Update Go language version and build environment to the latest 1.24.x release.

Build:
- Bump Go module and toolchain version from 1.23.x to 1.24.8.
- Update builder Docker image to use Go 1.24 instead of 1.21.

Chores:
- Align project Go version with patched release addressing recent security vulnerabilities.