### PR TITLE
feat: use generated secrets for clair postgres deployment (PROJQUAY-10279)

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -37,11 +37,13 @@ const (
 	datastoreAccessKey     = "AWS_ACCESS_KEY_ID"
 	datastoreSecretKey     = "AWS_SECRET_ACCESS_KEY"
 
-	databaseSecretKey    = "DATABASE_SECRET_KEY"
-	secretKey            = "SECRET_KEY"
-	dbURI                = "DB_URI"
-	dbRootPw             = "DB_ROOT_PW"
-	securityScannerV4PSK = "SECURITY_SCANNER_V4_PSK"
+	databaseSecretKey         = "DATABASE_SECRET_KEY"
+	secretKey                 = "SECRET_KEY"
+	dbURI                     = "DB_URI"
+	dbRootPw                  = "DB_ROOT_PW"
+	securityScannerV4PSK      = "SECURITY_SCANNER_V4_PSK"
+	clairPostgresPassword     = "CLAIR_POSTGRES_PASSWORD"
+	clairPostgresRootPassword = "CLAIR_POSTGRES_ROOT_PASSWORD"
 )
 
 // checkDeprecatedManagedKeys populates the provided quay context with information we
@@ -74,6 +76,8 @@ func (r *QuayRegistryReconciler) checkDeprecatedManagedKeys(
 		qctx.DbUri = string(secret.Data[dbURI])
 		qctx.DbRootPw = string(secret.Data[dbRootPw])
 		qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
+		qctx.ClairPostgresPassword = string(secret.Data[clairPostgresPassword])
+		qctx.ClairPostgresRootPassword = string(secret.Data[clairPostgresRootPassword])
 		break
 	}
 
@@ -105,6 +109,8 @@ func (r *QuayRegistryReconciler) checkManagedKeys(
 	qctx.DbUri = string(secret.Data[dbURI])
 	qctx.DbRootPw = string(secret.Data[dbRootPw])
 	qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
+	qctx.ClairPostgresPassword = string(secret.Data[clairPostgresPassword])
+	qctx.ClairPostgresRootPassword = string(secret.Data[clairPostgresRootPassword])
 	return nil
 }
 

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -78,6 +78,16 @@ func (r *QuayRegistryReconciler) checkDeprecatedManagedKeys(
 		qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
 		qctx.ClairPostgresPassword = string(secret.Data[clairPostgresPassword])
 		qctx.ClairPostgresRootPassword = string(secret.Data[clairPostgresRootPassword])
+
+		// If the managed-keys secret exists but doesn't have clair postgres keys,
+		// this is an upgrade from a version that used hardcoded "postgres" credentials.
+		// Preserve the old password so existing databases remain accessible.
+		if qctx.ClairPostgresPassword == "" {
+			qctx.ClairPostgresPassword = "postgres"
+		}
+		if qctx.ClairPostgresRootPassword == "" {
+			qctx.ClairPostgresRootPassword = "postgres"
+		}
 		break
 	}
 
@@ -111,6 +121,16 @@ func (r *QuayRegistryReconciler) checkManagedKeys(
 	qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
 	qctx.ClairPostgresPassword = string(secret.Data[clairPostgresPassword])
 	qctx.ClairPostgresRootPassword = string(secret.Data[clairPostgresRootPassword])
+
+	// If the managed-keys secret exists but doesn't have clair postgres keys,
+	// this is an upgrade from a version that used hardcoded "postgres" credentials.
+	// Preserve the old password so existing databases remain accessible.
+	if qctx.ClairPostgresPassword == "" {
+		qctx.ClairPostgresPassword = "postgres"
+	}
+	if qctx.ClairPostgresRootPassword == "" {
+		qctx.ClairPostgresRootPassword = "postgres"
+	}
 	return nil
 }
 

--- a/controllers/quay/features_test.go
+++ b/controllers/quay/features_test.go
@@ -1,8 +1,18 @@
 package controllers
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "github.com/quay/quay-operator/apis/quay/v1"
+	quaycontext "github.com/quay/quay-operator/pkg/context"
 )
 
 func Test_extractImageName(t *testing.T) {
@@ -119,5 +129,116 @@ func Test_repositoryNameComparison(t *testing.T) {
 					matches, tt.shouldMatch)
 			}
 		})
+	}
+}
+
+func TestCheckManagedKeys_UpgradeFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+		},
+	}
+	secretName := fmt.Sprintf("%s-%s", quay.Name, v1.ManagedKeysName)
+
+	for _, tt := range []struct {
+		name                      string
+		secretData                map[string][]byte
+		expectedClairPassword     string
+		expectedClairRootPassword string
+	}{
+		{
+			name: "upgrade - secret exists without clair postgres keys",
+			secretData: map[string][]byte{
+				"DATABASE_SECRET_KEY": []byte("some-key"),
+				"SECRET_KEY":          []byte("another-key"),
+			},
+			expectedClairPassword:     "postgres",
+			expectedClairRootPassword: "postgres",
+		},
+		{
+			name: "normal reconcile - secret has clair postgres keys",
+			secretData: map[string][]byte{
+				"DATABASE_SECRET_KEY":          []byte("some-key"),
+				"CLAIR_POSTGRES_PASSWORD":      []byte("random-pw"),
+				"CLAIR_POSTGRES_ROOT_PASSWORD": []byte("random-root-pw"),
+			},
+			expectedClairPassword:     "random-pw",
+			expectedClairRootPassword: "random-root-pw",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: quay.Namespace,
+				},
+				Data: tt.secretData,
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(secret).
+				Build()
+
+			reconciler := QuayRegistryReconciler{
+				Client: fakeClient,
+				Log:    testLogger,
+			}
+
+			qctx := &quaycontext.QuayRegistryContext{}
+			if err := reconciler.checkManagedKeys(context.Background(), qctx, quay); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if qctx.ClairPostgresPassword != tt.expectedClairPassword {
+				t.Errorf("ClairPostgresPassword = %q, want %q",
+					qctx.ClairPostgresPassword, tt.expectedClairPassword)
+			}
+			if qctx.ClairPostgresRootPassword != tt.expectedClairRootPassword {
+				t.Errorf("ClairPostgresRootPassword = %q, want %q",
+					qctx.ClairPostgresRootPassword, tt.expectedClairRootPassword)
+			}
+		})
+	}
+}
+
+func TestCheckManagedKeys_FreshInstall(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	reconciler := QuayRegistryReconciler{
+		Client: fakeClient,
+		Log:    testLogger,
+	}
+
+	qctx := &quaycontext.QuayRegistryContext{}
+	if err := reconciler.checkManagedKeys(context.Background(), qctx, quay); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Fresh install: no secret exists, fields should remain empty
+	// so KustomizationFor() generates random passwords
+	if qctx.ClairPostgresPassword != "" {
+		t.Errorf("ClairPostgresPassword = %q, want empty", qctx.ClairPostgresPassword)
+	}
+	if qctx.ClairPostgresRootPassword != "" {
+		t.Errorf("ClairPostgresRootPassword = %q, want empty", qctx.ClairPostgresRootPassword)
 	}
 }

--- a/kustomize/components/clairpostgres/kustomization.yaml
+++ b/kustomize/components/clairpostgres/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
   - ./postgres.deployment.yaml
   - ./postgres.service.yaml
   - ./clair-postgres-conf-sample.configmap.yaml
+secretGenerator:
+  # NOTE: `clairpostgres-config-secret` fields generated in `kustomize.go`.
+  - name: clairpostgres-config-secret

--- a/kustomize/components/clairpostgres/postgres.deployment.yaml
+++ b/kustomize/components/clairpostgres/postgres.deployment.yaml
@@ -36,13 +36,25 @@ spec:
               protocol: TCP
           env:
             - name: POSTGRESQL_USER
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-username
             - name: POSTGRESQL_DATABASE
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-name
             - name: POSTGRESQL_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-password
             - name: POSTGRESQL_ADMIN_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-root-password
             - name: POSTGRESQL_SHARED_BUFFERS
               value: 256MB
             - name: POSTGRESQL_MAX_CONNECTIONS

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -33,12 +33,12 @@ type QuayRegistryContext struct {
 	SecretKey         string
 
 	// Database
-	DbUri               string
-	DbRootPw            string
-	NeedsPgUpgrade      bool
-	NeedsClairPgUpgrade bool
+	DbUri                     string
+	DbRootPw                  string
+	NeedsPgUpgrade            bool
+	NeedsClairPgUpgrade       bool
 	ClairPostgresPassword     string
-	ClairPostgresRootPassword  string
+	ClairPostgresRootPassword string
 
 	// Clair integration
 	SecurityScannerV4PSK string

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -37,6 +37,8 @@ type QuayRegistryContext struct {
 	DbRootPw            string
 	NeedsPgUpgrade      bool
 	NeedsClairPgUpgrade bool
+	ClairPostgresPassword     string
+	ClairPostgresRootPassword  string
 
 	// Clair integration
 	SecurityScannerV4PSK string

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -336,6 +336,22 @@ func KustomizationFor(
 		ctx.DbRootPw = rootpw
 	}
 
+	if ctx.ClairPostgresPassword == "" {
+		clairPostgresPw, err := generateRandomString(secretKeyLength)
+		if err != nil {
+			return nil, err
+		}
+		ctx.ClairPostgresPassword = clairPostgresPw
+	}
+
+	if ctx.ClairPostgresRootPassword == "" {
+		clairPostgresRootPw, err := generateRandomString(32)
+		if err != nil {
+			return nil, err
+		}
+		ctx.ClairPostgresRootPassword = clairPostgresRootPw
+	}
+
 	userProvidedCaCerts := []string{}
 	for key, val := range quayConfigFiles {
 		if !strings.HasPrefix(key, "extra_ca_cert_") {

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -422,6 +422,8 @@ func KustomizationFor(
 						"DB_URI=" + ctx.DbUri,
 						"DB_ROOT_PW=" + ctx.DbRootPw,
 						"SECURITY_SCANNER_V4_PSK=" + ctx.SecurityScannerV4PSK,
+						"CLAIR_POSTGRES_PASSWORD=" + ctx.ClairPostgresPassword,
+						"CLAIR_POSTGRES_ROOT_PASSWORD=" + ctx.ClairPostgresRootPassword,
 					},
 				},
 			},

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -366,6 +366,9 @@ var quayComponents = map[string][]client.Object{
 	"job": {
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "quay-app-upgrade"}},
 	},
+	"clairpostgres": {
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "clairpostgres-config-secret"}},
+	},
 }
 
 func withComponents(components []string) []client.Object {

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -373,8 +373,7 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 		// Get clair postgres password from context
 		dbPassword := qctx.ClairPostgresPassword
 		if dbPassword == "" {
-			// Fallback to default if not set (for backward compatibility during migration)
-			dbPassword = "postgres"
+			return nil, fmt.Errorf("clair postgres password is empty")
 		}
 		cfg, err := clairConfigFor(log, quay, quayHostname, preSharedKey, dbPassword)
 		if err != nil {

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -370,10 +370,12 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 			preSharedKey = config.(map[string]interface{})["SECURITY_SCANNER_V4_PSK"].(string)
 		}
 
-		// Get clair postgres password from context
-		dbPassword := qctx.ClairPostgresPassword
+		// Get clair postgres root password from context. We use the root password
+		// here because POSTGRESQL_USER=postgres (the superuser), and the SCLORG
+		// container sets the superuser password via POSTGRESQL_ADMIN_PASSWORD.
+		dbPassword := qctx.ClairPostgresRootPassword
 		if dbPassword == "" {
-			return nil, fmt.Errorf("clair postgres password is empty")
+			return nil, fmt.Errorf("clair postgres root password is empty")
 		}
 		cfg, err := clairConfigFor(log, quay, quayHostname, preSharedKey, dbPassword)
 		if err != nil {


### PR DESCRIPTION
Update clair postgres deployment to obtain environment variables from a
generated secret instead of hardcoded values, matching the pattern used
by the quay postgres deployment. This improves security by using randomly
generated passwords and ensures consistency across database deployments.

Changes:
- Add ComponentClairPostgres case in componentConfigFilesFor to generate
  secret fields (database-username, database-password, database-name,
  database-root-password)
- Add ClairPostgresPassword and ClairPostgresRootPassword to context
- Generate passwords in kustomize.go similar to DbRootPw
- Update clairConfigFor to use generated password in connection string
- Add secretGenerator to clairpostgres kustomization.yaml
- Update clairpostgres deployment to use secretKeyRef for all env vars

## Summary by Sourcery

Use generated secrets for Clair Postgres configuration and deployment instead of hardcoded credentials.

New Features:
- Introduce generated Clair Postgres and root passwords stored in context and exposed via a kustomize secret generator for the Clair Postgres deployment.

Enhancements:
- Update Clair configuration generation to consume the dynamically generated Clair Postgres password in the database connection string.
- Add Clair Postgres component config file generation to populate secret fields consumed by the Clair Postgres deployment.