### PR TITLE
fix(kustomize): use generated secrets for clair postgres deployment (PROJQUAY-10279)

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -42,6 +42,11 @@ const (
 	dbURI                = "DB_URI"
 	dbRootPw             = "DB_ROOT_PW"
 	securityScannerV4PSK = "SECURITY_SCANNER_V4_PSK"
+
+	clairDbUser   = "CLAIR_DB_USER"
+	clairDbPw     = "CLAIR_DB_PASSWORD"
+	clairDbRootPw = "CLAIR_DB_ROOT_PW"
+	clairDbName   = "CLAIR_DB_NAME"
 )
 
 // checkDeprecatedManagedKeys populates the provided quay context with information we
@@ -74,6 +79,10 @@ func (r *QuayRegistryReconciler) checkDeprecatedManagedKeys(
 		qctx.DbUri = string(secret.Data[dbURI])
 		qctx.DbRootPw = string(secret.Data[dbRootPw])
 		qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
+		qctx.ClairDbUser = string(secret.Data[clairDbUser])
+		qctx.ClairDbPassword = string(secret.Data[clairDbPw])
+		qctx.ClairDbRootPw = string(secret.Data[clairDbRootPw])
+		qctx.ClairDbName = string(secret.Data[clairDbName])
 		break
 	}
 
@@ -105,6 +114,10 @@ func (r *QuayRegistryReconciler) checkManagedKeys(
 	qctx.DbUri = string(secret.Data[dbURI])
 	qctx.DbRootPw = string(secret.Data[dbRootPw])
 	qctx.SecurityScannerV4PSK = string(secret.Data[securityScannerV4PSK])
+	qctx.ClairDbUser = string(secret.Data[clairDbUser])
+	qctx.ClairDbPassword = string(secret.Data[clairDbPw])
+	qctx.ClairDbRootPw = string(secret.Data[clairDbRootPw])
+	qctx.ClairDbName = string(secret.Data[clairDbName])
 	return nil
 }
 

--- a/kustomize/components/clairpgupgrade/base/clair-pg-old.deployment.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg-old.deployment.yaml
@@ -36,13 +36,25 @@ spec:
               protocol: TCP
           env:
             - name: POSTGRESQL_USER
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-username
             - name: POSTGRESQL_DATABASE
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-name
             - name: POSTGRESQL_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-password
             - name: POSTGRESQL_ADMIN_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-root-password
             - name: POSTGRESQL_SHARED_BUFFERS
               value: 256MB
             - name: POSTGRESQL_MAX_CONNECTIONS

--- a/kustomize/components/clairpgupgrade/base/clair-pg-upgrade.job.yaml
+++ b/kustomize/components/clairpgupgrade/base/clair-pg-upgrade.job.yaml
@@ -33,7 +33,10 @@ spec:
                   name: clair-config-secret
                   key: clair-db-old-host
             - name: POSTGRESQL_MIGRATION_ADMIN_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-root-password
             - name: POSTGRESQL_SHARED_BUFFERS
               value: 256MB
             - name: POSTGRESQL_MAX_CONNECTIONS

--- a/kustomize/components/clairpostgres/kustomization.yaml
+++ b/kustomize/components/clairpostgres/kustomization.yaml
@@ -1,9 +1,12 @@
 # Clair component adds Clair v4 security scanner and its database.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-resources: 
+resources:
   - ./postgres.serviceaccount.yaml
   - ./postgres.persistentvolumeclaim.yaml
   - ./postgres.deployment.yaml
   - ./postgres.service.yaml
   - ./clair-postgres-conf-sample.configmap.yaml
+secretGenerator:
+  # NOTE: `clairpostgres-config-secret` fields generated in `kustomize.go`.
+  - name: clairpostgres-config-secret

--- a/kustomize/components/clairpostgres/postgres.deployment.yaml
+++ b/kustomize/components/clairpostgres/postgres.deployment.yaml
@@ -36,13 +36,25 @@ spec:
               protocol: TCP
           env:
             - name: POSTGRESQL_USER
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-username
             - name: POSTGRESQL_DATABASE
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-name
             - name: POSTGRESQL_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-password
             - name: POSTGRESQL_ADMIN_PASSWORD
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: clairpostgres-config-secret
+                  key: database-root-password
             - name: POSTGRESQL_SHARED_BUFFERS
               value: 256MB
             - name: POSTGRESQL_MAX_CONNECTIONS

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -38,6 +38,12 @@ type QuayRegistryContext struct {
 	NeedsPgUpgrade      bool
 	NeedsClairPgUpgrade bool
 
+	// Clair Database
+	ClairDbUser     string
+	ClairDbPassword string
+	ClairDbName     string
+	ClairDbRootPw   string
+
 	// Clair integration
 	SecurityScannerV4PSK string
 }

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -329,6 +329,29 @@ func KustomizationFor(
 		configFiles = append(configFiles, filepath.Join("bundle", key))
 	}
 
+	if v1.ComponentIsManaged(quay.Spec.Components, v1.ComponentClairPostgres) && ctx.ClairDbPassword == "" {
+		// DbRootPw is populated from managed keys for existing deployments
+		// but empty for new ones (before the generation block below).
+		if ctx.DbRootPw == "" {
+			// New deployment: generate random credentials.
+			pw, err := generateRandomString(32)
+			if err != nil {
+				return nil, err
+			}
+			ctx.ClairDbPassword = pw
+		} else {
+			// Upgrade path: default to legacy hardcoded values
+			ctx.ClairDbPassword = "postgres"
+		}
+		// The sclorg PG image sets POSTGRESQL_ADMIN_PASSWORD on the
+		// "postgres" superuser after POSTGRESQL_PASSWORD. When
+		// POSTGRESQL_USER is also "postgres" both must match or the
+		// user password is silently overwritten by the admin password.
+		ctx.ClairDbRootPw = ctx.ClairDbPassword
+		ctx.ClairDbUser = "postgres"
+		ctx.ClairDbName = "postgres"
+	}
+
 	if ctx.DbRootPw == "" {
 		rootpw, err := generateRandomString(32)
 		if err != nil {
@@ -407,6 +430,10 @@ func KustomizationFor(
 						"DB_URI=" + ctx.DbUri,
 						"DB_ROOT_PW=" + ctx.DbRootPw,
 						"SECURITY_SCANNER_V4_PSK=" + ctx.SecurityScannerV4PSK,
+						"CLAIR_DB_USER=" + ctx.ClairDbUser,
+						"CLAIR_DB_PASSWORD=" + ctx.ClairDbPassword,
+						"CLAIR_DB_ROOT_PW=" + ctx.ClairDbRootPw,
+						"CLAIR_DB_NAME=" + ctx.ClairDbName,
 					},
 				},
 			},

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -412,6 +412,9 @@ var quayComponents = map[string][]client.Object{
 		&autoscaling.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "quay-mirror"}},
 		&autoscaling.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "clair-app"}},
 	},
+	"clairpostgres": {
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "clairpostgres-config-secret"}},
+	},
 	"job": {
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "quay-app-upgrade"}},
 	},

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -370,7 +370,7 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 			preSharedKey = config.(map[string]interface{})["SECURITY_SCANNER_V4_PSK"].(string)
 		}
 
-		cfg, err := clairConfigFor(log, quay, quayHostname, preSharedKey)
+		cfg, err := clairConfigFor(log, qctx, quay, quayHostname, preSharedKey)
 		if err != nil {
 			return nil, err
 		}
@@ -380,13 +380,20 @@ func componentConfigFilesFor(log logr.Logger, qctx *quaycontext.QuayRegistryCont
 		cfgFiles["clair-db-old-host"] = []byte(strings.TrimSpace(strings.Join([]string{quay.GetName(), "clair-postgres-old"}, "-")))
 
 		return cfgFiles, nil
+	case v1.ComponentClairPostgres:
+		return map[string][]byte{
+			"database-username":      []byte(qctx.ClairDbUser),
+			"database-password":      []byte(qctx.ClairDbPassword),
+			"database-name":          []byte(qctx.ClairDbName),
+			"database-root-password": []byte(qctx.ClairDbRootPw),
+		}, nil
 	default:
 		return nil, nil
 	}
 }
 
 // clairConfigFor returns a Clair v4 config with the correct values.
-func clairConfigFor(log logr.Logger, quay *v1.QuayRegistry, quayHostname, preSharedKey string) ([]byte, error) {
+func clairConfigFor(log logr.Logger, qctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry, quayHostname, preSharedKey string) ([]byte, error) {
 	// the default number for the clair's database connections pool is arbitralily defined to
 	// 10 when the HPA component is unmanaged. If HPA is managed we have more control over the
 	// max number running clair pods so we increase it to the magic number of 33. This number
@@ -399,9 +406,9 @@ func clairConfigFor(log logr.Logger, quay *v1.QuayRegistry, quayHostname, preSha
 	}
 
 	host := strings.Join([]string{quay.GetName(), "clair-postgres"}, "-")
-	dbname := "postgres"
-	user := "postgres"
-	password := "postgres"
+	dbname := qctx.ClairDbName
+	user := qctx.ClairDbUser
+	password := qctx.ClairDbPassword
 	dbConn := fmt.Sprintf("host=%s port=5432 dbname=%s user=%s password=%s sslmode=disable pool_max_conns=%d", host, dbname, user, password, poolsize)
 
 	psk, err := base64.StdEncoding.DecodeString(preSharedKey)


### PR DESCRIPTION
## Summary

- Replace hardcoded `postgres` credentials in the Clair PostgreSQL deployment with generated secrets, matching the pattern used by the Quay PostgreSQL deployment
- Credentials are persisted in the managed keys secret across reconcile loops
- New deployments get randomly generated 32-char passwords
- Existing deployments default to the legacy `postgres` value for backward compatibility
- Both `POSTGRESQL_PASSWORD` and `POSTGRESQL_ADMIN_PASSWORD` use the same value since the sclorg PG image overwrites the user password with the admin password when `POSTGRESQL_USER` is `postgres`

## Changes

- Add `ClairDbUser`, `ClairDbPassword`, `ClairDbName`, `ClairDbRootPw` to `QuayRegistryContext`
- Persist/restore Clair DB credentials in managed keys secret (`features.go`)
- Generate random credentials for new deploys; default to `postgres` for upgrades (`kustomize.go`)
- Add `ComponentClairPostgres` case to `componentConfigFilesFor()` and update `clairConfigFor()` to use context credentials (`secrets.go`)
- Add `secretGenerator` to clairpostgres kustomization
- Update clairpostgres deployment, upgrade job, and old PG deployment to use `secretKeyRef`

## Test plan

- [x] `make test` — all unit tests pass
- [x] Fresh install on CRC — `clairpostgres-config-secret` created with random credentials, Clair app connects successfully
- [x] Upgrade from master (hardcoded `postgres`) — credentials default to `postgres`, Clair remains healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)