### PR TITLE
 PROJQUAY-10873: fix(mirror): prevent pod loss during securityContext override

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -814,7 +814,7 @@ func GetReplicasOverrideForComponent(quay *QuayRegistry, kind ComponentKind) *in
 		}
 
 		if cmp.Overrides.Replicas == nil {
-			return nil
+			return ptr.To[int32](2)
 		}
 
 		return cmp.Overrides.Replicas

--- a/apis/quay/v1/quayregistry_types_test.go
+++ b/apis/quay/v1/quayregistry_types_test.go
@@ -770,3 +770,72 @@ func TestGetSecurityContextOverrideForComponent(t *testing.T) {
 		})
 	}
 }
+
+func TestGetReplicasOverrideForComponent(t *testing.T) {
+	tests := []struct {
+		name     string
+		quay     *QuayRegistry
+		kind     ComponentKind
+		expected *int32
+	}{
+		{
+			name: "ReturnsDefaultWhenNoOverrides",
+			quay: &QuayRegistry{
+				Spec: QuayRegistrySpec{
+					Components: []Component{
+						{Kind: ComponentMirror, Managed: true},
+					},
+				},
+			},
+			kind:     ComponentMirror,
+			expected: ptr.To[int32](2),
+		},
+		{
+			name: "ReturnsDefaultWhenOverridesSetButReplicasNil",
+			quay: &QuayRegistry{
+				Spec: QuayRegistrySpec{
+					Components: []Component{
+						{Kind: ComponentMirror, Managed: true, Overrides: &Override{
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: ptr.To(true),
+							},
+						}},
+					},
+				},
+			},
+			kind:     ComponentMirror,
+			expected: ptr.To[int32](2),
+		},
+		{
+			name: "ReturnsExplicitReplicas",
+			quay: &QuayRegistry{
+				Spec: QuayRegistrySpec{
+					Components: []Component{
+						{Kind: ComponentQuay, Managed: true, Overrides: &Override{Replicas: ptr.To[int32](5)}},
+					},
+				},
+			},
+			kind:     ComponentQuay,
+			expected: ptr.To[int32](5),
+		},
+		{
+			name: "ReturnsNilWhenComponentNotFound",
+			quay: &QuayRegistry{
+				Spec: QuayRegistrySpec{
+					Components: []Component{
+						{Kind: ComponentQuay, Managed: true},
+					},
+				},
+			},
+			kind:     ComponentMirror,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetReplicasOverrideForComponent(tt.quay, tt.kind)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause fix:** GetReplicasOverrideForComponent returned nil when a component had overrides (e.g. securityContext) but no explicit replicas setting. This caused the middleware to omit the replicas field from server-side apply, releasing operator ownership and letting Kubernetes revert desired replicas from 2→1.
- **Fix:** Return the default of 2 replicas consistently, regardless of whether other overrides are present, matching the behavior when Overrides == nil.
- **Defense-in-depth:** Keeps the existing maxUnavailable=0 strategy from the previous commit to prevent pod loss during any rollout where new pods fail admission.

## Test plan

- [x] Added TestGetReplicasOverrideForComponent covering: no overrides (default 2), overrides with securityContext but no replicas (default 2), explicit replicas override, and component not found
- [x] All existing tests pass
- [ ] QE verification: apply securityContext override on mirror component without replicas → mirror pods should remain at 2