### PR TITLE
fix(kustomize): defer upgrade job creation until object storage is ready (PROJQUAY-10876)

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -811,7 +811,6 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.Requeue, nil
 	}
 
-	osmanaged = v1.ComponentIsManaged(updatedQuay.Spec.Components, "objectstorage")
 	if osmanaged && !quayContext.ObjectStorageInitialized {
 		r.Log.Info("requeuing to populate values for managed component: `objectstorage`")
 		return r.Requeue, nil

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -423,7 +423,15 @@ func KustomizationFor(
 
 	componentPaths := []string{}
 	if overlay == upgradeOverlayDir() {
-		componentPaths = []string{"../components/job"}
+		// only include the upgrade job when object storage is either unmanaged
+		// or already initialized. when managed object storage is pending (OBC
+		// not yet bound), we skip the job to avoid creating it with incomplete
+		// storage configuration. the job will be created on the next reconcile
+		// after the OBC credentials become available.
+		osmanaged := v1.ComponentIsManaged(quay.Spec.Components, v1.ComponentObjectStorage)
+		if !osmanaged || ctx.ObjectStorageInitialized {
+			componentPaths = []string{"../components/job"}
+		}
 	}
 	for _, component := range quay.Spec.Components {
 		if !component.Managed || component.Kind == v1.ComponentQuay {

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -451,7 +451,8 @@ var inflateTests = []struct {
 			},
 		},
 		ctx: quaycontext.QuayRegistryContext{
-			SupportsObjectStorage: true,
+			SupportsObjectStorage:    true,
+			ObjectStorageInitialized: true,
 		},
 		configBundle: &corev1.Secret{
 			Data: map[string][]byte{
@@ -707,8 +708,9 @@ var inflateTests = []struct {
 			},
 		},
 		ctx: quaycontext.QuayRegistryContext{
-			SupportsObjectStorage: true,
-			DbUri:                 "postgresql://user:pass@db:5432/db",
+			SupportsObjectStorage:    true,
+			ObjectStorageInitialized: true,
+			DbUri:                    "postgresql://user:pass@db:5432/db",
 		},
 		configBundle: &corev1.Secret{
 			Data: map[string][]byte{


### PR DESCRIPTION
## Summary

Fixes a race condition where the upgrade Job is created before ObjectBucketClaim (OBC) credentials are available, causing it to fail permanently with empty storage configuration.

- When managed objectstorage is enabled, the OBC is created and the upgrade Job is generated in the same reconcile pass
- The OBC takes time to bind, so the config secret mounted by the Job has empty storage credentials
- The Job is immutable in Kubernetes and cannot be patched with correct config later
- The Job fails with `TypeError: __init__() missing 4 required positional arguments: 'hostname', 'access_key', 'secret_key', and 'bucket_name'`

**Fix:** In `KustomizationFor()`, skip the Job component when managed object storage has not yet been initialized. The upgrade overlay still scales Quay to 0 replicas, and the Job is created on the next reconcile after the OBC binds with valid credentials.

## Validation

1. Deploy operator locally against a cluster with NooBaa (e.g. CRC):
   ```bash
   SKIP_RESOURCE_REQUESTS=true QUAY_VERSION=dev go run main.go --metrics-addr=:9090
   ```

2. Create a QuayRegistry with managed objectstorage:
   ```yaml
   apiVersion: quay.redhat.com/v1
   kind: QuayRegistry
   metadata:
     name: test
     namespace: quay-test
   spec:
     components:
       - kind: clair
         managed: false
       - kind: clairpostgres
         managed: false
       - kind: mirror
         managed: false
       - kind: horizontalpodautoscaler
         managed: false
   ```

3. Verify the expected reconcile flow in operator logs:
   - First reconcile: upgrade overlay applied (Quay scaled to 0), **no Job created**, OBC created
   - Operator requeues: `"requeuing to populate values for managed component: objectstorage"`
   - After OBC binds: Job created with correct storage config, migration completes
   - Quay pods scale back up and become Ready

4. Verify **without** the fix, the Job is created immediately with empty storage config and fails permanently.

Jira: https://issues.redhat.com/browse/PROJQUAY-10876

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>