### PR TITLE
fix(kustomize): ensure Jobs are created after Secrets (PROJQUAY-10830)

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -175,13 +175,14 @@ func decode(bytes []byte) interface{} {
 }
 
 // EnsureCreationOrder sorts the given slice of Kubernetes objects so that when created in order,
-// `Deployments` will be created after their dependencies (`Secrets`/`ConfigMaps`/etc).
+// `Deployments` and `Jobs` will be created after their dependencies (`Secrets`/`ConfigMaps`/etc).
 func EnsureCreationOrder(objects []client.Object) []client.Object {
 	sort.Slice(
 		objects,
 		func(i, j int) bool {
 			obji := objects[i]
-			return obji.GetObjectKind().GroupVersionKind().Kind != "Deployment"
+			kind := obji.GetObjectKind().GroupVersionKind().Kind
+			return kind != "Deployment" && kind != "Job"
 		},
 	)
 	return objects

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -241,6 +241,55 @@ var kustomizationForTests = []struct {
 	},
 }
 
+func TestEnsureCreationOrder(t *testing.T) {
+	objects := []client.Object{
+		&appsv1.Deployment{
+			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "quay-app"},
+		},
+		&corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "quay-config-secret"},
+		},
+		&batchv1.Job{
+			TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "quay-app-upgrade"},
+		},
+		&corev1.Service{
+			TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "quay-app"},
+		},
+	}
+
+	sorted := EnsureCreationOrder(objects)
+
+	// Deployments and Jobs should come after Secrets and Services
+	for i, obj := range sorted {
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		if kind == "Deployment" || kind == "Job" {
+			// Every remaining object should also be a Deployment or Job
+			for _, remaining := range sorted[i:] {
+				rKind := remaining.GetObjectKind().GroupVersionKind().Kind
+				assert.True(t, rKind == "Deployment" || rKind == "Job",
+					"expected Deployment or Job at end, got %s", rKind)
+			}
+			break
+		}
+	}
+
+	// First two should be non-Deployment/Job kinds, last two should be Deployment/Job
+	for _, obj := range sorted[:2] {
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		assert.True(t, kind != "Deployment" && kind != "Job",
+			"expected non-Deployment/Job in first half, got %s", kind)
+	}
+	for _, obj := range sorted[2:] {
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		assert.True(t, kind == "Deployment" || kind == "Job",
+			"expected Deployment or Job in second half, got %s", kind)
+	}
+}
+
 func TestKustomizationFor(t *testing.T) {
 	assert := assert.New(t)
 	log := logr.Discard()


### PR DESCRIPTION
Add Job kind to EnsureCreationOrder sort condition to prevent upgrade
Jobs from being applied before their dependency Secrets exist.
