### PR TITLE
docs: add AI agent documentation with progressive disclosure (PROJQUAY-9897)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# Quay Operator - AI Agent Guide
+
+Kubernetes operator for deploying [Quay container registry](https://github.com/quay/quay) on OpenShift/Kubernetes.
+
+## Tech Stack
+
+- **Language**: Go 1.23+
+- **Framework**: controller-runtime (Kubebuilder)
+- **CRD**: `QuayRegistry` in `quay.redhat.com/v1`
+- **Dependencies**: PostgreSQL, Redis, Clair, object storage (NooBaa/S3)
+
+## Development Workflow
+
+```bash
+# Build
+make manager
+
+# Run locally against cluster (requires KUBECONFIG)
+make run
+
+# Run without resource requests (dev mode)
+SKIP_RESOURCE_REQUESTS=true make run
+
+# Test
+make test
+
+# Format and vet
+make fmt && make vet
+
+# Generate CRDs and code
+make generate && make manifests
+```
+
+## Project Structure
+
+```
+apis/quay/v1/          # CRD type definitions (QuayRegistry)
+controllers/quay/      # Reconciliation logic
+pkg/kustomize/         # Manifest generation from Kustomize
+pkg/cmpstatus/         # Component health evaluation
+pkg/context/           # Runtime state (cluster capabilities, TLS, storage)
+kustomize/             # Base Kustomize manifests by component
+e2e/                   # E2E tests using kuttl
+hack/                  # Deployment and utility scripts
+```
+
+## Documentation by Topic
+
+Consult these files when working on specific areas:
+
+| Topic | File | When to Read |
+|-------|------|--------------|
+| Architecture | `agent_docs/architecture.md` | Understanding reconciliation flow, controllers, status evaluation |
+| Testing | `agent_docs/testing.md` | Running tests, writing e2e tests, kuttl patterns |
+| Deployment | `agent_docs/deployment.md` | CRD management, OpenShift deployment, image building |
+| Components | `agent_docs/components.md` | Managed components, overrides, adding new components |
+
+## Contributing
+
+All changes require a referenced [PROJQUAY Jira](https://issues.redhat.com/projects/PROJQUAY/issues).
+
+Commit message format:
+```
+<subsystem>: <what changed> (PROJQUAY-####)
+
+<why this change was made>
+```
+
+## Key Conventions
+
+- Maintain existing code style
+- Run `make fmt` before committing
+- Keep CRD backward compatible
+- Test component changes with e2e tests in `e2e/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE
+
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# GEMINI
+
+Please follow instructions from @./AGENTS.md

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -1,0 +1,86 @@
+# Architecture
+
+## Controller Pattern
+
+The operator uses controller-runtime with two reconcilers:
+
+### QuayRegistryReconciler (`controllers/quay/quayregistry_controller.go`)
+
+Main reconciler handling the QuayRegistry lifecycle:
+
+1. **Deletion handling** - Process finalizers when QuayRegistry is deleted
+2. **Migration checks** - Wait for upgrade jobs to complete before proceeding
+3. **Config bundle creation** - Generate initial config secret if missing
+4. **Context gathering** - Detect cluster capabilities (Routes, ObjectStorage, Monitoring)
+5. **Component validation** - Validate overrides and component configuration
+6. **Kustomize inflation** - Generate Kubernetes manifests from Kustomize bases
+7. **Object application** - Apply all generated resources to cluster
+8. **Status update** - Set conditions and registry endpoint
+
+### QuayRegistryStatusReconciler (`controllers/quay/quayregistry_status_controller.go`)
+
+Periodically evaluates component health and updates status conditions.
+
+## Kustomize-Based Manifest Generation
+
+`pkg/kustomize/kustomize.go` inflates QuayRegistry specs into deployable objects:
+
+- Reads base manifests from `kustomize/base/`
+- Applies component overlays from `kustomize/components/`
+- Injects runtime values (secrets, hostnames, TLS certs)
+- Returns slice of `client.Object` ready for cluster application
+
+## Component Status Evaluation
+
+`pkg/cmpstatus/` contains per-component health checkers:
+
+```
+pkg/cmpstatus/
+├── evaluator.go      # Orchestrates all component checks
+├── clair.go          # Clair deployment health
+├── postgres.go       # PostgreSQL StatefulSet health
+├── quay.go           # Quay deployment health
+├── redis.go          # Redis deployment health
+└── ...
+```
+
+Each checker implements:
+```go
+type Checker interface {
+    Name() string
+    Check(context.Context, qv1.QuayRegistry) (qv1.Condition, error)
+}
+```
+
+## Runtime Context
+
+`pkg/context/context.go` carries state through reconciliation:
+
+```go
+type QuayRegistryContext struct {
+    SupportsRoutes       bool   // OpenShift Route API available
+    SupportsObjectStorage bool  // ObjectBucketClaim API available
+    SupportsMonitoring   bool   // Prometheus API available
+    ClusterHostname      string // For generating registry endpoint
+    TLSCert, TLSKey      []byte // TLS configuration
+    // ... storage, database, Clair settings
+}
+```
+
+## Feature Detection
+
+`controllers/quay/features.go` detects cluster capabilities:
+
+- **Routes**: Checks for `route.openshift.io/v1` API
+- **ObjectStorage**: Checks for `objectbucket.io/v1alpha1` API
+- **Monitoring**: Checks for `monitoring.coreos.com/v1` API
+
+Components are automatically managed/unmanaged based on available APIs.
+
+## Config Validation
+
+`pkg/middleware/middleware.go` validates and transforms Quay configuration:
+
+- Validates config against JSON schema
+- Ensures required fields for managed components
+- Merges user config with operator-generated values

--- a/agent_docs/components.md
+++ b/agent_docs/components.md
@@ -1,0 +1,128 @@
+# Components
+
+## QuayRegistry CRD
+
+The `QuayRegistry` custom resource defines a Quay deployment:
+
+```yaml
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: example
+spec:
+  configBundleSecret: quay-config-bundle  # Optional: custom config
+  components:
+    - kind: postgres
+      managed: true
+      overrides:
+        volumeSize: 100Gi
+```
+
+## Managed Components
+
+Components can be `managed: true` (operator handles lifecycle) or `managed: false` (user provides external service).
+
+| Component | Description | Required | Default |
+|-----------|-------------|----------|---------|
+| `quay` | Quay application | Yes (always managed) | managed |
+| `postgres` | Quay database | Yes | managed |
+| `redis` | Build logs, locking | Yes | managed |
+| `objectstorage` | Image blob storage | Yes | managed (if ObjectBucketClaim API available) |
+| `route` | External access | Yes (OpenShift) | managed (if Route API available) |
+| `tls` | TLS certificates | Yes | managed (if no custom certs provided) |
+| `clair` | Vulnerability scanner | No | managed |
+| `clairpostgres` | Clair database | No | managed |
+| `horizontalpodautoscaler` | HPA for Quay/Clair/Mirror | No | managed |
+| `mirror` | Repository mirroring | No | managed |
+| `monitoring` | Prometheus metrics | No | managed (if Prometheus API available) |
+
+## Component Overrides
+
+Overrides customize managed component resources.
+
+### Supported Overrides by Component
+
+| Override | quay | clair | mirror | postgres | clairpostgres | redis |
+|----------|------|-------|--------|----------|---------------|-------|
+| `volumeSize` | - | Yes | - | Yes | Yes | - |
+| `storageClassName` | - | - | - | Yes | Yes | - |
+| `env` | Yes | Yes | Yes | Yes | Yes | Yes |
+| `replicas` | Yes | Yes | Yes | - | - | - |
+| `affinity` | Yes | Yes | Yes | - | - | - |
+| `resources` | Yes | Yes | Yes | Yes | Yes | - |
+| `labels` | Yes | Yes | Yes | Yes | Yes | Yes |
+| `annotations` | Yes | Yes | Yes | Yes | Yes | Yes |
+
+### Override Examples
+
+```yaml
+spec:
+  components:
+    # PostgreSQL with custom storage
+    - kind: postgres
+      managed: true
+      overrides:
+        volumeSize: 100Gi
+        storageClassName: fast-storage
+        env:
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: "500"
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: "2"
+
+    # Quay with custom replicas and affinity
+    - kind: quay
+      managed: true
+      overrides:
+        replicas: 3
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      quay-component: quay-app
+                  topologyKey: kubernetes.io/hostname
+```
+
+## Override Validation
+
+Defined in `apis/quay/v1/quayregistry_types.go`:
+
+- Cannot set overrides on unmanaged components
+- Cannot override replicas when HPA is managed (except to 0 for scale-down)
+- Volume/storage overrides only allowed on components with persistent storage
+
+## Adding a New Component
+
+1. Add `ComponentKind` constant in `apis/quay/v1/quayregistry_types.go`
+2. Add to `AllComponents` slice
+3. Add Kustomize manifests in `kustomize/components/<name>/`
+4. Create status checker in `pkg/cmpstatus/<name>.go`
+5. Update `pkg/kustomize/kustomize.go` to handle the component
+6. Add e2e tests in `e2e/`
+
+## Unmanaged Component Configuration
+
+When a component is unmanaged, provide configuration in the config bundle secret:
+
+```yaml
+# For unmanaged postgres
+DATABASE_SECRET_KEY: <base64-encoded>
+DB_URI: postgresql://user:pass@host:5432/quay
+
+# For unmanaged redis
+BUILDLOGS_REDIS:
+  host: redis.example.com
+  port: 6379
+
+# For unmanaged objectstorage
+DISTRIBUTED_STORAGE_CONFIG:
+  default:
+    - S3Storage
+    - host: s3.amazonaws.com
+      # ... S3 config
+```

--- a/agent_docs/deployment.md
+++ b/agent_docs/deployment.md
@@ -1,0 +1,102 @@
+# Deployment
+
+## Local Development
+
+```bash
+# Install CRDs into cluster
+make install
+
+# Run controller locally
+make run
+
+# Run with namespace restriction
+go run main.go --namespace <your-namespace>
+
+# Run without resource requests (useful for resource-constrained clusters)
+SKIP_RESOURCE_REQUESTS=true make run
+```
+
+## Quick Deployment on OpenShift
+
+```bash
+# 1. Install NooBaa object storage via ODF operator
+./hack/storage.sh
+
+# 2. Deploy the operator from published catalog
+./hack/deploy.sh
+
+# 3. Create a QuayRegistry
+oc create -n <your-namespace> -f ./config/samples/managed.quayregistry.yaml
+```
+
+### Environment Variables for hack/deploy.sh
+
+- `TAG` - Catalog image tag (default: `3.6-unstable`)
+- `CATALOG_IMAGE` - Full catalog image reference
+- `OPERATOR_PKG_NAME` - Operator package name (default: `quay-operator-test`)
+
+## CRD Management
+
+```bash
+# Install CRDs
+make install
+
+# Uninstall CRDs
+make uninstall
+
+# Apply CRDs manually
+kubectl apply -f ./bundle/upstream/manifests/*.crd.yaml
+
+# Generate CRDs from Go types
+make manifests
+```
+
+## Building Container Images
+
+```bash
+# Build operator image
+make docker-build IMG=<registry>/<namespace>/quay-operator:dev
+
+# Push operator image
+make docker-push IMG=<registry>/<namespace>/quay-operator:dev
+```
+
+### Building Custom Catalog
+
+1. Build and push operator image
+2. Update image in `bundle/upstream/manifests/quay-operator.clusterserviceversion.yaml`
+3. Build operator bundle:
+   ```bash
+   docker build -t <registry>/quay-operator-bundle:dev -f ./bundle/Dockerfile ./bundle
+   docker push <registry>/quay-operator-bundle:dev
+   ```
+4. Build operator index:
+   ```bash
+   cd bundle/upstream
+   opm index add --bundles <registry>/quay-operator-bundle:dev --tag <registry>/quay-operator-index:dev
+   docker push <registry>/quay-operator-index:dev
+   ```
+5. Update `bundle/quay-operator.catalogsource.yaml` with index image
+6. Apply CatalogSource:
+   ```bash
+   kubectl create -n openshift-marketplace -f ./bundle/quay-operator.catalogsource.yaml
+   ```
+
+## Sample QuayRegistry Resources
+
+Located in `config/samples/`:
+
+- `managed.quayregistry.yaml` - Fully managed deployment
+- Additional samples for various configurations
+
+## Component Image Overrides
+
+Override component images via environment variables:
+
+```bash
+export RELATED_IMAGE_COMPONENT_QUAY=quay.io/projectquay/quay:v3.10.0
+export RELATED_IMAGE_COMPONENT_CLAIR=quay.io/projectquay/clair:v4.7.0
+export RELATED_IMAGE_COMPONENT_POSTGRES=quay.io/sclorg/postgresql-13-c9s:latest
+export RELATED_IMAGE_COMPONENT_REDIS=docker.io/library/redis:7
+make run
+```

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -1,0 +1,81 @@
+# Testing
+
+## Unit Tests
+
+```bash
+# Run all tests with coverage
+make test
+
+# Run tests directly with verbose output
+go test -v ./...
+
+# Run a single test
+go test -v -run TestFunctionName ./path/to/package/...
+
+# Run tests for a specific package
+go test -v ./pkg/kustomize/...
+go test -v ./controllers/quay/...
+```
+
+## E2E Tests
+
+E2E tests use [kuttl](https://kuttl.dev/) (Kubernetes Test TooL).
+
+```bash
+# Run e2e tests (downloads kuttl if needed)
+make test-e2e
+```
+
+### E2E Test Structure
+
+Tests are in `e2e/` with each scenario in its own directory:
+
+```
+e2e/
+├── happy_path/                    # Basic QuayRegistry creation
+│   ├── 00-create-quay-registry.yaml
+│   └── 00-assert.yaml
+├── hpa/                           # HPA management scenarios
+│   ├── 00-create-quay-registry.yaml
+│   ├── 00-assert.yaml
+│   ├── 01-unmanage-hpa.yaml
+│   └── 01-assert.yaml
+├── affinity_override/             # Affinity override tests
+├── storageclass_overrides/        # StorageClass override tests
+└── ...
+```
+
+### Kuttl Test Files
+
+- `NN-*.yaml` - Test steps (create/update resources)
+- `NN-assert.yaml` - Assertions (expected state)
+- `NN-errors.yaml` - Expected errors (optional)
+
+Steps execute in order (00, 01, 02...). Each step waits for its assertion to pass.
+
+### Writing New E2E Tests
+
+1. Create directory in `e2e/` for your scenario
+2. Add `00-create-quay-registry.yaml` with initial QuayRegistry
+3. Add `00-assert.yaml` with expected conditions/resources
+4. Add numbered steps for mutations and their assertions
+
+Example assertion (`00-assert.yaml`):
+```yaml
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+```
+
+## Test Environment
+
+Tests use envtest (kubebuilder's test environment):
+
+- Spins up local API server and etcd
+- No real cluster required for unit tests
+- E2E tests require a real cluster with `KUBECONFIG` set


### PR DESCRIPTION
## Summary

- Adds structured documentation for AI coding assistants (Claude, Gemini) following progressive disclosure principles
- Creates `CLAUDE.md` and `GEMINI.md` as pointers to shared `AGENTS.md`
- `AGENTS.md` provides high-level project overview and essential dev commands
- `agent_docs/` contains topic-specific detailed documentation:
  - `architecture.md`: reconciliation flow, controllers, status evaluation
  - `testing.md`: unit tests, e2e tests with kuttl
  - `deployment.md`: local dev, OpenShift deployment, image building
  - `components.md`: managed components, overrides, CRD structure

## Test plan

- [ ] Verify documentation renders correctly on GitHub
- [ ] Verify file references work in AI coding assistants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add AI-assistant-focused documentation for the Quay Operator with a central agent guide and topic-specific deep-dive docs.

Documentation:
- Introduce AGENTS.md as a central AI agent guide covering tech stack, workflows, structure, and contributor conventions.
- Add detailed topic docs under agent_docs/ for architecture, testing, deployment, and component management.
- Provide CLAUDE.md and GEMINI.md entry-point files that direct AI coding assistants to the shared documentation.