### PR TITLE
NO-ISSUE: fix(controller): skip recreation of succeeded or active Jobs

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -1044,6 +1044,26 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(
 
 	jobGVK := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 	if gvk == jobGVK {
+		// Check if an existing Job with this name is still running or already
+		// completed. Jobs are immutable so we normally delete+recreate, but we
+		// must not recreate a Job that is active or has already succeeded —
+		// the migrations are not idempotent and a second run will fail.
+		var existingJob batchv1.Job
+		jobKey := types.NamespacedName{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+		}
+		if err := r.Get(ctx, jobKey, &existingJob); err == nil {
+			if existingJob.Status.Succeeded >= 1 {
+				log.Info("immutable resource already completed successfully, skipping recreation")
+				return false, nil
+			}
+			if existingJob.Status.Active >= 1 {
+				log.Info("immutable resource is still running, skipping recreation")
+				return false, nil
+			}
+		}
+
 		propagationPolicy := metav1.DeletePropagationForeground
 		opts := &client.DeleteOptions{
 			PropagationPolicy: &propagationPolicy,


### PR DESCRIPTION
Jobs are immutable so the operator uses a delete+recreate pattern, but
it was unconditionally deleting and recreating every Job on each reconcile
loop. Since Quay's database migrations are not idempotent (CREATE TABLE
without IF NOT EXISTS), re-running a completed upgrade Job causes
DuplicateTable errors. Similarly, deleting a still-running Job and
recreating it can cause duplicate migration attempts.

Now check Job status before deletion: skip if Succeeded >= 1 or
Active >= 1.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Brady Pratt <bpratt@redhat.com>
