### PR TITLE
PROJQUAY-10725: fix(controller): replace per-reconcile Route probe with cached discovery

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -10,7 +10,6 @@ import (
 	err "errors"
 	"fmt"
 	"strings"
-	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -23,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/quay/config-tool/pkg/lib/fieldgroups/hostsettings"
@@ -96,7 +94,6 @@ func (r *QuayRegistryReconciler) checkDeprecatedManagedKeys(
 func (r *QuayRegistryReconciler) checkManagedKeys(
 	ctx context.Context, qctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry,
 ) error {
-
 	nsn := types.NamespacedName{
 		Name:      fmt.Sprintf("%s-%s", quay.Name, v1.ManagedKeysName),
 		Namespace: quay.Namespace,
@@ -127,7 +124,6 @@ func (r *QuayRegistryReconciler) checkManagedKeys(
 func (r *QuayRegistryReconciler) checkClusterCAHash(
 	ctx context.Context, qctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry,
 ) error {
-
 	hashConfigMapContents := func(data map[string]string, key string) string {
 		certData, exists := data[key]
 		if !exists {
@@ -194,21 +190,14 @@ func (r *QuayRegistryReconciler) checkManagedTLS(
 	qctx.TLSKey = providedTLSKey
 }
 
-// checkRoutesAvailable checks if the cluster supports Route objects. // XXX here
-// be dragons. This functions attempts to create a fake route and then read the
-// certificate used on it, this should be refactored. This is as wrong as it can
-// get.
-func (r *QuayRegistryReconciler) checkRoutesAvailable(
-	ctx context.Context,
+var errRouteProbeInProgress = fmt.Errorf("route probe in progress, awaiting ingress status")
+
+// parseServerHostname extracts the SERVER_HOSTNAME field from the config bundle
+// and sets it on the QuayRegistryContext if present.
+func parseServerHostname(
 	qctx *quaycontext.QuayRegistryContext,
-	quay *v1.QuayRegistry,
 	bundle *corev1.Secret,
 ) error {
-	// NOTE: The `route` component is unique because we allow users to set the
-	// `SERVER_HOSTNAME` field instead of controlling the entire fieldgroup. This
-	// value is then passed to the created `Route` using a Kustomize variable.
-
-	// REFACTOR: The below `qctx` obj setting the hostname should be put in a separate function.
 	var config map[string]interface{}
 	if err := yaml.Unmarshal(bundle.Data["config.yaml"], &config); err != nil {
 		return fmt.Errorf("unable to parse config.yaml: %w", err)
@@ -222,19 +211,39 @@ func (r *QuayRegistryReconciler) checkRoutesAvailable(
 	if fieldGroup.ServerHostname != "" {
 		qctx.ServerHostname = fieldGroup.ServerHostname
 	}
+	return nil
+}
 
-	// If route is unmanaged and not explicilty defined then skip routes check
-	routeExplicitlyDefined := v1.ComponentIsExplicitlyDefined(quay.Spec.Components, v1.ComponentRoute)
-	routeManaged := v1.ComponentIsManaged(quay.Spec.Components, v1.ComponentRoute)
-	if routeExplicitlyDefined && !routeManaged {
+// ensureRouteDiscovery discovers the cluster hostname and wildcard cert via a
+// probe Route. Results are cached for the operator's lifetime. Returns
+// errRouteProbeInProgress if the probe route exists but status.ingress is not
+// yet populated (caller should requeue).
+func (r *QuayRegistryReconciler) ensureRouteDiscovery(
+	ctx context.Context,
+	qctx *quaycontext.QuayRegistryContext,
+	quay *v1.QuayRegistry,
+) error {
+	// Fast path: hostname already cached from a previous reconcile.
+	if cached := r.clusterHostname.Load(); cached != nil {
+		qctx.SupportsRoutes = true
+		qctx.ClusterHostname = *cached
+		if cachedCert := r.clusterWildcardCert.Load(); cachedCert != nil {
+			qctx.ClusterWildcardCert = *cachedCert
+		}
 		return nil
+	}
+
+	routeName := fmt.Sprintf("%s-test-route", quay.GetName())
+	routeNSN := types.NamespacedName{
+		Name:      routeName,
+		Namespace: quay.GetNamespace(),
 	}
 
 	fakeRoute := v1.EnsureOwnerReference(
 		quay,
 		&routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-test-route", quay.GetName()),
+				Name:      routeName,
 				Namespace: quay.GetNamespace(),
 			},
 			Spec: routev1.RouteSpec{
@@ -246,65 +255,65 @@ func (r *QuayRegistryReconciler) checkRoutesAvailable(
 		},
 	)
 
-	// if we fail to create the fake route and the failure is not IsAlreadyExists then
-	// we consider as if the cluster does not support Route objects. XXX This must be
-	// redesigned. I am keeping the logic as is but we shouldn't blindly trust that any
-	// error means "does not support routes".
 	if err := r.Create(ctx, fakeRoute); err != nil && !errors.IsAlreadyExists(err) {
-		r.Log.Info("cluster does not support `Route` API", "error", err)
+		r.Log.Info("failed to create probe route", "error", err)
 		return nil
 	}
 
-	// Wait until `status.ingress` is populated (should be immediately).
-	r.Log.Info("cluster supports `Routes` API")
 	var rt routev1.Route
-	if err := wait.PollUntilContextTimeout(
-		ctx,
-		time.Second,
-		5*time.Minute,
-		false,
-		func(ctx context.Context) (done bool, err error) {
-			routensn := types.NamespacedName{
-				Name:      fmt.Sprintf("%s-test-route", quay.GetName()),
-				Namespace: quay.GetNamespace(),
-			}
-
-			if err := r.Get(ctx, routensn, &rt); err != nil {
-				return true, err
-			}
-
-			if len(rt.Status.Ingress) == 0 {
-				r.Log.Info("waiting to detect `routerCanonicalHostname`")
-				return false, nil
-			}
-
-			qctx.SupportsRoutes = true
-			prefix := fmt.Sprintf("router-%s.", rt.Status.Ingress[0].RouterName)
-			cnname := rt.Status.Ingress[0].RouterCanonicalHostname
-			qctx.ClusterHostname = strings.TrimPrefix(cnname, prefix)
-			r.Log.Info("Detected cluster hostname " + qctx.ClusterHostname)
-			return true, nil
-		},
-	); err != nil {
-		return err
+	if err := r.Get(ctx, routeNSN, &rt); err != nil {
+		return fmt.Errorf("failed to get probe route: %w", err)
 	}
 
-	if qctx.ServerHostname == "" {
-		qctx.ServerHostname = fmt.Sprintf(
-			"%s-quay-%s.%s",
-			quay.GetName(),
-			quay.GetNamespace(),
-			qctx.ClusterHostname,
-		)
+	if len(rt.Status.Ingress) == 0 {
+		r.Log.Info("waiting to detect routerCanonicalHostname")
+		return errRouteProbeInProgress
 	}
 
+	// Extract and cache cluster hostname.
+	prefix := fmt.Sprintf("router-%s.", rt.Status.Ingress[0].RouterName)
+	cnname := rt.Status.Ingress[0].RouterCanonicalHostname
+	hostname := strings.TrimPrefix(cnname, prefix)
+	r.Log.Info("detected cluster hostname", "hostname", hostname)
+
+	qctx.SupportsRoutes = true
+	qctx.ClusterHostname = hostname
+	r.clusterHostname.Store(&hostname)
+
+	// Best-effort wildcard cert extraction.
 	wildcard, err := getCertificatesPEM(rt.Spec.Host + ":443")
 	if err != nil {
-		return err
+		r.Log.Info("failed to extract wildcard cert, continuing without it", "error", err)
+	} else {
+		qctx.ClusterWildcardCert = wildcard
+		r.clusterWildcardCert.Store(&wildcard)
 	}
-	qctx.ClusterWildcardCert = wildcard
 
-	return r.Delete(ctx, &rt)
+	if err := r.Delete(ctx, &rt); err != nil && !errors.IsNotFound(err) {
+		r.Log.Error(err, "failed to delete probe route")
+	}
+
+	return nil
+}
+
+// fillServerHostname derives ServerHostname from ClusterHostname if not
+// explicitly set in the config bundle.
+func fillServerHostname(
+	qctx *quaycontext.QuayRegistryContext,
+	quay *v1.QuayRegistry,
+) {
+	if qctx.ServerHostname != "" {
+		return
+	}
+	if qctx.ClusterHostname == "" {
+		return
+	}
+	qctx.ServerHostname = fmt.Sprintf(
+		"%s-quay-%s.%s",
+		quay.GetName(),
+		quay.GetNamespace(),
+		qctx.ClusterHostname,
+	)
 }
 
 func (r *QuayRegistryReconciler) checkObjectBucketClaimsAvailable(

--- a/controllers/quay/features_test.go
+++ b/controllers/quay/features_test.go
@@ -1,9 +1,239 @@
 package controllers
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	v1 "github.com/quay/quay-operator/apis/quay/v1"
+	quaycontext "github.com/quay/quay-operator/pkg/context"
 )
+
+func TestParseServerHostname(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		configYAML       string
+		expectedHostname string
+		expectErr        bool
+	}{
+		{
+			name:             "SERVER_HOSTNAME set",
+			configYAML:       "SERVER_HOSTNAME: registry.example.com",
+			expectedHostname: "registry.example.com",
+		},
+		{
+			name:             "SERVER_HOSTNAME not set",
+			configYAML:       "FEATURE_USER_INITIALIZE: true",
+			expectedHostname: "",
+		},
+		{
+			name:       "invalid YAML",
+			configYAML: "{{invalid",
+			expectErr:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			qctx := quaycontext.NewQuayRegistryContext()
+			bundle := &corev1.Secret{
+				Data: map[string][]byte{
+					"config.yaml": []byte(tt.configYAML),
+				},
+			}
+
+			err := parseServerHostname(qctx, bundle)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if qctx.ServerHostname != tt.expectedHostname {
+				t.Errorf("ServerHostname = %q, want %q", qctx.ServerHostname, tt.expectedHostname)
+			}
+		})
+	}
+}
+
+func TestFillServerHostname(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		serverHostname   string
+		clusterHostname  string
+		quayName         string
+		quayNamespace    string
+		expectedHostname string
+	}{
+		{
+			name:             "already set",
+			serverHostname:   "custom.example.com",
+			clusterHostname:  "apps.cluster.example.com",
+			quayName:         "test",
+			quayNamespace:    "ns",
+			expectedHostname: "custom.example.com",
+		},
+		{
+			name:             "derived from cluster hostname",
+			serverHostname:   "",
+			clusterHostname:  "apps.cluster.example.com",
+			quayName:         "test",
+			quayNamespace:    "ns",
+			expectedHostname: "test-quay-ns.apps.cluster.example.com",
+		},
+		{
+			name:             "both empty",
+			serverHostname:   "",
+			clusterHostname:  "",
+			quayName:         "test",
+			quayNamespace:    "ns",
+			expectedHostname: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			qctx := quaycontext.NewQuayRegistryContext()
+			qctx.ServerHostname = tt.serverHostname
+			qctx.ClusterHostname = tt.clusterHostname
+
+			quay := &v1.QuayRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.quayName,
+					Namespace: tt.quayNamespace,
+				},
+			}
+
+			fillServerHostname(qctx, quay)
+
+			if qctx.ServerHostname != tt.expectedHostname {
+				t.Errorf("ServerHostname = %q, want %q", qctx.ServerHostname, tt.expectedHostname)
+			}
+		})
+	}
+}
+
+func TestEnsureRouteDiscovery(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = routev1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns",
+			UID:       "test-uid",
+		},
+	}
+
+	t.Run("fast path: hostname cached", func(t *testing.T) {
+		r := &QuayRegistryReconciler{
+			Log: zap.New(zap.UseDevMode(true)),
+		}
+		hostname := "apps.cached.example.com"
+		r.clusterHostname.Store(&hostname)
+		cert := []byte("cached-cert")
+		r.clusterWildcardCert.Store(&cert)
+
+		qctx := quaycontext.NewQuayRegistryContext()
+		err := r.ensureRouteDiscovery(context.Background(), qctx, quay)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !qctx.SupportsRoutes {
+			t.Error("expected SupportsRoutes=true")
+		}
+		if qctx.ClusterHostname != "apps.cached.example.com" {
+			t.Errorf("ClusterHostname = %q, want %q", qctx.ClusterHostname, "apps.cached.example.com")
+		}
+		if string(qctx.ClusterWildcardCert) != "cached-cert" {
+			t.Errorf("ClusterWildcardCert = %q, want %q", string(qctx.ClusterWildcardCert), "cached-cert")
+		}
+	})
+
+	t.Run("probe in progress: route exists but no ingress", func(t *testing.T) {
+		existingRoute := &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-test-route",
+				Namespace: "ns",
+			},
+		}
+		client := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(existingRoute).
+			Build()
+
+		r := &QuayRegistryReconciler{
+			Client: client,
+			Log:    zap.New(zap.UseDevMode(true)),
+		}
+
+		qctx := quaycontext.NewQuayRegistryContext()
+		err := r.ensureRouteDiscovery(context.Background(), qctx, quay)
+		if !errors.Is(err, errRouteProbeInProgress) {
+			t.Fatalf("expected errRouteProbeInProgress, got: %v", err)
+		}
+	})
+
+	t.Run("successful discovery: route with ingress", func(t *testing.T) {
+		existingRoute := &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-test-route",
+				Namespace: "ns",
+			},
+			Spec: routev1.RouteSpec{
+				Host: "test-test-route-ns.apps.cluster.example.com",
+				To: routev1.RouteTargetReference{
+					Kind: "Service",
+					Name: "none",
+				},
+			},
+			Status: routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{
+					{
+						RouterName:              "default",
+						RouterCanonicalHostname: "router-default.apps.cluster.example.com",
+					},
+				},
+			},
+		}
+		client := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(existingRoute).
+			Build()
+
+		r := &QuayRegistryReconciler{
+			Client: client,
+			Log:    zap.New(zap.UseDevMode(true)),
+		}
+
+		qctx := quaycontext.NewQuayRegistryContext()
+		err := r.ensureRouteDiscovery(context.Background(), qctx, quay)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !qctx.SupportsRoutes {
+			t.Error("expected SupportsRoutes=true")
+		}
+		if qctx.ClusterHostname != "apps.cluster.example.com" {
+			t.Errorf("ClusterHostname = %q, want %q", qctx.ClusterHostname, "apps.cluster.example.com")
+		}
+
+		// Verify hostname was cached.
+		cached := r.clusterHostname.Load()
+		if cached == nil || *cached != "apps.cluster.example.com" {
+			t.Error("hostname was not cached")
+		}
+	})
+}
 
 func Test_extractImageName(t *testing.T) {
 	for _, tt := range []struct {

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -75,6 +76,11 @@ type QuayRegistryReconciler struct {
 	WatchNamespace       string
 	Requeue              ctrl.Result
 	SkipResourceRequests bool
+
+	// Cached route discovery results (write-once, read-many)
+	supportsRoutes      bool
+	clusterHostname     atomic.Pointer[string]
+	clusterWildcardCert atomic.Pointer[[]byte]
 }
 
 // manageQuayDeletion makes sure that we process a QuayRegistry once it is flagged for
@@ -556,16 +562,44 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		)
 	}
 
-	if err := r.checkRoutesAvailable(ctx, quayContext, updatedQuay, cbundle); err != nil {
+	if err := parseServerHostname(quayContext, cbundle); err != nil {
 		return r.reconcileWithCondition(
 			ctx,
 			&quay,
 			v1.ConditionTypeRolloutBlocked,
 			metav1.ConditionTrue,
-			v1.ConditionReasonRouteComponentDependencyError,
-			fmt.Sprintf("could not check for `Routes` API: %s", err),
+			v1.ConditionReasonConfigInvalid,
+			fmt.Sprintf("unable to parse SERVER_HOSTNAME from config: %s", err),
 		)
 	}
+
+	if r.supportsRoutes {
+		quayContext.SupportsRoutes = true
+
+		routeIsUnmanaged := v1.ComponentIsExplicitlyDefined(updatedQuay.Spec.Components, v1.ComponentRoute) &&
+			!v1.ComponentIsManaged(updatedQuay.Spec.Components, v1.ComponentRoute)
+		userProvidedAll := quayContext.ServerHostname != "" && quayContext.TLSCert != nil
+
+		needsProbe := !routeIsUnmanaged && !userProvidedAll
+		if needsProbe {
+			if err := r.ensureRouteDiscovery(ctx, quayContext, updatedQuay); err != nil {
+				if goerrors.Is(err, errRouteProbeInProgress) {
+					log.Info("route probe in progress, will retry")
+					return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+				}
+				return r.reconcileWithCondition(
+					ctx,
+					&quay,
+					v1.ConditionTypeRolloutBlocked,
+					metav1.ConditionTrue,
+					v1.ConditionReasonRouteComponentDependencyError,
+					fmt.Sprintf("could not check for `Routes` API: %s", err),
+				)
+			}
+		}
+	}
+
+	fillServerHostname(quayContext, updatedQuay)
 
 	osmanaged := v1.ComponentIsManaged(updatedQuay.Spec.Components, v1.ComponentObjectStorage)
 	if err := r.checkObjectBucketClaimsAvailable(
@@ -1200,6 +1234,17 @@ func (r *QuayRegistryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r.Log.Error(err, "Failed to add `PrometheusRule` API to scheme")
 
 		return err
+	}
+
+	// Detect Route API availability once at startup via RESTMapper (zero side effects).
+	_, err := mgr.GetRESTMapper().RESTMapping(
+		schema.GroupKind{Group: "route.openshift.io", Kind: "Route"},
+	)
+	r.supportsRoutes = (err == nil)
+	if r.supportsRoutes {
+		r.Log.Info("Route API detected at startup")
+	} else {
+		r.Log.Info("Route API not available, running in non-OpenShift mode")
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
Split checkRoutesAvailable() into three focused functions:
- parseServerHostname: extracts SERVER_HOSTNAME from config bundle
- ensureRouteDiscovery: non-blocking probe with atomic.Pointer caching
- fillServerHostname: derives hostname from cluster hostname if unset

Route API availability is now detected once at startup via RESTMapper
instead of creating a fake Route on every reconcile. The blocking
wait.PollUntilContextTimeout (up to 5min) is replaced with a sentinel
error + RequeueAfter: 5s pattern. Wildcard cert extraction is now
best-effort (logged, not fatal). The probe is skipped entirely when the
user provides both SERVER_HOSTNAME and custom TLS cert.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
