### PR TITLE
chore: printcolumns, validation, owns, probes, RBAC

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -250,6 +250,8 @@ type QuayRegistryStatus struct {
 	LastUpdate string `json:"lastUpdated,omitempty"`
 	// Conditions represent the conditions that a QuayRegistry can have.
 	Conditions []Condition `json:"conditions,omitempty"`
+	// ObservedGeneration is the most recent generation observed by the controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // GetCondition retrieves the condition with the matching type from the given list.

--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -40,6 +40,7 @@ type QuayVersion string
 var QuayVersionCurrent QuayVersion = QuayVersion(os.Getenv("QUAY_VERSION"))
 
 // ComponentKind holds a component type, e.g. "clair", "postgres", etc.
+// +kubebuilder:validation:Enum=quay;postgres;clair;clairpostgres;redis;horizontalpodautoscaler;objectstorage;route;mirror;monitoring;tls
 type ComponentKind string
 
 // Follow a list of constants representing all supported components.
@@ -146,6 +147,7 @@ type QuayRegistrySpec struct {
 }
 
 // Component describes how the Operator should handle a backing Quay service.
+// +kubebuilder:validation:XValidation:rule="self.managed || !has(self.overrides)",message="cannot set overrides on unmanaged component"
 type Component struct {
 	// Kind is the unique name of this type of component.
 	Kind ComponentKind `json:"kind"`
@@ -163,6 +165,7 @@ type Override struct {
 	StorageClassName *string         `json:"storageClassName,omitempty"`
 	Env              []corev1.EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// +nullable
+	// +kubebuilder:validation:Minimum=0
 	Replicas        *int32                  `json:"replicas,omitempty"`
 	Affinity        *corev1.Affinity        `json:"affinity,omitempty"`
 	Labels          map[string]string       `json:"labels,omitempty"`

--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -298,6 +298,10 @@ func RemoveCondition(conditions []Condition, conditionType ConditionType) []Cond
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.currentVersion`
+// +kubebuilder:printcolumn:name="Endpoint",type=string,JSONPath=`.status.registryEndpoint`
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // QuayRegistry is the Schema for the quayregistries API.
 type QuayRegistry struct {

--- a/bundle/manifests/quayregistries.crd.yaml
+++ b/bundle/manifests/quayregistries.crd.yaml
@@ -13,7 +13,20 @@ spec:
     singular: quayregistry
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.currentVersion
+      name: Version
+      type: string
+    - jsonPath: .status.registryEndpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: QuayRegistry is the Schema for the quayregistries API.

--- a/bundle/manifests/quayregistries.crd.yaml
+++ b/bundle/manifests/quayregistries.crd.yaml
@@ -1221,6 +1221,11 @@ spec:
                 description: LastUpdate is the timestamp when the Operator last processed
                   this instance.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
               registryEndpoint:
                 description: RegistryEndpoint is the external access point for the
                   Quay registry.

--- a/bundle/manifests/quayregistries.crd.yaml
+++ b/bundle/manifests/quayregistries.crd.yaml
@@ -60,6 +60,18 @@ spec:
                   properties:
                     kind:
                       description: Kind is the unique name of this type of component.
+                      enum:
+                      - quay
+                      - postgres
+                      - clair
+                      - clairpostgres
+                      - redis
+                      - horizontalpodautoscaler
+                      - objectstorage
+                      - route
+                      - mirror
+                      - monitoring
+                      - tls
                       type: string
                     managed:
                       description: |-
@@ -966,6 +978,7 @@ spec:
                           type: object
                         replicas:
                           format: int32
+                          minimum: 0
                           nullable: true
                           type: integer
                         resources:
@@ -1177,6 +1190,9 @@ spec:
                   - kind
                   - managed
                   type: object
+                  x-kubernetes-validations:
+                  - message: cannot set overrides on unmanaged component
+                    rule: self.managed || !has(self.overrides)
                 type: array
               configBundleSecret:
                 description: |-

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -13,7 +13,20 @@ spec:
     singular: quayregistry
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.currentVersion
+      name: Version
+      type: string
+    - jsonPath: .status.registryEndpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: QuayRegistry is the Schema for the quayregistries API.

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -1221,6 +1221,11 @@ spec:
                 description: LastUpdate is the timestamp when the Operator last processed
                   this instance.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
               registryEndpoint:
                 description: RegistryEndpoint is the external access point for the
                   Quay registry.

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -60,6 +60,18 @@ spec:
                   properties:
                     kind:
                       description: Kind is the unique name of this type of component.
+                      enum:
+                      - quay
+                      - postgres
+                      - clair
+                      - clairpostgres
+                      - redis
+                      - horizontalpodautoscaler
+                      - objectstorage
+                      - route
+                      - mirror
+                      - monitoring
+                      - tls
                       type: string
                     managed:
                       description: |-
@@ -966,6 +978,7 @@ spec:
                           type: object
                         replicas:
                           format: int32
+                          minimum: 0
                           nullable: true
                           type: integer
                         resources:
@@ -1177,6 +1190,9 @@ spec:
                   - kind
                   - managed
                   type: object
+                  x-kubernetes-validations:
+                  - message: cannot set overrides on unmanaged component
+                    rule: self.managed || !has(self.overrides)
                 type: array
               configBundleSecret:
                 description: |-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,95 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbucketclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - quay.redhat.com
   resources:
   - quayregistries
@@ -24,3 +113,29 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -1193,8 +1193,13 @@ func (r *QuayRegistryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.QuayRegistry{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&batchv1.Job{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.PersistentVolumeClaim{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
-		// TODO: Add `.Owns()` for every resource type we manage...
 		Complete(r)
 }
 

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -499,6 +499,8 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	updatedQuay := quay.DeepCopy()
+	updatedQuay.Status.ObservedGeneration = quay.Generation
+
 	if v1.FlaggedForDeletion(updatedQuay) {
 		return r.manageQuayDeletion(ctx, updatedQuay, log)
 	}

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -479,6 +479,15 @@ func (r *QuayRegistryReconciler) GetOldConfigBundleSecrets(
 
 // +kubebuilder:rbac:groups=quay.redhat.com,resources=quayregistries,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=quay.redhat.com,resources=quayregistries/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods;services;secrets;configmaps;serviceaccounts;persistentvolumeclaims;events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=objectbucket.io,resources=objectbucketclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is called every time an update happens in a QuayRegistry object. It attempts to
 // create all needed objects to get a quay instance running.

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -113,13 +114,14 @@ func main() {
 	webhookServer := webhook.NewServer(webhookServerOptions)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:           scheme,
-		Cache:            cacheOptions,
-		Client:           clientOptions,
-		LeaderElection:   enableLeaderElection,
-		LeaderElectionID: "7daa4ab6.quay.redhat.com",
-		Metrics:          metricsOptions,
-		WebhookServer:    webhookServer,
+		Scheme:                 scheme,
+		Cache:                  cacheOptions,
+		Client:                 clientOptions,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "7daa4ab6.quay.redhat.com",
+		Metrics:                metricsOptions,
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: ":8081",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -162,6 +164,15 @@ func main() {
 	}
 
 	// +kubebuilder:scaffold:builder
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
## Summary

Brings the quay-operator in line with modern kubebuilder conventions across 6 targeted improvements:

- **PrintColumns**: `kubectl get quayregistries` now shows Version, Endpoint, Available, and Age
- **ObservedGeneration**: `status.observedGeneration` tracks last processed generation
- **Validation markers + CEL**: enum on `ComponentKind` rejects typos at admission, `Minimum=0` on replicas, CEL rule prevents overrides on unmanaged components
- **Owns watches**: controller watches Deployments, Jobs, Services, Secrets, ConfigMaps, and PVCs via owner references — reconciles immediately on drift instead of waiting for requeue
- **Health probes**: `/healthz` and `/readyz` endpoints on port 8081
- **RBAC markers**: full permission set declared via kubebuilder markers, `config/rbac/role.yaml` now auto-generated matching the CSV

## Demo Results (KinD cluster)

### PrintColumns
```
$ kubectl get quayregistries -A
NAMESPACE            NAME   VERSION   ENDPOINT   AVAILABLE   AGE
demo-bestpractices   demo                        False       117s
```

### Validation — enum rejects typos at admission
```
$ kubectl apply -f bad-component.yaml
The QuayRegistry "bad-component" is invalid:
* spec.components[0].kind: Unsupported value: "banana": supported values: "quay", "postgres",
  "clair", "clairpostgres", "redis", "horizontalpodautoscaler", "objectstorage", "route",
  "mirror", "monitoring", "tls"
```

### Validation — CEL rejects overrides on unmanaged
```
$ kubectl apply -f bad-override.yaml
The QuayRegistry "bad-override" is invalid:
  spec.components[0]: Invalid value: "object": cannot set overrides on unmanaged component
```

### Validation — negative replicas rejected
```
$ kubectl apply -f bad-replicas.yaml
The QuayRegistry "bad-replicas" is invalid:
  spec.components[0].overrides.replicas: Invalid value: -1: ... should be >= 0
```

### Owns watches — all resource types registered
```
Starting EventSource  source="kind source: *v1.Deployment"
Starting EventSource  source="kind source: *v1.Job"
Starting EventSource  source="kind source: *v1.Service"
Starting EventSource  source="kind source: *v1.Secret"
Starting EventSource  source="kind source: *v1.ConfigMap"
Starting EventSource  source="kind source: *v1.PersistentVolumeClaim"
```

### Health probes
```
$ curl -s http://localhost:8081/healthz
ok
$ curl -s http://localhost:8081/readyz
ok
```

## Test plan

- [x] `make test` passes
- [x] `make manifests && make generate` produces expected CRD/RBAC
- [x] Verified on KinD: printcolumns, enum validation, CEL rejection, owns watches, health probes
- [x] Verify on OpenShift with a fully reconciling QuayRegistry

🤖 Generated with [Claude Code](https://claude.com/claude-code)