### PR TITLE
fix: resolve deprecations and Dockerfile Go version mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.21 as builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.23 as builder
 
 ARG TARGETOS TARGETARCH
 WORKDIR /workspace

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,32 +12,32 @@ namePrefix: quay-operator-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
   # Protect the /metrics endpoint by putting it behind auth.
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+#- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/controllers/quay/suite_test.go
+++ b/controllers/quay/suite_test.go
@@ -51,7 +51,7 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "QuayRegistry Controller Suite")
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	testLogger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
 	logf.SetLogger(testLogger)
 	testEventRecorder = record.NewFakeRecorder(100)
@@ -85,7 +85,6 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	close(done)
 })
 
 var _ = AfterSuite(func() {

--- a/kustomize/components/clairpgupgrade/base/kustomization.yaml
+++ b/kustomize/components/clairpgupgrade/base/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - ./clair-pg-old.persistentvolumeclaim.yaml
   - ./clair-pg-old.deployment.yaml
   - ./clair-pg-old.service.yaml
-patchesStrategicMerge:
-  - ./clair-pg.deployment.patch.yaml
+patches:
+  - path: ./clair-pg.deployment.patch.yaml

--- a/kustomize/components/clairpgupgrade/scale-down-clair/kustomization.yaml
+++ b/kustomize/components/clairpgupgrade/scale-down-clair/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-patchesStrategicMerge:
-  - ./clair.deployment.patch.yaml
+patches:
+  - path: ./clair.deployment.patch.yaml
 components:
   - "../base"

--- a/kustomize/components/pgupgrade/kustomization.yaml
+++ b/kustomize/components/pgupgrade/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
   - ./quay-pg-upgrade.job.yaml
   - ./quay-pg-old.persistentvolumeclaim.yaml
   - ./quay-pg-old.deployment.yaml
-patchesStrategicMerge:
-  - ./quay.deployment.patch.yaml
-  - ./quay-pg.deployment.patch.yaml
+patches:
+  - path: ./quay.deployment.patch.yaml
+  - path: ./quay-pg.deployment.patch.yaml

--- a/kustomize/components/tls/kustomization.yaml
+++ b/kustomize/components/tls/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources: []
-patchesStrategicMerge: []
+patches: []

--- a/kustomize/overlays/current/config-only/kustomization.yaml
+++ b/kustomize/overlays/current/config-only/kustomization.yaml
@@ -1,8 +1,8 @@
 # Overlay variant for only deploying config editor.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../../tmp
-patchesStrategicMerge:
+patches:
   # Scale the app deployment to 0 pods in order to prevent pod errors on startup from invalid configuration.
-  - ./quay.deployment.patch.yaml
+  - path: ./quay.deployment.patch.yaml

--- a/kustomize/overlays/current/kustomization.yaml
+++ b/kustomize/overlays/current/kustomization.yaml
@@ -1,5 +1,5 @@
 # Overlay variant for current Project Quay release.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../tmp

--- a/kustomize/overlays/current/unmanaged-tls/kustomization.yaml
+++ b/kustomize/overlays/current/unmanaged-tls/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../../tmp
-patchesStrategicMerge:
-  - ./quay.deployment.patch.yaml
+patches:
+  - path: ./quay.deployment.patch.yaml

--- a/kustomize/overlays/current/upgrade/kustomization.yaml
+++ b/kustomize/overlays/current/upgrade/kustomization.yaml
@@ -1,8 +1,8 @@
 # Overlay variant for upgrading to current Project Quay release.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../../tmp
-patchesStrategicMerge:
+patches:
   # Scale the app deployment to 0 pods in order to run all migrations present in the new container image using the "upgrade" `Job`.
-  - ./quay.deployment.patch.yaml
+  - path: ./quay.deployment.patch.yaml


### PR DESCRIPTION
Update Dockerfile builder image from Go 1.21 to 1.23 to match go.mod.
Replace deprecated kustomize fields: bases -> resources and
patchesStrategicMerge -> patches across config/ and kustomize/
directories. Fix deprecated Ginkgo Done channel pattern in test suite.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Brady Pratt <bpratt@redhat.com>
