### PR TITLE
fix(controller): replace blocking poll in Job reconciliation with requeue pattern (PROJQUAY-10724)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,9 +52,6 @@ import (
 )
 
 const (
-	creationPollInterval = time.Second * 2
-	creationPollTimeout  = time.Second * 600
-
 	grafanaDashboardConfigMapNameSuffix   = "grafana-dashboard-quay"
 	grafanaTitleJSONPath                  = "title"
 	grafanaNamespaceFilterJSONPath        = "templating.list.1.options.0.value"
@@ -387,7 +383,6 @@ func (r *QuayRegistryReconciler) checkPostgresUpgradeStatus(
 
 	log.Info("successfully updated `status` after Quay upgrade")
 	return r.Requeue, nil
-
 }
 
 // createInitialBundleSecret creates a new config bundle secret for provided QuayRegistry
@@ -455,7 +450,6 @@ func (r *QuayRegistryReconciler) GetConfigBundleSecret(
 // when a new config bundle secret is created.
 func (r *QuayRegistryReconciler) GetOldConfigBundleSecrets(
 	ctx context.Context, quay *v1.QuayRegistry,
-
 ) ([]corev1.Secret, error) {
 	secretList := &corev1.SecretList{}
 	if err := r.Client.List(
@@ -756,7 +750,8 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 		}
 
-		if err := r.createOrUpdateObject(ctx, obj, quay, log); err != nil {
+		requeue, err := r.createOrUpdateObject(ctx, obj, quay, log)
+		if err != nil {
 			return r.reconcileWithCondition(
 				ctx,
 				&quay,
@@ -765,6 +760,9 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				v1.ConditionReasonComponentCreationFailed,
 				fmt.Sprintf("error creating/updating object %s %s: %s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err.Error()),
 			)
+		}
+		if requeue {
+			return r.Requeue, nil
 		}
 	}
 
@@ -1025,7 +1023,7 @@ func convertHpaToV2beta2(hpa *autoscalingv2.HorizontalPodAutoscaler) (*autoscali
 
 func (r *QuayRegistryReconciler) createOrUpdateObject(
 	ctx context.Context, obj client.Object, quay v1.QuayRegistry, log logr.Logger,
-) error {
+) (bool, error) {
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	log = log.WithValues("kind", gvk.Kind, "name", obj.GetName())
 	log.Info("creating/updating object")
@@ -1037,7 +1035,7 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(
 		var err error
 		if obj, err = v1.RemoveOwnerReference(&quay, obj); err != nil {
 			log.Error(err, "could not remove `ownerReferences` from grafana config")
-			return err
+			return false, err
 		}
 	}
 
@@ -1053,31 +1051,20 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(
 
 		if err := r.Client.Delete(ctx, obj, opts); err != nil && !errors.IsNotFound(err) {
 			log.Error(err, "failed to delete immutable resource")
-			return err
+			return false, err
 		}
 
-		if err := wait.PollUntilContextTimeout(
-			ctx,
-			creationPollInterval,
-			creationPollTimeout,
-			false,
-			func(ctx context.Context) (bool, error) {
-				if err := r.Client.Create(ctx, obj); err != nil {
-					if errors.IsAlreadyExists(err) {
-						log.Info("immutable resource being deleted, retry")
-						return false, nil
-					}
-					return true, err
-				}
+		if err := r.Client.Create(ctx, obj); err != nil {
+			if errors.IsAlreadyExists(err) {
+				log.Info("immutable resource still being deleted, will requeue")
 				return true, nil
-			},
-		); err != nil {
+			}
 			log.Error(err, "failed to create immutable resource")
-			return err
+			return false, err
 		}
 
-		log.Info("succefully (re)created immutable resource")
-		return nil
+		log.Info("successfully (re)created immutable resource")
+		return false, nil
 	}
 
 	hpaGVK := schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"}
@@ -1092,17 +1079,17 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(
 		var hpa *autoscalingv2beta2.HorizontalPodAutoscaler
 		hpa, err = convertHpaToV2beta2(obj.(*autoscalingv2.HorizontalPodAutoscaler))
 		if err != nil {
-			return err
+			return false, err
 		}
 		err = r.Client.Patch(ctx, hpa, client.Apply, opts...)
 	}
 	if err != nil {
 		log.Error(err, "failed to create/update object")
-		return err
+		return false, err
 	}
 
 	log.Info("finished creating/updating object")
-	return nil
+	return false, nil
 }
 
 func (r *QuayRegistryReconciler) updateWithCondition(
@@ -1246,7 +1233,6 @@ func (r *QuayRegistryReconciler) patchNamespaceForMonitoring(
 func (r *QuayRegistryReconciler) cleanupNamespaceLabels(ctx context.Context, quay *v1.QuayRegistry) error {
 	var ns corev1.Namespace
 	err := r.Client.Get(ctx, types.NamespacedName{Name: quay.GetNamespace()}, &ns)
-
 	if err != nil {
 		return err
 	}
@@ -1282,7 +1268,8 @@ func (r *QuayRegistryReconciler) cleanupGrafanaConfigMap(ctx context.Context, qu
 	var grafanaConfigMap corev1.ConfigMap
 	grafanaConfigMapName := types.NamespacedName{
 		Name:      quay.GetName() + "-" + grafanaDashboardConfigMapNameSuffix,
-		Namespace: grafanaDashboardConfigNamespace}
+		Namespace: grafanaDashboardConfigNamespace,
+	}
 
 	if err := r.Client.Get(ctx, grafanaConfigMapName, &grafanaConfigMap); err == nil || !errors.IsNotFound(err) {
 		return r.Client.Delete(ctx, &grafanaConfigMap)

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -10,20 +10,118 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/cert"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/quay/quay-operator/apis/quay/v1"
 	quaycontext "github.com/quay/quay-operator/pkg/context"
 	"github.com/quay/quay-operator/pkg/kustomize"
 )
+
+func TestCreateOrUpdateObject_Job(t *testing.T) {
+	jobObj := &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{Name: "test", Image: "busybox"},
+					},
+				},
+			},
+		},
+	}
+
+	quay := v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-registry",
+			Namespace: "default",
+		},
+	}
+
+	for _, tt := range []struct {
+		name              string
+		existing          bool
+		createInterceptor func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error
+		wantRequeue       bool
+		wantErr           bool
+	}{
+		{
+			name:        "job does not exist, create succeeds",
+			existing:    false,
+			wantRequeue: false,
+			wantErr:     false,
+		},
+		{
+			name:     "job still terminating, returns requeue",
+			existing: true,
+			createInterceptor: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				return k8serrors.NewAlreadyExists(
+					schema.GroupResource{Group: "batch", Resource: "jobs"},
+					obj.GetName(),
+				)
+			},
+			wantRequeue: true,
+			wantErr:     false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			if tt.existing {
+				existingJob := jobObj.DeepCopy()
+				existingJob.SetResourceVersion("1")
+				builder = builder.WithObjects(existingJob)
+			}
+			if tt.createInterceptor != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Create: tt.createInterceptor,
+				})
+			}
+			fakeClient := builder.Build()
+
+			reconciler := &QuayRegistryReconciler{
+				Client:        fakeClient,
+				Log:           testLogger,
+				Scheme:        scheme.Scheme,
+				EventRecorder: testEventRecorder,
+			}
+
+			obj := jobObj.DeepCopy()
+			requeue, err := reconciler.createOrUpdateObject(
+				context.Background(), obj, quay, testLogger,
+			)
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if requeue != tt.wantRequeue {
+				t.Errorf("requeue = %v, want %v", requeue, tt.wantRequeue)
+			}
+		})
+	}
+}
 
 func newQuayRegistry(name, namespace string) *v1.QuayRegistry {
 	quay := &v1.QuayRegistry{
@@ -66,7 +164,6 @@ func newConfigBundle(name, namespace string, withCerts bool) corev1.Secret {
 			config["SERVER_HOSTNAME"].(string),
 			nil,
 			[]string{config["SERVER_HOSTNAME"].(string)})
-
 		if err != nil {
 			panic(err)
 		}
@@ -148,7 +245,8 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 				context.Background(),
 				types.NamespacedName{
 					Name:      updatedQuayRegistry.Spec.ConfigBundleSecret,
-					Namespace: quayRegistry.GetNamespace()},
+					Namespace: quayRegistry.GetNamespace(),
+				},
 				&configBundleSecret)).
 				To(Succeed())
 		})
@@ -172,7 +270,8 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 				context.Background(),
 				types.NamespacedName{
 					Name:      updatedQuayRegistry.Spec.ConfigBundleSecret,
-					Namespace: quayRegistry.GetNamespace()},
+					Namespace: quayRegistry.GetNamespace(),
+				},
 				&configBundleSecret)).
 				To(Succeed())
 		})
@@ -308,7 +407,8 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 				Namespace: namespace,
 				LabelSelector: labels.SelectorFromSet(map[string]string{
 					kustomize.QuayRegistryNameLabel: quayRegistryName.Name,
-				})}
+				}),
+			}
 
 			Expect(k8sClient.List(context.Background(), &secrets, &listOptions)).To(Succeed())
 


### PR DESCRIPTION
## Summary

- Replace blocking `wait.PollUntilContextTimeout` in `createOrUpdateObject()` with a non-blocking requeue pattern for Job recreation
- Remove unused `creationPollInterval` and `creationPollTimeout` constants and `wait` import
- Add unit tests for Job requeue behavior

## Problem

When recreating Jobs (which have immutable fields), the operator blocked the reconcile goroutine polling every 2s for up to 10 minutes waiting for the old Job to be fully deleted. Combined with the global mutex shared across both controllers, a single slow Job deletion serialized all QuayRegistry reconciliation cluster-wide.

## Solution

Instead of blocking, attempt to create the new Job immediately after deletion. If `AlreadyExists` is returned (old Job still terminating), return a requeue result and release the mutex. Each reconcile pass completes in milliseconds instead of blocking for the full pod termination duration.

## Metrics (CRC cluster, 60s termination grace period)

| Metric | Before | After |
|--------|--------|-------|
| Total reconcile time | 140.4s | 19.1s |
| Max reconcile duration | >60s | 2.5s |
| Reconciles > 60s | 2 | 0 |
| Max mutex hold time | ~62s | ~2.5s |

## Test plan

- [x] `make fmt && make vet && make test` pass
- [x] Unit test for Job requeue path added
- [x] Before/after metrics comparison on CRC with slow-terminating Job (60s grace period)

Fixes: [PROJQUAY-10724](https://issues.redhat.com/browse/PROJQUAY-10724)

🤖 Generated with [Claude Code](https://claude.com/claude-code)