### PR TITLE
NO-ISSUE: test(e2e): add reconcile lifecycle and config rotation tests

### DIFF
--- a/test/chainsaw/reconcile/05-assert.yaml
+++ b/test/chainsaw/reconcile/05-assert.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reconcile-quay-mirror
+spec:
+  template:
+    metadata:
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - quay-mirror
+---
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: reconcile
+status:
+  conditions:
+  - type: ComponentHPAReady
+    status: "True"
+  - type: ComponentRouteReady
+    status: "True"
+  - type: ComponentMonitoringReady
+    status: "True"
+  - type: ComponentPostgresReady
+    status: "True"
+  - type: ComponentObjectStorageReady
+    status: "True"
+  - type: ComponentClairReady
+    status: "True"
+  - type: ComponentClairPostgresReady
+    status: "True"
+  - type: ComponentTLSReady
+    status: "True"
+  - type: ComponentRedisReady
+    status: "True"
+  - type: ComponentQuayReady
+    status: "True"
+  - type: ComponentMirrorReady
+    reason: ComponentReady
+    status: "True"
+  - type: Available
+    status: "True"
+  - type: ComponentsCreated
+    status: "True"
+  - type: RolloutBlocked
+    status: "False"

--- a/test/chainsaw/reconcile/05-remanage-mirror.yaml
+++ b/test/chainsaw/reconcile/05-remanage-mirror.yaml
@@ -1,0 +1,107 @@
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: reconcile
+spec:
+  configBundleSecret: ($values.configBundle)
+  components:
+  - kind: quay
+    managed: true
+    overrides:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - quay-app
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+        l2: TESTING
+      annotations:
+        a1: TESTING
+        a2: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: clair
+    managed: true
+    overrides:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - clair-app
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: postgres
+    managed: true
+    overrides:
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: redis
+    managed: true
+    overrides:
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: mirror
+    managed: true
+    overrides:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - quay-mirror
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: clairpostgres
+    managed: true
+  - kind: horizontalpodautoscaler
+    managed: false
+  - kind: objectstorage
+    managed: ($values.managedObjectStorage)
+  - kind: route
+    managed: ($values.managedRoute)
+  - kind: monitoring
+    managed: ($values.managedMonitoring)
+  - kind: tls
+    managed: ($values.managedTLS)

--- a/test/chainsaw/reconcile/06-assert.yaml
+++ b/test/chainsaw/reconcile/06-assert.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reconcile-quay-mirror
+spec:
+  replicas: 0
+---
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: reconcile
+status:
+  conditions:
+  - type: ComponentHPAReady
+    status: "True"
+  - type: ComponentRouteReady
+    status: "True"
+  - type: ComponentMonitoringReady
+    status: "True"
+  - type: ComponentPostgresReady
+    status: "True"
+  - type: ComponentObjectStorageReady
+    status: "True"
+  - type: ComponentClairReady
+    status: "True"
+  - type: ComponentClairPostgresReady
+    status: "True"
+  - type: ComponentTLSReady
+    status: "True"
+  - type: ComponentRedisReady
+    status: "True"
+  - type: ComponentQuayReady
+    status: "True"
+  - type: ComponentMirrorReady
+    reason: ComponentReady
+    message: "Mirror manually scaled down"
+    status: "True"
+  - type: Available
+    status: "True"
+  - type: ComponentsCreated
+    status: "True"
+  - type: RolloutBlocked
+    status: "False"

--- a/test/chainsaw/reconcile/06-scale-to-zero.yaml
+++ b/test/chainsaw/reconcile/06-scale-to-zero.yaml
@@ -1,0 +1,89 @@
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: reconcile
+spec:
+  configBundleSecret: ($values.configBundle)
+  components:
+  - kind: quay
+    managed: true
+    overrides:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - quay-app
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+        l2: TESTING
+      annotations:
+        a1: TESTING
+        a2: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: clair
+    managed: true
+    overrides:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - clair-app
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: postgres
+    managed: true
+    overrides:
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: redis
+    managed: true
+    overrides:
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: mirror
+    managed: true
+    overrides:
+      replicas: 0
+  - kind: clairpostgres
+    managed: true
+  - kind: horizontalpodautoscaler
+    managed: false
+  - kind: objectstorage
+    managed: ($values.managedObjectStorage)
+  - kind: route
+    managed: ($values.managedRoute)
+  - kind: monitoring
+    managed: ($values.managedMonitoring)
+  - kind: tls
+    managed: ($values.managedTLS)

--- a/test/chainsaw/reconcile/07-assert.yaml
+++ b/test/chainsaw/reconcile/07-assert.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reconcile-quay-mirror
+spec:
+  replicas: 2
+---
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: reconcile
+status:
+  conditions:
+  - type: ComponentHPAReady
+    status: "True"
+  - type: ComponentRouteReady
+    status: "True"
+  - type: ComponentMonitoringReady
+    status: "True"
+  - type: ComponentPostgresReady
+    status: "True"
+  - type: ComponentObjectStorageReady
+    status: "True"
+  - type: ComponentClairReady
+    status: "True"
+  - type: ComponentClairPostgresReady
+    status: "True"
+  - type: ComponentTLSReady
+    status: "True"
+  - type: ComponentRedisReady
+    status: "True"
+  - type: ComponentQuayReady
+    status: "True"
+  - type: ComponentMirrorReady
+    reason: ComponentReady
+    status: "True"
+  - type: Available
+    status: "True"
+  - type: ComponentsCreated
+    status: "True"
+  - type: RolloutBlocked
+    status: "False"

--- a/test/chainsaw/reconcile/07-restore-mirror.yaml
+++ b/test/chainsaw/reconcile/07-restore-mirror.yaml
@@ -1,0 +1,108 @@
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: reconcile
+spec:
+  configBundleSecret: ($values.configBundle)
+  components:
+  - kind: quay
+    managed: true
+    overrides:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - quay-app
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+        l2: TESTING
+      annotations:
+        a1: TESTING
+        a2: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: clair
+    managed: true
+    overrides:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - clair-app
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: postgres
+    managed: true
+    overrides:
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: redis
+    managed: true
+    overrides:
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: mirror
+    managed: true
+    overrides:
+      replicas: 2
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: quay-component
+                  operator: In
+                  values:
+                  - quay-mirror
+              topologyKey: kubernetes.io/hostname
+      labels:
+        l1: TESTING
+      annotations:
+        a1: TESTING
+      env:
+      - name: TESTING
+        value: TESTING
+  - kind: clairpostgres
+    managed: true
+  - kind: horizontalpodautoscaler
+    managed: false
+  - kind: objectstorage
+    managed: ($values.managedObjectStorage)
+  - kind: route
+    managed: ($values.managedRoute)
+  - kind: monitoring
+    managed: ($values.managedMonitoring)
+  - kind: tls
+    managed: ($values.managedTLS)

--- a/test/chainsaw/reconcile/08-assert.yaml
+++ b/test/chainsaw/reconcile/08-assert.yaml
@@ -1,0 +1,34 @@
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: reconcile
+status:
+  conditions:
+  - type: ComponentHPAReady
+    status: "True"
+  - type: ComponentRouteReady
+    status: "True"
+  - type: ComponentMonitoringReady
+    status: "True"
+  - type: ComponentPostgresReady
+    status: "True"
+  - type: ComponentObjectStorageReady
+    status: "True"
+  - type: ComponentClairReady
+    status: "True"
+  - type: ComponentClairPostgresReady
+    status: "True"
+  - type: ComponentTLSReady
+    status: "True"
+  - type: ComponentRedisReady
+    status: "True"
+  - type: ComponentQuayReady
+    status: "True"
+  - type: ComponentMirrorReady
+    status: "True"
+  - type: Available
+    status: "True"
+  - type: ComponentsCreated
+    status: "True"
+  - type: RolloutBlocked
+    status: "False"

--- a/test/chainsaw/reconcile/chainsaw-test.yaml
+++ b/test/chainsaw/reconcile/chainsaw-test.yaml
@@ -156,3 +156,87 @@ spec:
           # Verify tag is queryable via the registry API
           PUSH_DIGEST=$(crane digest ${CRANE_FLAGS} "${REGISTRY}/admin/e2e-test:latest")
           echo "PASS: push verified digest=${PUSH_DIGEST}"
+  - name: step-05
+    try:
+    - apply:
+        file: 05-remanage-mirror.yaml
+    - assert:
+        file: 05-assert.yaml
+  - name: step-06
+    try:
+    - apply:
+        file: 06-scale-to-zero.yaml
+    - assert:
+        file: 06-assert.yaml
+  - name: step-07
+    try:
+    - apply:
+        file: 07-restore-mirror.yaml
+    - assert:
+        file: 07-assert.yaml
+  - name: step-08
+    try:
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euxo pipefail
+
+          # Record the current config secret name
+          OLD_SECRET=$(kubectl get secret -n $NAMESPACE -o name \
+            | grep "reconcile-quay-config-secret" | head -1 || true)
+          echo "Current config secret: ${OLD_SECRET}"
+
+          if [ -z "${OLD_SECRET}" ]; then
+            echo "ERROR: no config secret found"
+            exit 1
+          fi
+
+          # Ensure config bundle secret exists (on OpenShift it may not)
+          if ! kubectl get secret reconcile-config -n $NAMESPACE &>/dev/null; then
+            echo "Creating config bundle secret for OpenShift..."
+            kubectl create secret generic reconcile-config -n $NAMESPACE \
+              --from-literal=config.yaml="FEATURE_MAILING: false"
+            kubectl patch quayregistry reconcile -n $NAMESPACE --type=merge \
+              -p '{"spec":{"configBundleSecret":"reconcile-config"}}'
+            # Wait for reconcile to settle with the new config bundle
+            echo "Waiting for reconcile to settle..."
+            sleep 30
+            # Re-record after settle since the secret name may have changed
+            OLD_SECRET=$(kubectl get secret -n $NAMESPACE -o name \
+              | grep "reconcile-quay-config-secret" | head -1 || true)
+            echo "Config secret after settle: ${OLD_SECRET}"
+          fi
+
+          # Patch the config bundle to trigger config rotation
+          # Add a new key that doesn't exist in the original config
+          CONFIG=$(kubectl get secret reconcile-config -n $NAMESPACE \
+            -o jsonpath='{.data.config\.yaml}' | base64 -d)
+          UPDATED_CONFIG=$(printf '%s\nTAGGING_DISABLED: true\n' "${CONFIG}")
+          kubectl patch secret reconcile-config -n $NAMESPACE --type=merge \
+            -p "{\"data\":{\"config.yaml\":\"$(echo -n "${UPDATED_CONFIG}" | base64 -w0)\"}}"
+          echo "Config bundle patched"
+
+          # Wait for the operator to create a new config secret
+          echo "Waiting for config secret rotation..."
+          for i in $(seq 1 60); do
+            NEW_SECRET=$(kubectl get secret -n $NAMESPACE -o name \
+              | grep "reconcile-quay-config-secret" | head -1 || true)
+            if [ -n "${NEW_SECRET}" ] && [ "${NEW_SECRET}" != "${OLD_SECRET}" ]; then
+              echo "PASS: config secret rotated: ${OLD_SECRET} -> ${NEW_SECRET}"
+              break
+            fi
+            [ "$i" -eq 60 ] && { echo "ERROR: config secret rotation timeout"; exit 1; }
+            sleep 5
+          done
+
+          # Verify only one config secret exists (old one was cleaned up)
+          COUNT=$(kubectl get secret -n $NAMESPACE -o name \
+            | grep -c "reconcile-quay-config-secret" || true)
+          if [ "${COUNT}" -ne 1 ]; then
+            echo "ERROR: expected 1 config secret, found ${COUNT}"
+            kubectl get secret -n $NAMESPACE -o name | grep "reconcile-quay-config-secret" || true
+            exit 1
+          fi
+          echo "PASS: old config secret cleaned up, ${COUNT} config secret(s) remain"
+    - assert:
+        file: 08-assert.yaml


### PR DESCRIPTION
Add four new steps to the reconcile chainsaw test:
- Step 05: re-manage a previously unmanaged component, assert overrides restored
- Step 06: scale mirror to zero via replicas override, assert scaled-down status path
- Step 07: restore mirror replicas to default
- Step 08: patch config bundle and assert config secret rotation and cleanup

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
