### PR TITLE
NO-ISSUE: build(redis): switch redis image from docker.io to quay.io/sclorg

### DIFF
--- a/agent_docs/deployment.md
+++ b/agent_docs/deployment.md
@@ -97,6 +97,6 @@ Override component images via environment variables:
 export RELATED_IMAGE_COMPONENT_QUAY=quay.io/projectquay/quay:v3.10.0
 export RELATED_IMAGE_COMPONENT_CLAIR=quay.io/projectquay/clair:v4.7.0
 export RELATED_IMAGE_COMPONENT_POSTGRES=quay.io/sclorg/postgresql-13-c9s:latest
-export RELATED_IMAGE_COMPONENT_REDIS=docker.io/library/redis:7
+export RELATED_IMAGE_COMPONENT_REDIS=quay.io/sclorg/redis-7-c9s:latest
 make run
 ```

--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -167,7 +167,7 @@ spec:
                       - name: RELATED_IMAGE_COMPONENT_CLAIRPOSTGRES_PREVIOUS
                         value: quay.io/sclorg/postgresql-13-c9s:latest
                       - name: RELATED_IMAGE_COMPONENT_REDIS
-                        value: docker.io/library/redis:7.0
+                        value: quay.io/sclorg/redis-7-c9s:latest
                 serviceAccountName: quay-operator
       permissions:
         - rules:

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -117,7 +117,7 @@ digest quay.io/sclorg/postgresql-13-c9s:latest POSTGRES_DIGEST
 digest quay.io/sclorg/postgresql-13-c9s:latest POSTGRES_OLD_DIGEST
 digest quay.io/sclorg/postgresql-15-c9s:latest POSTGRES_CLAIR_DIGEST
 digest quay.io/sclorg/postgresql-13-c9s:latest POSTGRES_CLAIR_OLD_DIGEST
-digest docker.io/library/redis:7.0 REDIS_DIGEST
+digest quay.io/sclorg/redis-7-c9s:latest REDIS_DIGEST
 
 # need exporting so that yq can see them
 export OPERATOR_DIGEST

--- a/kustomize/components/redis/redis.deployment.yaml
+++ b/kustomize/components/redis/redis.deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: quay-redis
       containers:
         - name: redis-master
-          image: docker.io/library/redis:7.0
+          image: quay.io/sclorg/redis-7-c9s:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -59,7 +59,7 @@ func ComponentImageFor(component v1.ComponentKind) (types.Image, error) {
 	defaultImagesFor := map[v1.ComponentKind]string{
 		v1.ComponentQuay:          "quay.io/projectquay/quay",
 		v1.ComponentClair:         "quay.io/projectquay/clair",
-		v1.ComponentRedis:         "docker.io/library/redis",
+		v1.ComponentRedis:         "quay.io/sclorg/redis-7-c9s",
 		v1.ComponentPostgres:      "quay.io/sclorg/postgresql-13-c9s",
 		v1.ComponentClairPostgres: "quay.io/sclorg/postgresql-15-c9s",
 	}

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -96,7 +96,7 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", Digest: "sha256:abc123"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", Digest: "sha256:abc123"},
-				{Name: "docker.io/library/redis", NewName: "redis", Digest: "sha256:abc123"},
+				{Name: "quay.io/sclorg/redis-7-c9s", NewName: "redis", Digest: "sha256:abc123"},
 				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", Digest: "sha256:abc123"},
 			},
 			SecretGenerator: []types.SecretArgs{},
@@ -129,7 +129,7 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", NewTag: "latest"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", NewTag: "alpine"},
-				{Name: "docker.io/library/redis", NewName: "redis", NewTag: "buster"},
+				{Name: "quay.io/sclorg/redis-7-c9s", NewName: "redis", NewTag: "buster"},
 				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", NewTag: "latest"},
 			},
 			SecretGenerator: []types.SecretArgs{},
@@ -161,7 +161,7 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", NewTag: "latest"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", NewTag: "alpine"},
-				{Name: "docker.io/library/redis", NewName: "redis", NewTag: "buster"},
+				{Name: "quay.io/sclorg/redis-7-c9s", NewName: "redis", NewTag: "buster"},
 				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", NewTag: "latest"},
 			},
 			SecretGenerator: []types.SecretArgs{},
@@ -196,7 +196,7 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", NewTag: "latest"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", NewTag: "alpine"},
-				{Name: "docker.io/library/redis", NewName: "redis", NewTag: "buster"},
+				{Name: "quay.io/sclorg/redis-7-c9s", NewName: "redis", NewTag: "buster"},
 				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "postgres", NewTag: "latest"},
 				{Name: "centos/postgresql-10-centos7", NewName: "postgres_previous", NewTag: "latest"},
 			},
@@ -231,7 +231,7 @@ var kustomizationForTests = []struct {
 			Images: []types.Image{
 				{Name: "quay.io/projectquay/quay", NewName: "quay", NewTag: "latest"},
 				{Name: "quay.io/projectquay/clair", NewName: "clair", NewTag: "alpine"},
-				{Name: "docker.io/library/redis", NewName: "redis", NewTag: "buster"},
+				{Name: "quay.io/sclorg/redis-7-c9s", NewName: "redis", NewTag: "buster"},
 				{Name: "quay.io/sclorg/postgresql-15-c9s", NewName: "clairpostgres", NewTag: "latest"},
 				{Name: "quay.io/sclorg/postgresql-13-c9s", NewName: "clairpostgres_previous", NewTag: "latest"},
 			},


### PR DESCRIPTION
Replace docker.io/library/redis:7.0 with quay.io/sclorg/redis-7-c9s:latest to avoid Docker Hub rate limits and align with how postgres images are already sourced from quay.io/sclorg.

Updates deployment manifests, kustomize image override defaults, build scripts, CSV, docs, and tests.

This is for upstream only, we use rhel based images for downstream