### PR TITLE
PROJQUAY-11189: fix(reconciler): recreate succeeded upgrade job during version upgrade

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -1100,6 +1100,10 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(
 		// completed. Jobs are immutable so we normally delete+recreate, but we
 		// must not recreate a Job that is active or has already succeeded —
 		// the migrations are not idempotent and a second run will fail.
+		//
+		// Exception: during an operator upgrade (CurrentVersion != QuayVersionCurrent),
+		// a succeeded Job from the previous version must be deleted and recreated
+		// so the new version's migrations can run.
 		var existingJob batchv1.Job
 		jobKey := types.NamespacedName{
 			Name:      obj.GetName(),
@@ -1107,8 +1111,14 @@ func (r *QuayRegistryReconciler) createOrUpdateObject(
 		}
 		if err := r.Get(ctx, jobKey, &existingJob); err == nil {
 			if existingJob.Status.Succeeded >= 1 {
-				log.Info("immutable resource already completed successfully, skipping recreation")
-				return false, nil
+				if quay.Status.CurrentVersion == v1.QuayVersionCurrent {
+					log.Info("immutable resource already completed successfully, skipping recreation")
+					return false, nil
+				}
+				log.Info("upgrade in progress, deleting old succeeded job for recreation",
+					"currentVersion", quay.Status.CurrentVersion,
+					"targetVersion", v1.QuayVersionCurrent,
+				)
 			}
 			if existingJob.Status.Active >= 1 {
 				log.Info("immutable resource is still running, skipping recreation")

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -52,19 +52,15 @@ func TestCreateOrUpdateObject_Job(t *testing.T) {
 		},
 	}
 
-	quay := v1.QuayRegistry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-registry",
-			Namespace: "default",
-		},
-	}
-
 	for _, tt := range []struct {
 		name              string
 		existing          bool
+		jobStatus         batchv1.JobStatus
+		quayVersion       v1.QuayVersion
 		createInterceptor func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error
 		wantRequeue       bool
 		wantErr           bool
+		wantJobRecreated  bool
 	}{
 		{
 			name:        "job does not exist, create succeeds",
@@ -84,13 +80,50 @@ func TestCreateOrUpdateObject_Job(t *testing.T) {
 			wantRequeue: true,
 			wantErr:     false,
 		},
+		{
+			name:        "succeeded job skipped when versions match",
+			existing:    true,
+			jobStatus:   batchv1.JobStatus{Succeeded: 1},
+			quayVersion: v1.QuayVersionCurrent,
+			wantRequeue: false,
+			wantErr:     false,
+		},
+		{
+			name:             "succeeded job recreated during upgrade",
+			existing:         true,
+			jobStatus:        batchv1.JobStatus{Succeeded: 1},
+			quayVersion:      "old-version",
+			wantRequeue:      false,
+			wantErr:          false,
+			wantJobRecreated: true,
+		},
+		{
+			name:        "active job skipped even during upgrade",
+			existing:    true,
+			jobStatus:   batchv1.JobStatus{Active: 1},
+			quayVersion: "old-version",
+			wantRequeue: false,
+			wantErr:     false,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			quay := v1.QuayRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-registry",
+					Namespace: "default",
+				},
+				Status: v1.QuayRegistryStatus{
+					CurrentVersion: tt.quayVersion,
+				},
+			}
+
 			builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
 			if tt.existing {
 				existingJob := jobObj.DeepCopy()
 				existingJob.SetResourceVersion("1")
-				builder = builder.WithObjects(existingJob)
+				existingJob.Status = tt.jobStatus
+				builder = builder.WithObjects(existingJob).
+					WithStatusSubresource(&batchv1.Job{})
 			}
 			if tt.createInterceptor != nil {
 				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
@@ -119,6 +152,19 @@ func TestCreateOrUpdateObject_Job(t *testing.T) {
 			}
 			if requeue != tt.wantRequeue {
 				t.Errorf("requeue = %v, want %v", requeue, tt.wantRequeue)
+			}
+
+			if tt.wantJobRecreated {
+				var got batchv1.Job
+				err := fakeClient.Get(context.Background(), types.NamespacedName{
+					Name: jobObj.Name, Namespace: jobObj.Namespace,
+				}, &got)
+				if err != nil {
+					t.Fatalf("expected recreated job to exist: %v", err)
+				}
+				if got.Status.Succeeded != 0 {
+					t.Error("recreated job should not have Succeeded status from old job")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
During operator upgrades, createOrUpdateObject unconditionally skipped Jobs with Succeeded >= 1, including upgrade jobs from the previous version. This caused the new version's database migrations to never run, leaving quay pods running against an unmigrated schema.

Now check whether the operator version has changed before skipping a succeeded Job. When CurrentVersion != QuayVersionCurrent, the old job is deleted and recreated with the new version's image.