### PR TITLE
fix(api): reject duplicate components in QuayRegistry spec (PROJQUAY-10722)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -516,6 +516,14 @@ func hasAffinity(component Component) bool {
 
 // ValidateOverrides validates that the overrides set for each component are valid.
 func ValidateOverrides(quay *QuayRegistry) error {
+	seen := make(map[ComponentKind]bool)
+	for _, component := range quay.Spec.Components {
+		if seen[component.Kind] {
+			return fmt.Errorf("duplicate component %q in spec.components", component.Kind)
+		}
+		seen[component.Kind] = true
+	}
+
 	for _, component := range quay.Spec.Components {
 
 		// No overrides provided

--- a/apis/quay/v1/quayregistry_types_test.go
+++ b/apis/quay/v1/quayregistry_types_test.go
@@ -559,6 +559,21 @@ var validateOverridesTests = []struct {
 		},
 		errors.New("component redis does not support securityContext overrides"),
 	},
+	{
+		"DuplicateComponentEntries",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "clairpostgres", Managed: true, Overrides: &Override{VolumeSize: &resource.Quantity{}}},
+					{Kind: "postgres", Managed: true},
+					{Kind: "redis", Managed: true},
+					{Kind: "clair", Managed: true},
+					{Kind: "clairpostgres", Managed: true},
+				},
+			},
+		},
+		errors.New(`duplicate component "clairpostgres" in spec.components`),
+	},
 }
 
 func TestValidOverrides(t *testing.T) {


### PR DESCRIPTION
Duplicate component entries in spec.components caused undefined behavior
where some code paths used the first match and others the last. Add
validation in ValidateOverrides() to detect and reject duplicates,
surfacing the error via the existing RolloutBlocked status condition.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
