### PR TITLE
PROJQUAY-10873: fix(middleware): do not apply securityContext override to init containers 

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -184,9 +184,6 @@ func Process(quay *v1.QuayRegistry, qctx *quaycontext.QuayRegistryContext, obj c
 			for i := range dep.Spec.Template.Spec.Containers {
 				dep.Spec.Template.Spec.Containers[i].SecurityContext = osecctx
 			}
-			for i := range dep.Spec.Template.Spec.InitContainers {
-				dep.Spec.Template.Spec.InitContainers[i].SecurityContext = osecctx
-			}
 		}
 
 		if oannot := v1.GetAnnotationsOverrideForComponent(quay, kind); oannot != nil {

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -480,7 +480,41 @@ func TestProcessDeploymentSecurityContextOverride(t *testing.T) {
 				},
 			},
 			expectedContainerSC: overrideSC,
-			expectedInitSC:      overrideSC,
+			expectedInitSC:      defaultSC,
+		},
+		{
+			name: "SecurityContextOverrideDoesNotAffectInitContainers",
+			quay: &v1.QuayRegistry{
+				Spec: v1.QuayRegistrySpec{
+					Components: []v1.Component{
+						{Kind: v1.ComponentMirror, Managed: true, Overrides: &v1.Override{SecurityContext: overrideSC}},
+					},
+				},
+			},
+			dep: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-quay-mirror",
+					Labels:      map[string]string{"quay-component": "quay-mirror"},
+					Annotations: map[string]string{"quay-component": "mirror"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "quay-mirror", SecurityContext: defaultSC},
+							},
+							InitContainers: []corev1.Container{
+								{Name: "quay-mirror-init", SecurityContext: defaultSC},
+							},
+						},
+					},
+				},
+			},
+			expectedContainerSC: overrideSC,
+			expectedInitSC:      defaultSC,
 		},
 		{
 			name: "NoOverrideRetainsDefaults",
@@ -527,8 +561,8 @@ func TestProcessDeploymentSecurityContextOverride(t *testing.T) {
 			for _, c := range dep.Spec.Template.Spec.Containers {
 				assert.Equal(t, tt.expectedContainerSC, c.SecurityContext)
 			}
-			if tt.expectedInitSC != nil {
-				for _, c := range dep.Spec.Template.Spec.InitContainers {
+			for _, c := range dep.Spec.Template.Spec.InitContainers {
+				if tt.expectedInitSC != nil {
 					assert.Equal(t, tt.expectedInitSC, c.SecurityContext)
 				}
 			}


### PR DESCRIPTION
## Summary

- **Bug**: `securityContext` overrides from the QuayRegistry CR were applied to both containers and init containers. This caused mirror pods to be rejected by the `restricted-v2` SCC when the override included capabilities like `CHOWN`/`DAC_OVERRIDE`, since the mirror init container (`quay-mirror-init`) doesn't need them.
- **Fix**: Remove the init container override loop in `Process()`. Init containers are internal implementation details (health checks, setup) that should always run with the operator's default restricted securityContext.
- **Tests**: Updated existing test expectations and added a new mirror-specific test case `SecurityContextOverrideDoesNotAffectInitContainers`.

## JIRA

[PROJQUAY-10873](https://issues.redhat.com/browse/PROJQUAY-10873)

## Test plan

- [x] `go test ./pkg/middleware/ -run TestProcessDeploymentSecurityContextOverride -v` — all 3 test cases pass
- [ ] Deploy quay-operator with mirror component and securityContext override, verify mirror pods start successfully under `restricted-v2` SCC

🤖 Generated with [Claude Code](https://claude.com/claude-code)