### PR TITLE
chore: Add arm64 supported label in operator csv [PROJQUAY-9888]

### DIFF
--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -51,6 +51,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
 spec:
   customresourcedefinitions:


### PR DESCRIPTION
Add arm64 supported label in CSV, then openshift UI could display operator info