### PR TITLE
monitoring: fix Grafana dashboard variable substitution (PROJQUAY-9386)

### DIFF
--- a/kustomize/components/monitoring/quay-grafana-dashboard.configmap.yaml
+++ b/kustomize/components/monitoring/quay-grafana-dashboard.configmap.yaml
@@ -961,6 +961,11 @@ data:
           },
           {
             "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "namespace",
+              "value": "quay-namespace"
+            },
             "datasource": null,
             "hide": 1,
             "includeAll": false,
@@ -974,19 +979,20 @@ data:
                 "value": "quay-namespace"
               }
             ],
-            "query": "namespace",
+            "query": "quay-namespace",
             "refresh": 0,
             "regex": "",
             "skipUrlSync": false,
             "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "custom"
           },
           {
             "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "service",
+              "value": "quay-metrics"
+            },
             "datasource": null,
             "hide": 1,
             "includeAll": false,
@@ -1000,16 +1006,12 @@ data:
                 "value": "quay-metrics"
               }
             ],
-            "query": "service",
+            "query": "quay-metrics",
             "refresh": 0,
             "regex": "",
             "skipUrlSync": false,
             "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "custom"
           }
         ]
       },

--- a/kustomize/components/monitoring/quay-grafana-dashboard_test.go
+++ b/kustomize/components/monitoring/quay-grafana-dashboard_test.go
@@ -1,0 +1,109 @@
+package monitoring_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+type ConfigMap struct {
+	Data map[string]string `json:"data"`
+}
+
+type VariableValue struct {
+	Selected bool   `json:"selected"`
+	Text     string `json:"text"`
+	Value    string `json:"value"`
+}
+
+type GrafanaDashboard struct {
+	Templating struct {
+		List []struct {
+			Name    string         `json:"name"`
+			Type    string         `json:"type"`
+			Query   string         `json:"query"`
+			Hide    int            `json:"hide"`
+			Current *VariableValue `json:"current"`
+		} `json:"list"`
+	} `json:"templating"`
+}
+
+func TestGrafanaDashboardVariables(t *testing.T) {
+	// Read the ConfigMap YAML
+	content, err := os.ReadFile("quay-grafana-dashboard.configmap.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read dashboard configmap: %v", err)
+	}
+
+	var cm ConfigMap
+	if err := yaml.Unmarshal(content, &cm); err != nil {
+		t.Fatalf("Failed to unmarshal configmap YAML: %v", err)
+	}
+
+	dashboardJSON, ok := cm.Data["quay.json"]
+	if !ok {
+		t.Fatal("Dashboard JSON not found in configmap data")
+	}
+
+	var dashboard GrafanaDashboard
+	if err := json.Unmarshal([]byte(dashboardJSON), &dashboard); err != nil {
+		t.Fatalf("Failed to unmarshal dashboard JSON: %v", err)
+	}
+
+	// Validate variables
+	expectedVars := map[string]struct {
+		varType string
+		hide    int
+	}{
+		"datasource": {varType: "datasource", hide: 0},
+		"namespace":  {varType: "custom", hide: 1},
+		"service":    {varType: "custom", hide: 1},
+	}
+
+	for _, v := range dashboard.Templating.List {
+		expected, ok := expectedVars[v.Name]
+		if !ok {
+			t.Logf("Unknown variable %q found", v.Name)
+			continue
+		}
+
+		if v.Type != expected.varType {
+			t.Errorf("Variable %q has type %q, expected %q", v.Name, v.Type, expected.varType)
+		}
+
+		if v.Hide != expected.hide {
+			t.Errorf("Variable %q has hide=%d, expected %d", v.Name, v.Hide, expected.hide)
+		}
+
+		// For custom type variables, validate configuration
+		if v.Type == "custom" {
+			if v.Query == "" {
+				t.Errorf("Variable %q has empty query", v.Name)
+			}
+			// Check for trailing comma (the original bug)
+			if len(v.Query) > 0 && v.Query[len(v.Query)-1] == ',' {
+				t.Errorf("Variable %q query %q has trailing comma", v.Name, v.Query)
+			}
+			// Check that current field is set (required for Grafana to apply the variable)
+			if v.Current == nil {
+				t.Errorf("Variable %q is missing 'current' field - Grafana won't apply the variable value", v.Name)
+			} else if v.Current.Value == "" {
+				t.Errorf("Variable %q has empty current value", v.Name)
+			}
+		}
+	}
+
+	// Ensure all expected variables exist
+	foundVars := make(map[string]bool)
+	for _, v := range dashboard.Templating.List {
+		foundVars[v.Name] = true
+	}
+
+	for name := range expectedVars {
+		if !foundVars[name] {
+			t.Errorf("Expected variable %q not found in dashboard", name)
+		}
+	}
+}


### PR DESCRIPTION
The Quay Grafana dashboard was showing "No datapoints found" due to
invalid characters in dashboard variable queries. The OpenShift Console
monitoring-plugin does not substitute Grafana template variables of
type "query" the same way a real Grafana instance would.

This fix makes three changes:

1. Change template variable type from "query" to "custom" in the
   dashboard ConfigMap template. Custom type variables have explicit
   options rather than dynamically queried ones.

2. Add "current" field to template variables, which is required for
   Grafana to properly apply the selected variable value.

3. Replace $namespace and $service placeholders directly in all panel
   expressions during reconciliation. This is necessary because the
   OpenShift Console monitoring-plugin does not substitute custom type
   variables into PromQL expressions.

Also adds a unit test to validate the dashboard template structure.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Fix Grafana dashboard variable handling so Quay metrics display correctly in the OpenShift Console monitoring plugin.

Bug Fixes:
- Ensure Grafana namespace and service dashboard variables have valid custom-type configuration so variable substitution no longer breaks metric queries.
- Populate current values for namespace and service variables so Grafana correctly applies selected values in the dashboard panels.
- Inline namespace and service placeholders into panel expressions to work around missing variable substitution in the OpenShift Console monitoring plugin.

Tests:
- Add a unit test validating the dashboard ConfigMap JSON structure and variable configuration to prevent regressions in Grafana variable handling.