### PR TITLE
chore: set stable clair version

### DIFF
--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ spec:
                       - name: RELATED_IMAGE_COMPONENT_QUAY
                         value: quay.io/projectquay/quay:latest
                       - name: RELATED_IMAGE_COMPONENT_CLAIR
-                        value: quay.io/projectquay/clair:nightly
+                        value: quay.io/projectquay/clair:4.8.0
                       - name: RELATED_IMAGE_COMPONENT_BUILDER
                         value: quay.io/projectquay/quay-builder:master
                       - name: RELATED_IMAGE_COMPONENT_BUILDER_QEMU

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -64,7 +64,7 @@ docker buildx build --push --platform "linux/amd64,linux/ppc64le,linux/s390x"  -
 digest "${REGISTRY}/${NAMESPACE}/quay-operator:${TAG}" OPERATOR_DIGEST
 
 digest "${REGISTRY}/${NAMESPACE}/quay:${TAG}" QUAY_DIGEST
-digest "${REGISTRY}/${NAMESPACE}/clair:nightly" CLAIR_DIGEST
+digest "${REGISTRY}/${NAMESPACE}/clair:4.8.0" CLAIR_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/quay-builder:${TAG}" BUILDER_DIGEST
 digest "${REGISTRY}/${NAMESPACE}/quay-builder-qemu:3.9.0" BUILDER_QEMU_DIGEST
 digest quay.io/sclorg/postgresql-13-c9s:latest POSTGRES_DIGEST

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -29,7 +29,7 @@ spec:
                         - clair-app
                 topologyKey: "kubernetes.io/hostname"
       containers:
-        - image: quay.io/projectquay/clair:nightly
+        - image: quay.io/projectquay/clair:4.8.0
           imagePullPolicy: IfNotPresent
           name: clair-app
           env:


### PR DESCRIPTION
just to ensure CI for the operator is stable, we don't care about
testing next clair in our main jobs

Signed-off-by: Brady Pratt <bpratt@redhat.com>
