### PR TITLE
feat(overrides): allow resource overrides for Redis component (PROJQUAY-10730)

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -106,6 +106,7 @@ var supportsResourceOverrides = []ComponentKind{
 	ComponentMirror,
 	ComponentPostgres,
 	ComponentClairPostgres,
+	ComponentRedis,
 }
 
 var supportsReplicasOverride = []ComponentKind{

--- a/e2e/resource_overrides/00-assert.yaml
+++ b/e2e/resource_overrides/00-assert.yaml
@@ -48,3 +48,20 @@ spec:
             requests:
               cpu: 300m
               memory: 300Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skynet-quay-redis
+spec:
+  template:
+    spec:
+      containers:
+        - name: redis-master
+          resources:
+            limits:
+              cpu: 400m
+              memory: 400Mi
+            requests:
+              cpu: 400m
+              memory: 400Mi

--- a/e2e/resource_overrides/00-create-quay-registry.yaml
+++ b/e2e/resource_overrides/00-create-quay-registry.yaml
@@ -34,3 +34,13 @@ spec:
           requests:
             cpu: 300m
             memory: 300Mi
+    - kind: redis
+      managed: true
+      overrides:
+        resources:
+          limits:
+            cpu: 400m
+            memory: 400Mi
+          requests:
+            cpu: 400m
+            memory: 400Mi


### PR DESCRIPTION
Add ComponentRedis to the supportsResourceOverrides allowlist so that
Redis pods can have their CPU/memory requests and limits tuned per
environment instead of using the hardcoded defaults (500m/1Gi requests,
4000m/16Gi limits).

The existing override middleware already handles Redis deployments via
the `quay-component: redis` annotation — this change simply unblocks
validation to accept Redis resource overrides in the QuayRegistry CR.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
