### PR TITLE
NO-ISSUE: fix(controller): defer workload creation until OBC is initialized

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -732,7 +732,14 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		)
 	}
 
-	for _, obj := range kustomize.EnsureCreationOrder(deploymentObjects) {
+	// When managed object storage is pending initialization (OBC not yet
+	// bound), defer creating Deployments and Jobs. This prevents the config
+	// secret from being created with incomplete storage values only to be
+	// regenerated (with a different hash) once the OBC is bound, which
+	// would trigger an unnecessary deployment rollout.
+	deferWorkloads := osmanaged && !quayContext.ObjectStorageInitialized
+
+	for _, obj := range filterDeferredWorkloads(kustomize.EnsureCreationOrder(deploymentObjects), deferWorkloads) {
 		// For metrics and dashboards to work, we need to deploy the Grafana ConfigMap
 		// in the `openshift-config-managed` namespace and add the label
 		// `openshift.io/cluster-monitoring: true` to the registry namespace
@@ -1323,4 +1330,22 @@ func (r *QuayRegistryReconciler) finalizeQuay(ctx context.Context, quay *v1.Quay
 	}
 
 	return nil
+}
+
+// filterDeferredWorkloads removes Deployments and Jobs from the given
+// slice when deferWorkloads is true. When false, the slice is returned
+// unchanged.
+func filterDeferredWorkloads(objects []client.Object, deferWorkloads bool) []client.Object {
+	if !deferWorkloads {
+		return objects
+	}
+	filtered := make([]client.Object, 0, len(objects))
+	for _, obj := range objects {
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		if kind == "Deployment" || kind == "Job" {
+			continue
+		}
+		filtered = append(filtered, obj)
+	}
+	return filtered
 }

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -862,6 +863,59 @@ func Test_cleanupPreviousSecret(t *testing.T) {
 
 			if tt.experr {
 				t.Errorf("expecting error but nil returned")
+			}
+		})
+	}
+}
+
+func testObj(kind string) client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Kind: kind})
+	return u
+}
+
+func TestFilterDeferredWorkloads(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		deferWorkloads bool
+		inputKinds     []string
+		wantKinds      []string
+	}{
+		{
+			name:           "deferWorkloads false passes all objects through",
+			deferWorkloads: false,
+			inputKinds:     []string{"Secret", "Deployment", "Job", "Service"},
+			wantKinds:      []string{"Secret", "Deployment", "Job", "Service"},
+		},
+		{
+			name:           "deferWorkloads true filters Deployments and Jobs",
+			deferWorkloads: true,
+			inputKinds:     []string{"Secret", "Deployment", "Job", "Service", "ConfigMap"},
+			wantKinds:      []string{"Secret", "Service", "ConfigMap"},
+		},
+		{
+			name:           "deferWorkloads true with no workloads is a no-op",
+			deferWorkloads: true,
+			inputKinds:     []string{"Secret", "Service"},
+			wantKinds:      []string{"Secret", "Service"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := make([]client.Object, len(tt.inputKinds))
+			for i, kind := range tt.inputKinds {
+				objects[i] = testObj(kind)
+			}
+
+			result := filterDeferredWorkloads(objects, tt.deferWorkloads)
+
+			if len(result) != len(tt.wantKinds) {
+				t.Fatalf("got %d objects, want %d", len(result), len(tt.wantKinds))
+			}
+			for i, obj := range result {
+				got := obj.GetObjectKind().GroupVersionKind().Kind
+				if got != tt.wantKinds[i] {
+					t.Errorf("object[%d] kind = %q, want %q", i, got, tt.wantKinds[i])
+				}
 			}
 		})
 	}


### PR DESCRIPTION
When managed object storage is enabled, the ObjectBucketClaim may not
be bound on the first reconcile. Previously, Deployments and Jobs were
created with an incomplete config secret (missing storage values). On
the next reconcile the OBC would be bound, generating a new config
secret with a different hash and triggering an unnecessary deployment
rollout (~67s wasted).

Skip creating Deployments and Jobs until the OBC is initialized. The
existing requeue at the end of the reconcile loop ensures a follow-up
pass where the config secret is generated with stable storage values
and workloads are created referencing it from the start.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
