### PR TITLE
PROJQUAY-6578: fix(reconciler): defer workloads until managed databases are ready

### DIFF
--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -84,5 +84,7 @@ jobs:
             for pod in $(kubectl get pods -n "$ns" -o name 2>/dev/null); do
               echo "--- $ns/$pod ---"
               kubectl logs -n "$ns" "$pod" --all-containers --tail=50 2>/dev/null || true
+              echo "--- $ns/$pod (previous) ---"
+              kubectl logs -n "$ns" "$pod" --all-containers --previous --tail=50 2>/dev/null || true
             done
           done

--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -153,7 +153,7 @@ spec:
                       - name: RELATED_IMAGE_COMPONENT_QUAY
                         value: quay.io/projectquay/quay:latest
                       - name: RELATED_IMAGE_COMPONENT_CLAIR
-                        value: quay.io/projectquay/clair:nightly
+                        value: quay.io/projectquay/clair:4.9.0
                       - name: RELATED_IMAGE_COMPONENT_BUILDER
                         value: quay.io/projectquay/quay-builder:master
                       - name: RELATED_IMAGE_COMPONENT_BUILDER_QEMU

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -376,6 +376,47 @@ func (r *QuayRegistryReconciler) checkObjectBucketClaimsAvailable(
 	return nil
 }
 
+// checkManagedDatabaseReady checks whether managed database deployments are
+// available. When a database component is unmanaged we cannot verify its
+// readiness so we optimistically mark it as initialized. When managed, the
+// corresponding deployment must have at least one available replica.
+func (r *QuayRegistryReconciler) checkManagedDatabaseReady(
+	ctx context.Context, qctx *quaycontext.QuayRegistryContext, quay *v1.QuayRegistry,
+) {
+	log := r.Log.WithValues("QuayRegistry", quay.GetName())
+
+	checkDeployment := func(component v1.ComponentKind, suffix string) bool {
+		if !v1.ComponentIsManaged(quay.Spec.Components, component) {
+			log.Info("database component unmanaged, marking initialized",
+				"component", component, "deployment", suffix)
+			return true
+		}
+		name := fmt.Sprintf("%s-%s", quay.GetName(), suffix)
+		var dep appsv1.Deployment
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      name,
+			Namespace: quay.GetNamespace(),
+		}, &dep); err != nil {
+			log.Info("database deployment not found, not initialized",
+				"component", component, "deployment", name)
+			return false
+		}
+		ready := dep.Status.AvailableReplicas > 0
+		log.Info("database deployment status",
+			"component", component,
+			"deployment", name,
+			"availableReplicas", dep.Status.AvailableReplicas,
+			"readyReplicas", dep.Status.ReadyReplicas,
+			"replicas", dep.Status.Replicas,
+			"initialized", ready,
+		)
+		return ready
+	}
+
+	qctx.DatabaseInitialized = checkDeployment(v1.ComponentPostgres, "quay-database")
+	qctx.ClairDatabaseInitialized = checkDeployment(v1.ComponentClairPostgres, "clair-postgres")
+}
+
 // checkBuildManagerAvailable verifies if the config bundle contains an entry pointing to the
 // buildman host. If it contains then sets it properly in the provided QuayRegistryContext
 func (r *QuayRegistryReconciler) checkBuildManagerAvailable(

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -651,6 +651,8 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
+	r.checkManagedDatabaseReady(ctx, quayContext, updatedQuay)
+
 	if err := r.checkBuildManagerAvailable(quayContext, cbundle); err != nil {
 		return r.reconcileWithCondition(
 			ctx,
@@ -766,11 +768,20 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// When managed object storage is pending initialization (OBC not yet
-	// bound), defer creating Deployments and Jobs. This prevents the config
-	// secret from being created with incomplete storage values only to be
-	// regenerated (with a different hash) once the OBC is bound, which
-	// would trigger an unnecessary deployment rollout.
-	deferWorkloads := osmanaged && !quayContext.ObjectStorageInitialized
+	// bound) or managed databases are not yet ready, defer creating
+	// dependent Deployments and Jobs. Infrastructure deployments (postgres,
+	// clair-postgres, redis) are always created so they can start up.
+	deferWorkloads := (osmanaged && !quayContext.ObjectStorageInitialized) ||
+		!quayContext.DatabaseInitialized ||
+		!quayContext.ClairDatabaseInitialized
+
+	log.Info("workload deferral decision",
+		"deferWorkloads", deferWorkloads,
+		"objectStorageInitialized", quayContext.ObjectStorageInitialized,
+		"objectStorageManaged", osmanaged,
+		"databaseInitialized", quayContext.DatabaseInitialized,
+		"clairDatabaseInitialized", quayContext.ClairDatabaseInitialized,
+	)
 
 	for _, obj := range filterDeferredWorkloads(kustomize.EnsureCreationOrder(deploymentObjects), deferWorkloads) {
 		// For metrics and dashboards to work, we need to deploy the Grafana ConfigMap
@@ -851,6 +862,11 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if osmanaged && !quayContext.ObjectStorageInitialized {
 		r.Log.Info("requeuing to populate values for managed component: `objectstorage`")
+		return r.Requeue, nil
+	}
+
+	if !quayContext.DatabaseInitialized || !quayContext.ClairDatabaseInitialized {
+		r.Log.Info("requeuing to wait for managed database(s) to become ready")
 		return r.Requeue, nil
 	}
 
@@ -1366,9 +1382,19 @@ func (r *QuayRegistryReconciler) finalizeQuay(ctx context.Context, quay *v1.Quay
 	return nil
 }
 
-// filterDeferredWorkloads removes Deployments and Jobs from the given
-// slice when deferWorkloads is true. When false, the slice is returned
-// unchanged.
+// infrastructureComponents lists quay-component label values for
+// infrastructure deployments that must be created before dependent
+// workloads. These are never filtered out during deferral.
+var infrastructureComponents = map[string]bool{
+	"postgres":       true,
+	"clair-postgres": true,
+	"redis":          true,
+}
+
+// filterDeferredWorkloads removes dependent Deployments and Jobs from
+// the given slice when deferWorkloads is true. Infrastructure
+// deployments (postgres, clair-postgres, redis) are always kept.
+// When deferWorkloads is false, the slice is returned unchanged.
 func filterDeferredWorkloads(objects []client.Object, deferWorkloads bool) []client.Object {
 	if !deferWorkloads {
 		return objects
@@ -1377,7 +1403,10 @@ func filterDeferredWorkloads(objects []client.Object, deferWorkloads bool) []cli
 	for _, obj := range objects {
 		kind := obj.GetObjectKind().GroupVersionKind().Kind
 		if kind == "Deployment" || kind == "Job" {
-			continue
+			component := obj.GetLabels()["quay-component"]
+			if !infrastructureComponents[component] {
+				continue
+			}
 		}
 		filtered = append(filtered, obj)
 	}

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -968,42 +968,236 @@ func TestCheckObjectBucketClaimsAvailable_NamespaceScoped(t *testing.T) {
 	}
 }
 
+func TestCheckManagedDatabaseReady(t *testing.T) {
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+
+	for _, tt := range []struct {
+		name                string
+		components          []v1.Component
+		existingDeployments []appsv1.Deployment
+		wantDBInit          bool
+		wantClairDBInit     bool
+	}{
+		{
+			name: "both databases unmanaged",
+			components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: false},
+				{Kind: v1.ComponentClairPostgres, Managed: false},
+			},
+			wantDBInit:      true,
+			wantClairDBInit: true,
+		},
+		{
+			name: "managed postgres not found",
+			components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: true},
+				{Kind: v1.ComponentClairPostgres, Managed: false},
+			},
+			wantDBInit:      false,
+			wantClairDBInit: true,
+		},
+		{
+			name: "managed postgres zero available replicas",
+			components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: true},
+				{Kind: v1.ComponentClairPostgres, Managed: false},
+			},
+			existingDeployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-quay-database",
+						Namespace: "default",
+					},
+					Status: appsv1.DeploymentStatus{AvailableReplicas: 0},
+				},
+			},
+			wantDBInit:      false,
+			wantClairDBInit: true,
+		},
+		{
+			name: "managed postgres available",
+			components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: true},
+				{Kind: v1.ComponentClairPostgres, Managed: false},
+			},
+			existingDeployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-quay-database",
+						Namespace: "default",
+					},
+					Status: appsv1.DeploymentStatus{AvailableReplicas: 1},
+				},
+			},
+			wantDBInit:      true,
+			wantClairDBInit: true,
+		},
+		{
+			name: "managed clair-postgres not found",
+			components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: false},
+				{Kind: v1.ComponentClairPostgres, Managed: true},
+			},
+			wantDBInit:      true,
+			wantClairDBInit: false,
+		},
+		{
+			name: "managed clair-postgres available",
+			components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: false},
+				{Kind: v1.ComponentClairPostgres, Managed: true},
+			},
+			existingDeployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-clair-postgres",
+						Namespace: "default",
+					},
+					Status: appsv1.DeploymentStatus{AvailableReplicas: 1},
+				},
+			},
+			wantDBInit:      true,
+			wantClairDBInit: true,
+		},
+		{
+			name: "both managed and available",
+			components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: true},
+				{Kind: v1.ComponentClairPostgres, Managed: true},
+			},
+			existingDeployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-quay-database",
+						Namespace: "default",
+					},
+					Status: appsv1.DeploymentStatus{AvailableReplicas: 1},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-clair-postgres",
+						Namespace: "default",
+					},
+					Status: appsv1.DeploymentStatus{AvailableReplicas: 1},
+				},
+			},
+			wantDBInit:      true,
+			wantClairDBInit: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			quayCopy := quay.DeepCopy()
+			quayCopy.Spec.Components = tt.components
+
+			builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			for i := range tt.existingDeployments {
+				builder = builder.WithObjects(&tt.existingDeployments[i])
+			}
+			fakeClient := builder.Build()
+
+			reconciler := &QuayRegistryReconciler{
+				Client: fakeClient,
+				Log:    testLogger,
+			}
+
+			qctx := quaycontext.NewQuayRegistryContext()
+			reconciler.checkManagedDatabaseReady(context.Background(), qctx, quayCopy)
+
+			if qctx.DatabaseInitialized != tt.wantDBInit {
+				t.Errorf("DatabaseInitialized = %v, want %v", qctx.DatabaseInitialized, tt.wantDBInit)
+			}
+			if qctx.ClairDatabaseInitialized != tt.wantClairDBInit {
+				t.Errorf("ClairDatabaseInitialized = %v, want %v", qctx.ClairDatabaseInitialized, tt.wantClairDBInit)
+			}
+		})
+	}
+}
+
 func testObj(kind string) client.Object {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{Kind: kind})
 	return u
 }
 
+func testObjWithLabel(kind, component string) client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Kind: kind})
+	u.SetLabels(map[string]string{"quay-component": component})
+	return u
+}
+
 func TestFilterDeferredWorkloads(t *testing.T) {
+	type obj struct {
+		kind      string
+		component string // quay-component label value
+	}
 	for _, tt := range []struct {
 		name           string
 		deferWorkloads bool
-		inputKinds     []string
+		input          []obj
 		wantKinds      []string
 	}{
 		{
 			name:           "deferWorkloads false passes all objects through",
 			deferWorkloads: false,
-			inputKinds:     []string{"Secret", "Deployment", "Job", "Service"},
-			wantKinds:      []string{"Secret", "Deployment", "Job", "Service"},
+			input: []obj{
+				{"Secret", ""},
+				{"Deployment", "quay-app"},
+				{"Job", "quay-app-upgrade"},
+				{"Service", ""},
+			},
+			wantKinds: []string{"Secret", "Deployment", "Job", "Service"},
 		},
 		{
-			name:           "deferWorkloads true filters Deployments and Jobs",
+			name:           "deferWorkloads true filters dependent workloads",
 			deferWorkloads: true,
-			inputKinds:     []string{"Secret", "Deployment", "Job", "Service", "ConfigMap"},
-			wantKinds:      []string{"Secret", "Service", "ConfigMap"},
+			input: []obj{
+				{"Secret", ""},
+				{"Deployment", "quay-app"},
+				{"Job", "quay-app-upgrade"},
+				{"Service", ""},
+				{"ConfigMap", ""},
+			},
+			wantKinds: []string{"Secret", "Service", "ConfigMap"},
+		},
+		{
+			name:           "deferWorkloads true keeps infrastructure deployments",
+			deferWorkloads: true,
+			input: []obj{
+				{"Secret", ""},
+				{"Deployment", "postgres"},
+				{"Deployment", "clair-postgres"},
+				{"Deployment", "redis"},
+				{"Deployment", "quay-app"},
+				{"Deployment", "clair-app"},
+				{"Deployment", "quay-mirror"},
+				{"Job", "quay-app-upgrade"},
+			},
+			wantKinds: []string{"Secret", "Deployment", "Deployment", "Deployment"},
 		},
 		{
 			name:           "deferWorkloads true with no workloads is a no-op",
 			deferWorkloads: true,
-			inputKinds:     []string{"Secret", "Service"},
-			wantKinds:      []string{"Secret", "Service"},
+			input: []obj{
+				{"Secret", ""},
+				{"Service", ""},
+			},
+			wantKinds: []string{"Secret", "Service"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			objects := make([]client.Object, len(tt.inputKinds))
-			for i, kind := range tt.inputKinds {
-				objects[i] = testObj(kind)
+			objects := make([]client.Object, len(tt.input))
+			for i, o := range tt.input {
+				if o.component != "" {
+					objects[i] = testObjWithLabel(o.kind, o.component)
+				} else {
+					objects[i] = testObj(o.kind)
+				}
 			}
 
 			result := filterDeferredWorkloads(objects, tt.deferWorkloads)

--- a/kustomize/components/clair/clair.deployment.yaml
+++ b/kustomize/components/clair/clair.deployment.yaml
@@ -29,7 +29,7 @@ spec:
                         - clair-app
                 topologyKey: "kubernetes.io/hostname"
       containers:
-        - image: quay.io/projectquay/clair:nightly
+        - image: quay.io/projectquay/clair:4.8.0
           imagePullPolicy: IfNotPresent
           name: clair-app
           env:
@@ -79,7 +79,7 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 8080
-          livelinessProbe:
+          livenessProbe:
             httpGet:
               port: clair-intro
               path: /healthz

--- a/kustomize/components/clairpostgres/postgres.deployment.yaml
+++ b/kustomize/components/clairpostgres/postgres.deployment.yaml
@@ -34,6 +34,13 @@ spec:
           ports:
             - containerPort: 5432
               protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: POSTGRESQL_USER
               valueFrom:

--- a/kustomize/components/postgres/postgres.deployment.yaml
+++ b/kustomize/components/postgres/postgres.deployment.yaml
@@ -37,6 +37,13 @@ spec:
           ports:
             - containerPort: 5432
               protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: POSTGRESQL_USER
               valueFrom:

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -33,16 +33,18 @@ type QuayRegistryContext struct {
 	SecretKey         string
 
 	// Database
+	DatabaseInitialized bool
 	DbUri               string
 	DbRootPw            string
 	NeedsPgUpgrade      bool
 	NeedsClairPgUpgrade bool
 
 	// Clair Database
-	ClairDbUser     string
-	ClairDbPassword string
-	ClairDbName     string
-	ClairDbRootPw   string
+	ClairDatabaseInitialized bool
+	ClairDbUser              string
+	ClairDbPassword          string
+	ClairDbName              string
+	ClairDbRootPw            string
 
 	// Clair integration
 	SecurityScannerV4PSK string

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -493,6 +493,9 @@ func KustomizationFor(
 				GeneratorArgs: types.GeneratorArgs{
 					Name:     string(component.Kind) + "-config-secret",
 					Behavior: "merge",
+					Options: &types.GeneratorOptions{
+						DisableNameSuffixHash: true,
+					},
 					KvPairSources: types.KvPairSources{
 						LiteralSources: sources,
 					},

--- a/test/chainsaw/.chainsaw.yaml
+++ b/test/chainsaw/.chainsaw.yaml
@@ -32,8 +32,27 @@ spec:
       selector: quay-component=clair-app
       tail: 30
   - podLogs:
+      selector: quay-component=clair-postgres
+      tail: 30
+  - podLogs:
       selector: quay-component=quay-app-mirror
       tail: 20
   - podLogs:
       selector: quay-component=quay-database
       tail: 20
+  - script:
+      shell: /bin/bash
+      content: |
+        echo "=== Previous container logs (crash-looping pods) ==="
+        for component in clair-app clair-postgres quay-app quay-database; do
+          for pod in $(kubectl get pods -n $NAMESPACE -l quay-component=$component -o name 2>/dev/null); do
+            echo "--- $pod (previous) ---"
+            kubectl logs -n $NAMESPACE "$pod" --previous --tail=50 2>/dev/null || echo "(no previous logs)"
+          done
+        done
+        echo "=== Operator pod logs (last 200 lines) ==="
+        OPERATOR_NS=${OPERATOR_NS:-openshift-operators}
+        for pod in $(kubectl get pods -n "$OPERATOR_NS" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep quay-operator); do
+          echo "--- $OPERATOR_NS/$pod ---"
+          kubectl logs -n "$OPERATOR_NS" "$pod" --all-containers --tail=200 2>/dev/null || echo "(no operator logs)"
+        done

--- a/test/chainsaw/reconcile/chainsaw-test.yaml
+++ b/test/chainsaw/reconcile/chainsaw-test.yaml
@@ -57,6 +57,59 @@ spec:
           echo "Config bundle created in $NAMESPACE"
     - apply:
         file: 00-create-quay-registry.yaml
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euxo pipefail
+
+          # Verify the database is ready before dependent workloads start.
+          # This catches the race condition from PROJQUAY-6578 where the
+          # migration job started before postgres was available.
+
+          # Wait for the operator to reconcile and create the deployment.
+          echo "Waiting for postgres deployment to be created..."
+          for i in $(seq 1 60); do
+            if kubectl get deployment reconcile-quay-database -n $NAMESPACE &>/dev/null; then
+              echo "Postgres deployment found"
+              break
+            fi
+            [ "$i" -eq 60 ] && { echo "ERROR: postgres deployment not created"; exit 1; }
+            sleep 2
+          done
+
+          echo "Waiting for postgres deployment to have available replicas..."
+          kubectl rollout status deployment/reconcile-quay-database -n $NAMESPACE --timeout=300s
+
+          echo "Checking migration job status..."
+          for i in $(seq 1 60); do
+            JOB_STATUS=$(kubectl get job reconcile-quay-app-upgrade -n $NAMESPACE \
+              -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "0")
+            if [ "${JOB_STATUS}" = "1" ]; then
+              echo "PASS: migration job completed successfully"
+              break
+            fi
+            FAILED=$(kubectl get job reconcile-quay-app-upgrade -n $NAMESPACE \
+              -o jsonpath='{.status.failed}' 2>/dev/null || echo "0")
+            if [ "${FAILED:-0}" -gt "2" ]; then
+              echo "FAIL: migration job has ${FAILED} failures — database may not have been ready"
+              kubectl logs job/reconcile-quay-app-upgrade -n $NAMESPACE --tail=20 || true
+              exit 1
+            fi
+            [ "$i" -eq 60 ] && { echo "ERROR: migration job timeout"; exit 1; }
+            sleep 5
+          done
+
+          # Verify the migration job was created AFTER the postgres deployment
+          PG_CREATED=$(kubectl get deployment reconcile-quay-database -n $NAMESPACE \
+            -o jsonpath='{.metadata.creationTimestamp}')
+          JOB_CREATED=$(kubectl get job reconcile-quay-app-upgrade -n $NAMESPACE \
+            -o jsonpath='{.metadata.creationTimestamp}')
+          echo "Postgres created: ${PG_CREATED}, Job created: ${JOB_CREATED}"
+          if [[ "${JOB_CREATED}" < "${PG_CREATED}" ]]; then
+            echo "FAIL: migration job was created before postgres deployment"
+            exit 1
+          fi
+          echo "PASS: migration job created after postgres deployment"
     - assert:
         file: 00-assert-overrides.yaml
     - assert:


### PR DESCRIPTION
The migration job could start before postgres was available, causing
partial migrations and DuplicateTable errors on retry. Defer dependent
Deployments and Jobs until managed database deployments have available
replicas, while always creating infrastructure deployments (postgres,
clair-postgres, redis).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
