### PR TITLE
 PROJQUAY-10873: fix(mirror): set maxUnavailable to 0 to prevent pod loss during invalid rollout

### DIFF
--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -9,6 +9,9 @@ metadata:
 spec:
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       quay-component: quay-mirror


### PR DESCRIPTION
## Summary

- Sets explicit `maxUnavailable: 0` and `maxSurge: 1` on the mirror deployment's RollingUpdate strategy
- Prevents old mirror pods from being terminated during a rollout when new pods fail SCC admission (e.g., due to an invalid securityContext override adding CHOWN/DAC_OVERRIDE capabilities)
- Fixes the issue where mirror pod count drops from 2 to 1 during an invalid override rollout

## Problem

When a user applies an invalid `securityContext` override to the mirror component, the new ReplicaSet's pods are rejected by the restricted-v2 SCC. Without explicit `maxUnavailable`/`maxSurge` parameters, Kubernetes defaults (25%/25%) could allow one old pod to be killed before the new pod is Ready — dropping the mirror count from 2 to 1.

## Fix

Setting `maxUnavailable: 0` guarantees no old pod is removed until its replacement is Ready. Since pods with invalid securityContext never pass SCC admission (and thus never become Ready), all existing mirror pods are preserved.

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 0
    maxSurge: 1
```

## Test plan

### Unit tests
- [x] `make test` — all 6 test packages pass

### CRC validation (OpenShift 4.21, 24Gi RAM, ODF/NooBaa installed)

1. Deployed quay-operator locally (`SKIP_RESOURCE_REQUESTS=true make run`) against CRC
2. Created a QuayRegistry with clair/clairpostgres unmanaged
3. Confirmed 2 mirror pods created (old ReplicaSet `7749844cbf` with 2 replicas)
4. Verified deployment strategy on cluster shows `maxUnavailable: 0, maxSurge: 1`
5. Applied invalid securityContext override:
   ```bash
   oc patch quayregistry test -n quay --type='merge' \
     -p '{"spec":{"components":[{"kind":"mirror","managed":true,"overrides":{"securityContext":{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"capabilities":{"drop":["ALL"],"add":["NET_BIND_SERVICE","CHOWN","DAC_OVERRIDE"]}}}}]}}'
   ```
6. Observed results:
   - New ReplicaSet `5cfdcf7789` created (DESIRED=1, CURRENT=0) — pods rejected by SCC:
     ```
     unable to validate against any security context constraint:
     provider restricted-v2: .containers[0].capabilities.add: Invalid value: "CHOWN": capability may not be added
     provider restricted-v2: .containers[0].capabilities.add: Invalid value: "DAC_OVERRIDE": capability may not be added
     ```
   - **Old ReplicaSet retained all 2 pods** — no pods were terminated
7. Confirmed stability after 30+ seconds — old RS still at 2/2 pods

| | Before fix (default 25%/25%) | After fix (maxUnavailable: 0) |
|---|---|---|
| Old RS pods after bad override | 1 (one killed) | **2 (all preserved)** |
| New RS pods created | Fails SCC | Fails SCC |
| Pod loss | Yes | **No** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)