### PR TITLE
fix(controllers): remove global mutex from reconciliation controllers (PROJQUAY-10723)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -79,7 +78,6 @@ type QuayRegistryReconciler struct {
 	Scheme               *runtime.Scheme
 	EventRecorder        record.EventRecorder
 	WatchNamespace       string
-	Mtx                  *sync.Mutex
 	Requeue              ctrl.Result
 	SkipResourceRequests bool
 }
@@ -485,9 +483,6 @@ func (r *QuayRegistryReconciler) GetOldConfigBundleSecrets(
 // Reconcile is called every time an update happens in a QuayRegistry object. It attempts to
 // create all needed objects to get a quay instance running.
 func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Mtx.Lock()
-	defer r.Mtx.Unlock()
-
 	regid := fmt.Sprintf("%s/%s", req.NamespacedName.Namespace, req.NamespacedName.Name)
 	log := r.Log.WithValues("quayregistry", regid)
 	log.Info("begin reconcile")

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"sync"
 	"testing"
 	"time"
 
@@ -111,13 +110,11 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 	BeforeEach(func() {
 		namespace = randIdentifier(16)
 
-		var mtx sync.Mutex
 		controller = &QuayRegistryReconciler{
 			Client:        k8sClient,
 			Log:           testLogger,
 			Scheme:        scheme.Scheme,
 			EventRecorder: testEventRecorder,
-			Mtx:           &mtx,
 		}
 
 		Expect(k8sClient.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).Should(Succeed())

--- a/controllers/quay/quayregistry_status_controller.go
+++ b/controllers/quay/quayregistry_status_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -21,7 +20,6 @@ import (
 type QuayRegistryStatusReconciler struct {
 	Client client.Client
 	Log    logr.Logger
-	Mtx    *sync.Mutex
 }
 
 // NewQuayRegistryStatusReconciler returns a new QuayRegistryStatusController configured to use
@@ -43,9 +41,6 @@ func (q *QuayRegistryStatusReconciler) SetupWithManager(mgr ctrl.Manager) error 
 func (q *QuayRegistryStatusReconciler) Reconcile(
 	ctx context.Context, req ctrl.Request,
 ) (ctrl.Result, error) {
-	q.Mtx.Lock()
-	defer q.Mtx.Unlock()
-
 	log := q.Log.WithValues("quayregistrystatus", req.NamespacedName)
 	reschedule := ctrl.Result{RequeueAfter: time.Minute}
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
-	"sync"
 	"time"
 
 	"go.uber.org/zap/zapcore"
@@ -127,14 +126,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	var mtx sync.Mutex
 	if err = (&quaycontroller.QuayRegistryReconciler{
 		Client:               mgr.GetClient(),
 		Log:                  ctrl.Log.WithName("controllers").WithName("QuayRegistry"),
 		Scheme:               mgr.GetScheme(),
 		EventRecorder:        mgr.GetEventRecorderFor("quayregistry-controller"),
 		WatchNamespace:       namespace,
-		Mtx:                  &mtx,
 		Requeue:              ctrl.Result{RequeueAfter: 10 * time.Second},
 		SkipResourceRequests: skipres,
 	}).SetupWithManager(mgr); err != nil {
@@ -145,7 +142,6 @@ func main() {
 	if err = (&quaycontroller.QuayRegistryStatusReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("QuayRegistryStatus"),
-		Mtx:    &mtx,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "QuayRegistryStatus")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Removes the shared `sync.Mutex` that serialized all reconciliation work across both the spec and status controllers.

- Remove `Mtx *sync.Mutex` field from `QuayRegistryReconciler` and `QuayRegistryStatusReconciler`
- Remove `Lock()`/`Unlock()` calls from both `Reconcile()` methods
- Remove mutex creation and passing in `main.go`
- Remove mutex from test setup

## Why this is safe

The mutex was introduced in [1ae4e3e7](https://github.com/quay/quay-operator/commit/1ae4e3e7) (Aug 2021) when the status controller was split out, to prevent read-modify-write races on status updates. However, it is unnecessary because:

1. **Controller-runtime work queue serialization** — reconcile calls for the same object are serialized within each controller
2. **Kubernetes optimistic concurrency** — the API server enforces `resourceVersion`, rejecting conflicting writes with 409 Conflict
3. **Conflict handling already exists** — the status controller handles 409 Conflict errors correctly ([quayregistry_status_controller.go:73-75](https://github.com/quay/quay-operator/blob/master/controllers/quay/quayregistry_status_controller.go#L73-L75))

## What the mutex caused

- Status health checks (60s interval) blocked by spec reconciliation and vice versa
- The Job poll loop in `createOrUpdateObject` (up to 10 min timeout) held the mutex, blocking **all** other work
- All QuayRegistry instances serialized behind each other instead of reconciling in parallel

## CRC Benchmark Results

Tested locally against a CRC cluster with a single QuayRegistry, comparing before/after over a 10-minute window:

| Metric | With Mutex | Without Mutex | Delta |
|--------|-----------|--------------|-------|
| Total reconciles | 66 | 63 | -5% |
| Reconcile time (sum) | 36.21s | 26.38s | **-27%** |
| Avg reconcile duration | 549ms | 419ms | **-24%** |
| Workqueue wait (sum) | 854ms | 247ms | **-71%** |
| Avg queue wait per item | 12.9ms | 3.9ms | **-70%** |
| Reconcile errors | 0 | 1 (409 conflict, handled) | — |

The 409 Conflict was handled gracefully by the status controller, confirming concurrent execution is safe.

## Test plan

- [x] `make fmt && make vet` — clean
- [x] `make test` — all unit tests pass
- [x] Local `make run` against CRC — operator starts, QuayRegistry reconciles successfully
- [x] Verified status controller handles concurrent access via 409 Conflict retry
- [ ] e2e tests in CI

Jira: https://issues.redhat.com/browse/PROJQUAY-10723

🤖 Generated with [Claude Code](https://claude.com/claude-code)