### PR TITLE
database: Apply safe database connection arguments on initial deploy (PROJQUAY-10546)

### DIFF
--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -549,3 +549,65 @@ func TestClairMarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestPostgreSQLParsingLogic_Comprehensive(t *testing.T) {
+	assert := assert.New(t)
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *database.DbConnectionArgsStruct
+	}{
+		{
+			name:  "default_values",
+			input: map[string]any{},
+			expected: &database.DbConnectionArgsStruct{
+				MaxConnections:     10,
+				StaleTimeout:       180,
+				KeepAlives:         1,
+				KeepalivesIdle:     10,
+				KeepalivesInterval: 2,
+				KeepalivesCount:    5,
+			},
+		},
+		{
+			name: "partial_override",
+			input: map[string]any{
+				"max_connections": 20,
+				"stale_timeout":   600,
+			},
+			expected: &database.DbConnectionArgsStruct{
+				MaxConnections:     20,
+				StaleTimeout:       600,
+				KeepAlives:         1,
+				KeepalivesIdle:     10,
+				KeepalivesInterval: 2,
+				KeepalivesCount:    5,
+			},
+		},
+		{
+			name: "complete_override",
+			input: map[string]any{
+				"max_connections":     50,
+				"stale_timeout":       600,
+				"keepalives":          0,
+				"keepalives_interval": 5,
+				"keepalives_idle":     30,
+				"keepalives_count":    10,
+			},
+			expected: &database.DbConnectionArgsStruct{
+				MaxConnections:     50,
+				StaleTimeout:       600,
+				KeepAlives:         0,
+				KeepalivesIdle:     30,
+				KeepalivesInterval: 5,
+				KeepalivesCount:    10,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		result, err := database.NewDbConnectionArgsStruct(tt.input)
+		assert.Nil(err, tt.name)
+		assert.Equal(tt.expected, result, tt.name)
+	}
+}

--- a/vendor/github.com/quay/config-tool/pkg/lib/fieldgroups/database/database.go
+++ b/vendor/github.com/quay/config-tool/pkg/lib/fieldgroups/database/database.go
@@ -20,8 +20,14 @@ type DbConnectionArgsStruct struct {
 	Autorollback bool       `default:""  json:"autorollback,omitempty" yaml:"autorollback,omitempty"`
 
 	// Postgres arguments
-	SslRootCert string `default:""  json:"sslrootcert,omitempty" yaml:"sslrootcert,omitempty"`
-	SslMode     string `default:""  json:"sslmode,omitempty" yaml:"sslmode,omitempty"`
+	SslRootCert        string `default:""  json:"sslrootcert,omitempty" yaml:"sslrootcert,omitempty"`
+	SslMode            string `default:""  json:"sslmode,omitempty" yaml:"sslmode,omitempty"`
+	MaxConnections     int    `default:"10" json:"max_connections,omitempty" yaml:"max_connections,omitempty"`
+	StaleTimeout       int    `default:"180" json:"stale_timeout,omitempty" yaml:"stale_timeout,omitempty"`
+	KeepAlives         int    `default:"1" json:"keepalives,omitempty" yaml:"keepalives,omitempty"`
+	KeepalivesIdle     int    `default:"10" json:"keepalives_idle,omitempty" yaml:"keepalives_idle,omitempty"`
+	KeepalivesInterval int    `default:"2" json:"keepalives_interval,omitempty" yaml:"keepalives_interval,omitempty"`
+	KeepalivesCount    int    `default:"5" json:"keepalives_count,omitempty" yaml:"keepalives_count,omitempty"`
 }
 
 // SslStruct represents the SslStruct config fields
@@ -87,6 +93,48 @@ func NewDbConnectionArgsStruct(fullConfig map[string]interface{}) (*DbConnection
 		newDbConnectionArgsStruct.SslRootCert, ok = value.(string)
 		if !ok {
 			return newDbConnectionArgsStruct, errors.New("sslrootcert must be of type string")
+		}
+	}
+
+	if value, ok := fullConfig["max_connections"]; ok {
+		newDbConnectionArgsStruct.MaxConnections, ok = value.(int)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("max_connections must be a positive integer")
+		}
+	}
+
+	if value, ok := fullConfig["stale_timeout"]; ok {
+		newDbConnectionArgsStruct.StaleTimeout, ok = value.(int)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("stale_timeout must be a positive integer")
+		}
+	}
+
+	if value, ok := fullConfig["keepalives"]; ok {
+		newDbConnectionArgsStruct.KeepAlives, ok = value.(int)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("keepalives must be a positive integer")
+		}
+	}
+
+	if value, ok := fullConfig["keepalives_idle"]; ok {
+		newDbConnectionArgsStruct.KeepalivesIdle, ok = value.(int)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("keepalives_idle must be a positive integer")
+		}
+	}
+
+	if value, ok := fullConfig["keepalives_interval"]; ok {
+		newDbConnectionArgsStruct.KeepalivesInterval, ok = value.(int)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("keepalives_interval must be a positive integer")
+		}
+	}
+
+	if value, ok := fullConfig["keepalives_count"]; ok {
+		newDbConnectionArgsStruct.KeepalivesCount, ok = value.(int)
+		if !ok {
+			return newDbConnectionArgsStruct, errors.New("keepalives_count must be a positive integer")
 		}
 	}
 


### PR DESCRIPTION
So far, the operator did not set any specific configuration parameters during bootstrapping into the rendered `config.yaml` file. This caused Quay to rely on Peewee defaults. 

This change will tell the operator to apply some safe values for the stale timeout, keepalive probes and the number of connections each worker can open. This should lower the overall database pressure since connections will be closed after a period of inactivity and reopened if needed.

## Summary by Sourcery

Apply safe default PostgreSQL connection settings during configuration bootstrapping while allowing overrides from user-provided options.

New Features:
- Introduce configurable PostgreSQL connection arguments (max connections, stale timeout, and keepalive settings) with sensible defaults for initial deployments.

Tests:
- Add comprehensive tests verifying default and overridden PostgreSQL connection argument parsing into the configuration.