### PR TITLE
PROJQUAY-10873: fix(mirror): use RollingUpdate strategy for mirror deployment

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     quay-component: mirror
 spec:
   strategy:
-    type: Recreate
+    type: RollingUpdate
   selector:
     matchLabels:
       quay-component: quay-mirror


### PR DESCRIPTION
## Summary

- Change mirror deployment strategy from `Recreate` to `RollingUpdate` to prevent total mirror pod loss when a `securityContext` override causes SCC validation failures.
- With `Recreate`, old pods are terminated before new ones are created — if the new pods fail SCC validation, the deployment is stuck at 0 pods with no recovery.
- With `RollingUpdate`, old pods remain running until replacements are ready, so the mirror service stays operational even if the new pod spec is rejected.

## Validated on CRC

| Check | Bug (`Recreate`) | Fix (`RollingUpdate`) |
|-------|----------------|---------------------|
| Mirror pods after override | 0 Running | 1 Running (old pod preserved) |
| SCC FailedCreate events | Yes | Yes (same) |
| Recovery possible | No (stuck at 0) | Yes (old pods still serving) |

## Test plan

- [x] E2E validated on CRC: `Recreate` reproduces the bug (0 pods after bad override)
- [x] E2E validated on CRC: `RollingUpdate` keeps old pods alive during failed rollout
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)