### PR TITLE
use generated secrets for clair postgres deployment

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -37,11 +37,13 @@ const (
 	datastoreAccessKey     = "AWS_ACCESS_KEY_ID"
 	datastoreSecretKey     = "AWS_SECRET_ACCESS_KEY"
 
-	databaseSecretKey    = "DATABASE_SECRET_KEY"
-	secretKey            = "SECRET_KEY"
-	dbURI                = "DB_URI"
-	dbRootPw             = "DB_ROOT_PW"
-	securityScannerV4PSK = "SECURITY_SCANNER_V4_PSK"
+	databaseSecretKey         = "DATABASE_SECRET_KEY"
+	secretKey                 = "SECRET_KEY"
+	dbURI                     = "DB_URI"
+	dbRootPw                  = "DB_ROOT_PW"
+	securityScannerV4PSK      = "SECURITY_SCANNER_V4_PSK"
+	clairPostgresPassword     = "CLAIR_POSTGRES_PASSWORD"
+	clairPostgresRootPassword = "CLAIR_POSTGRES_ROOT_PASSWORD"
 )
 
 // checkDeprecatedManagedKeys populates the provided quay context with information we
@@ -74,6 +76,8 @@ func (r *QuayRegistryReconciler) checkDeprecatedManagedKeys(
 		qctx.DbUri = string(secret.Data[dbURI])
 		qctx.DbRootPw = string(secret.Data[dbRootPw])
 		qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
+		qctx.ClairPostgresPassword = string(secret.Data[clairPostgresPassword])
+		qctx.ClairPostgresRootPassword = string(secret.Data[clairPostgresRootPassword])
 		break
 	}
 
@@ -105,6 +109,8 @@ func (r *QuayRegistryReconciler) checkManagedKeys(
 	qctx.DbUri = string(secret.Data[dbURI])
 	qctx.DbRootPw = string(secret.Data[dbRootPw])
 	qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
+	qctx.ClairPostgresPassword = string(secret.Data[clairPostgresPassword])
+	qctx.ClairPostgresRootPassword = string(secret.Data[clairPostgresRootPassword])
 	return nil
 }
 

--- a/kustomize/components/clairpostgres/kustomization.yaml
+++ b/kustomize/components/clairpostgres/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
   - ./postgres.deployment.yaml
   - ./postgres.service.yaml
   - ./clair-postgres-conf-sample.configmap.yaml
+secretGenerator:
+  # NOTE: `clairpostgres-config-secret` fields generated in `kustomize.go`.
+  - name: clairpostgres-config-secret

--- a/kustomize/components/clairpostgres/postgres.deployment.yaml
+++ b/kustomize/components/clairpostgres/postgres.deployment.yaml
@@ -36,13 +36,25 @@ spec:
               protocol: TCP
           env:
             - name: POSTGRESQL_USER
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-username
             - name: POSTGRESQL_DATABASE
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-name
             - name: POSTGRESQL_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-password
             - name: POSTGRESQL_ADMIN_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-root-password
             - name: POSTGRESQL_SHARED_BUFFERS
               value: 256MB
             - name: POSTGRESQL_MAX_CONNECTIONS

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -33,12 +33,12 @@ type QuayRegistryContext struct {
 	SecretKey         string
 
 	// Database
-	DbUri               string
-	DbRootPw            string
-	NeedsPgUpgrade      bool
-	NeedsClairPgUpgrade bool
+	DbUri                     string
+	DbRootPw                  string
+	NeedsPgUpgrade            bool
+	NeedsClairPgUpgrade       bool
 	ClairPostgresPassword     string
-	ClairPostgresRootPassword  string
+	ClairPostgresRootPassword string
 
 	// Clair integration
 	SecurityScannerV4PSK string

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -37,6 +37,8 @@ type QuayRegistryContext struct {
 	DbRootPw            string
 	NeedsPgUpgrade      bool
 	NeedsClairPgUpgrade bool
+	ClairPostgresPassword     string
+	ClairPostgresRootPassword  string
 
 	// Clair integration
 	SecurityScannerV4PSK string

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -336,6 +336,22 @@ func KustomizationFor(
 		ctx.DbRootPw = rootpw
 	}
 
+	if ctx.ClairPostgresPassword == "" {
+		clairPostgresPw, err := generateRandomString(secretKeyLength)
+		if err != nil {
+			return nil, err
+		}
+		ctx.ClairPostgresPassword = clairPostgresPw
+	}
+
+	if ctx.ClairPostgresRootPassword == "" {
+		clairPostgresRootPw, err := generateRandomString(32)
+		if err != nil {
+			return nil, err
+		}
+		ctx.ClairPostgresRootPassword = clairPostgresRootPw
+	}
+
 	userProvidedCaCerts := []string{}
 	for key, val := range quayConfigFiles {
 		if !strings.HasPrefix(key, "extra_ca_cert_") {

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -422,6 +422,8 @@ func KustomizationFor(
 						"DB_URI=" + ctx.DbUri,
 						"DB_ROOT_PW=" + ctx.DbRootPw,
 						"SECURITY_SCANNER_V4_PSK=" + ctx.SecurityScannerV4PSK,
+						"CLAIR_POSTGRES_PASSWORD=" + ctx.ClairPostgresPassword,
+						"CLAIR_POSTGRES_ROOT_PASSWORD=" + ctx.ClairPostgresRootPassword,
 					},
 				},
 			},

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -366,6 +366,9 @@ var quayComponents = map[string][]client.Object{
 	"job": {
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "quay-app-upgrade"}},
 	},
+	"clairpostgres": {
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "clairpostgres-config-secret"}},
+	},
 }
 
 func withComponents(components []string) []client.Object {

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -373,7 +373,8 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 		// Get clair postgres password from context
 		dbPassword := qctx.ClairPostgresPassword
 		if dbPassword == "" {
-			return nil, fmt.Errorf("clair postgres password is empty")
+			log.Info("ClairPostgresPassword not set in context, using default")
+			dbPassword = "postgres"
 		}
 		cfg, err := clairConfigFor(log, quay, quayHostname, preSharedKey, dbPassword)
 		if err != nil {
@@ -389,11 +390,13 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 		// Use passwords from context (generated in kustomize.go)
 		databasePassword := qctx.ClairPostgresPassword
 		if databasePassword == "" {
-			return nil, fmt.Errorf("ClairPostgresPassword not set in context")
+			log.Info("ClairPostgresPassword not set in context, using default")
+			databasePassword = "postgres"
 		}
 		databaseRootPassword := qctx.ClairPostgresRootPassword
 		if databaseRootPassword == "" {
-			return nil, fmt.Errorf("ClairPostgresRootPassword not set in context")
+			log.Info("ClairPostgresRootPassword not set in context, using default")
+			databaseRootPassword = "postgres"
 		}
 
 		return map[string][]byte{

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -373,8 +373,7 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 		// Get clair postgres password from context
 		dbPassword := qctx.ClairPostgresPassword
 		if dbPassword == "" {
-			// Fallback to default if not set (for backward compatibility during migration)
-			dbPassword = "postgres"
+			return nil, fmt.Errorf("clair postgres password is empty")
 		}
 		cfg, err := clairConfigFor(log, quay, quayHostname, preSharedKey, dbPassword)
 		if err != nil {


### PR DESCRIPTION
debugging https://github.com/quay/quay-operator/pull/1098 further w/ CI changes

WILL NOT MERGE, just using this for CI triggering

## Summary by Sourcery

Use generated Clair Postgres credentials from the Quay registry context and wire them through kustomize, secrets, and deployment manifests.

New Features:
- Introduce generated Clair Postgres and root passwords stored in the QuayRegistryContext and propagated via managed keys secrets.

Enhancements:
- Configure Clair to use the context-provided Postgres password instead of a hardcoded default.
- Add a clairpostgres config secret and reference it from the Clair Postgres deployment environment variables for database credentials.

Tests:
- Extend kustomize tests to assert generation of the Clair Postgres config secret.