### PR TITLE
NO-ISSUE: ci(chainsaw): add global error catch handlers, descriptive step names, and CHAINSAW_EXTRA_ARGS

### DIFF
--- a/test/chainsaw/.chainsaw.yaml
+++ b/test/chainsaw/.chainsaw.yaml
@@ -14,3 +14,26 @@ spec:
     delete: 10m0s
     error: 10m0s
     exec: 10m0s
+  catch:
+  - events: {}
+  - describe:
+      apiVersion: quay.redhat.com/v1
+      kind: QuayRegistry
+  - get:
+      apiVersion: v1
+      kind: Pod
+  - get:
+      apiVersion: apps/v1
+      kind: Deployment
+  - podLogs:
+      selector: quay-component=quay-app
+      tail: 30
+  - podLogs:
+      selector: quay-component=clair-app
+      tail: 30
+  - podLogs:
+      selector: quay-component=quay-app-mirror
+      tail: 20
+  - podLogs:
+      selector: quay-component=quay-database
+      tail: 20

--- a/test/chainsaw/Makefile
+++ b/test/chainsaw/Makefile
@@ -11,17 +11,15 @@ CHAINSAW_VALUES_KIND := test/chainsaw/values-kind.yaml
 
 chainsaw: $(CHAINSAW) ## Download chainsaw locally if necessary.
 $(CHAINSAW): $(LOCALBIN)
+	@mkdir -p $(LOCALBIN)
 	@test -s $(LOCALBIN)/chainsaw && $(LOCALBIN)/chainsaw version 2>/dev/null | grep -q $(CHAINSAW_VERSION) || \
 	{ curl -sL "https://github.com/kyverno/chainsaw/releases/download/$(CHAINSAW_VERSION)/chainsaw_linux_amd64.tar.gz" | tar -xz -C $(LOCALBIN) chainsaw; }
 
-test-e2e: chainsaw ## Run Chainsaw e2e tests (excludes destructive and resource-intensive tests)
-	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/hpa"
+test-e2e: chainsaw ## Run Chainsaw e2e tests (excludes destructive tests)
+	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation" $(CHAINSAW_EXTRA_ARGS)
 
 test-e2e-destructive: chainsaw ## Run destructive Chainsaw e2e tests (ca-rotation, OpenShift only)
-	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --include-test-regex "/ca.rotation"
-
-test-e2e-hpa: chainsaw ## Run HPA e2e tests (resource-intensive, OpenShift only)
-	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --include-test-regex "/hpa"
+	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --include-test-regex "/ca.rotation" $(CHAINSAW_EXTRA_ARGS)
 
 test-e2e-kind: chainsaw ## Run Chainsaw e2e tests (KinD)
 	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_KIND) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/hpa" --assert-timeout 20m $(CHAINSAW_EXTRA_ARGS)

--- a/test/chainsaw/ca_rotation/chainsaw-test.yaml
+++ b/test/chainsaw/ca_rotation/chainsaw-test.yaml
@@ -7,13 +7,13 @@ metadata:
 spec:
   concurrent: false
   steps:
-  - name: step-00
+  - name: create-registry
     try:
     - apply:
         file: 00-create-quay-registry.yaml
     - assert:
         file: 00-assert.yaml
-  - name: step-01
+  - name: rotate-ca
     try:
     - script:
         content: |

--- a/test/chainsaw/hpa/chainsaw-test.yaml
+++ b/test/chainsaw/hpa/chainsaw-test.yaml
@@ -6,25 +6,25 @@ metadata:
   name: hpa
 spec:
   steps:
-  - name: step-00
+  - name: create-registry
     try:
     - apply:
         file: 00-create-quay-registry.yaml
     - assert:
         file: 00-assert.yaml
-  - name: step-01
+  - name: unmanage-hpa
     try:
     - apply:
         file: 01-unmanage-hpa.yaml
     - assert:
         file: 01-assert.yaml
-  - name: step-02
+  - name: bump-hpa-replicas
     try:
     - apply:
         file: 02-bump-hpas.yaml
     - assert:
         file: 02-assert.yaml
-  - name: step-03
+  - name: remanage-hpa
     try:
     - apply:
         file: 03-manage-hpa.yaml

--- a/test/chainsaw/reconcile/chainsaw-test.yaml
+++ b/test/chainsaw/reconcile/chainsaw-test.yaml
@@ -6,7 +6,7 @@ metadata:
   name: reconcile
 spec:
   steps:
-  - name: step-00
+  - name: create-registry
     try:
     - script:
         content: |
@@ -61,19 +61,19 @@ spec:
         file: 00-assert-overrides.yaml
     - assert:
         file: 00-assert-status.yaml
-  - name: step-01
+  - name: unmanage-mirror
     try:
     - apply:
         file: 01-unmanage-mirror.yaml
     - assert:
         file: 01-assert.yaml
-  - name: step-02
+  - name: scale-mirror
     try:
     - apply:
         file: 02-scale-mirror.yaml
     - assert:
         file: 02-assert.yaml
-  - name: step-03
+  - name: delete-quay-app
     try:
     - script:
         content: |
@@ -81,7 +81,7 @@ spec:
           echo "Deleted deployment reconcile-quay-app"
     - assert:
         file: 03-assert.yaml
-  - name: step-04
+  - name: push-pull-image
     try:
     - script:
         shell: /bin/bash
@@ -156,25 +156,25 @@ spec:
           # Verify tag is queryable via the registry API
           PUSH_DIGEST=$(crane digest ${CRANE_FLAGS} "${REGISTRY}/admin/e2e-test:latest")
           echo "PASS: push verified digest=${PUSH_DIGEST}"
-  - name: step-05
+  - name: remanage-mirror
     try:
     - apply:
         file: 05-remanage-mirror.yaml
     - assert:
         file: 05-assert.yaml
-  - name: step-06
+  - name: scale-to-zero
     try:
     - apply:
         file: 06-scale-to-zero.yaml
     - assert:
         file: 06-assert.yaml
-  - name: step-07
+  - name: restore-mirror
     try:
     - apply:
         file: 07-restore-mirror.yaml
     - assert:
         file: 07-assert.yaml
-  - name: step-08
+  - name: rotate-config
     try:
     - script:
         shell: /bin/bash


### PR DESCRIPTION
- Add global error catch handlers to collect events, pod logs, resource
  status, and QuayRegistry describe output on test step failures
- Rename all test steps from generic step-00/step-01 to descriptive
  names (create-registry, unmanage-mirror, rotate-config, etc.)
- Add CHAINSAW_EXTRA_ARGS to all chainsaw make targets
- Include HPA tests in default test-e2e suite

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
