### PR TITLE
PROJQUAY-11120: fix(clair): update updaters config for clair/config v1.4.3

### DIFF
--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -448,8 +448,20 @@ func clairConfigFor(log logr.Logger, qctx *quaycontext.QuayRegistryContext, quay
 			"name": "prometheus",
 		},
 		"updaters": map[string]interface{}{
+			"sets": []string{
+				"alpine",
+				"aws",
+				"clair.cvss",
+				"debian",
+				"oracle",
+				"photon",
+				"rhcc",
+				"rhel-vex",
+				"suse",
+				"ubuntu",
+			},
 			"config": map[string]interface{}{
-				"rhel": map[string]interface{}{
+				"rhel-vex": map[string]interface{}{
 					"ignore_unpatched": true,
 				},
 			},

--- a/pkg/kustomize/secrets_test.go
+++ b/pkg/kustomize/secrets_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/cert"
@@ -516,6 +518,26 @@ func TestEnsureTLSFor(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestClairConfigUpdaters(t *testing.T) {
+	quay := quayRegistry("test")
+	qctx := &quaycontext.QuayRegistryContext{
+		DbUri: "postgresql://user:pass@db:5432/clair",
+	}
+
+	cfgBytes, err := clairConfigFor(logr.Discard(), qctx, quay, "quay.example.com", "dGVzdHBzaw==")
+	assert.NoError(t, err)
+
+	cfg := string(cfgBytes)
+
+	// Must use rhel-vex, not the old rhel name
+	assert.True(t, strings.Contains(cfg, "rhel-vex"), "expected rhel-vex updater in clair config")
+	assert.False(t, strings.Contains(cfg, "  rhel:"), "old rhel updater name should not appear in clair config")
+
+	// Must have explicit sets to avoid enabling all updaters by default (including osv)
+	assert.True(t, strings.Contains(cfg, "sets:"), "expected explicit updater sets in clair config")
+	assert.False(t, strings.Contains(cfg, "osv"), "osv updater should not be in the default sets")
 }
 
 func TestClairMarshal(t *testing.T) {

--- a/test/chainsaw/reconcile/chainsaw-test.yaml
+++ b/test/chainsaw/reconcile/chainsaw-test.yaml
@@ -209,6 +209,73 @@ spec:
           # Verify tag is queryable via the registry API
           PUSH_DIGEST=$(crane digest ${CRANE_FLAGS} "${REGISTRY}/admin/e2e-test:latest")
           echo "PASS: push verified digest=${PUSH_DIGEST}"
+  - name: clair-updaters-healthy
+    try:
+    - script:
+        shell: /bin/bash
+        timeout: 5m0s
+        content: |
+          set -euxo pipefail
+
+          # Skip on OpenShift (same reason as push-pull-image)
+          if kubectl api-resources 2>/dev/null | grep route.openshift.io >/dev/null; then
+            echo "OpenShift detected — skipping Clair updater check"
+            exit 0
+          fi
+
+          # Give Clair time to attempt its first updater run after startup.
+          # The updaters start on a timer after the process launches, so
+          # we wait briefly then check the logs for errors.
+          echo "Waiting for Clair updaters to attempt initial run..."
+          sleep 30
+
+          # Collect clair-app logs
+          LOGS=$(kubectl logs -l quay-component=clair-app -n $NAMESPACE --tail=500 2>&1)
+
+          # Check for the specific errors caused by misconfigured updaters:
+          # - "Invalid Semantic Version" from the osv updater
+          # - unknown/invalid updater set names
+          ERRORS=""
+          if echo "${LOGS}" | grep -qi "invalid semantic version"; then
+            ERRORS="${ERRORS}\n  - Found 'Invalid Semantic Version' error (osv updater misconfiguration)"
+          fi
+          if echo "${LOGS}" | grep -qi "unknown updater"; then
+            ERRORS="${ERRORS}\n  - Found 'unknown updater' error"
+          fi
+          if echo "${LOGS}" | grep -qi "updater.*error\|error.*updater" | grep -vi "context canceled"; then
+            ERRORS="${ERRORS}\n  - Found updater error in logs"
+          fi
+
+          if [ -n "${ERRORS}" ]; then
+            echo "ERROR: Clair updater errors detected:"
+            echo -e "${ERRORS}"
+            echo ""
+            echo "=== Relevant log lines ==="
+            echo "${LOGS}" | grep -i "error\|invalid\|updater" | head -20
+            exit 1
+          fi
+
+          echo "PASS: No updater errors found in Clair logs"
+
+          # Also verify the generated clair config has the correct updater
+          # set names by inspecting the config secret
+          CONFIG_SECRET=$(kubectl get secret -n $NAMESPACE -o name \
+            | grep "quay-config-secret" | head -1)
+          if [ -n "${CONFIG_SECRET}" ]; then
+            CLAIR_CFG=$(kubectl get ${CONFIG_SECRET} -n $NAMESPACE \
+              -o jsonpath='{.data.clair-config\.yaml}' | base64 -d 2>/dev/null || true)
+            if echo "${CLAIR_CFG}" | grep -q "rhel-vex"; then
+              echo "PASS: Clair config uses rhel-vex updater name"
+            elif echo "${CLAIR_CFG}" | grep -q "rhel:"; then
+              echo "ERROR: Clair config still uses old 'rhel' updater name"
+              exit 1
+            fi
+            if echo "${CLAIR_CFG}" | grep -q "sets:"; then
+              echo "PASS: Clair config has explicit updater sets"
+            else
+              echo "WARNING: Clair config does not have explicit updater sets"
+            fi
+          fi
   - name: remanage-mirror
     try:
     - apply:


### PR DESCRIPTION
## Summary
- Rename `rhel` updater to `rhel-vex` in generated Clair config to match clair/config v1.4.3 naming
- Add explicit `sets` list excluding `osv` to prevent all updaters activating by default, which caused "Invalid Semantic Version" errors blocking vulnerability database pulls
- Add `TestClairConfigUpdaters` to validate the generated updater config

## Test plan
- [x] `go test ./pkg/kustomize/...` passes
- [ ] Deploy on cluster and verify Clair can pull vulnerability database without errors
- [ ] Confirm `osv` updater does not activate unless explicitly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)