### PR TITLE
PROJQUAY-11212: feat(route): support annotation and label overrides on managed routes

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -301,6 +301,27 @@ func Process(quay *v1.QuayRegistry, qctx *quaycontext.QuayRegistryContext, obj c
 		return obj, nil
 	}
 
+	if olabels := v1.GetLabelsOverrideForComponent(quay, v1.ComponentRoute); olabels != nil {
+		if rt.Labels == nil {
+			rt.Labels = map[string]string{}
+		}
+		for key, value := range olabels {
+			if v1.ExceptionLabel(key) {
+				continue
+			}
+			rt.Labels[key] = value
+		}
+	}
+
+	if oannot := v1.GetAnnotationsOverrideForComponent(quay, v1.ComponentRoute); oannot != nil {
+		if rt.Annotations == nil {
+			rt.Annotations = map[string]string{}
+		}
+		for key, value := range oannot {
+			rt.Annotations[key] = value
+		}
+	}
+
 	// if we are managing TLS we can simply return the original route as no change is needed.
 	if v1.ComponentIsManaged(quay.Spec.Components, v1.ComponentTLS) {
 		return obj, nil

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -125,6 +125,79 @@ var processTests = []struct {
 		nil,
 	},
 	{
+		"routeAnnotationOverrideTLSManaged",
+		&v1.QuayRegistry{
+			Spec: v1.QuayRegistrySpec{
+				Components: []v1.Component{
+					{Kind: "route", Managed: true, Overrides: &v1.Override{
+						Annotations: map[string]string{
+							"haproxy.router.openshift.io/ip_whitelist": "1.2.3.4",
+						},
+					}},
+					{Kind: "tls", Managed: true},
+				},
+			},
+		},
+		&route.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"quay-component": "quay-app-route"},
+			},
+		},
+		&route.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"quay-component": "quay-app-route"},
+				Annotations: map[string]string{
+					"haproxy.router.openshift.io/ip_whitelist": "1.2.3.4",
+				},
+			},
+		},
+		nil,
+	},
+	{
+		"routeLabelOverrideTLSUnmanaged",
+		&v1.QuayRegistry{
+			Spec: v1.QuayRegistrySpec{
+				Components: []v1.Component{
+					{Kind: "route", Managed: true, Overrides: &v1.Override{
+						Labels: map[string]string{
+							"custom-label": "my-value",
+						},
+						Annotations: map[string]string{
+							"haproxy.router.openshift.io/ip_whitelist": "1.2.3.4",
+						},
+					}},
+					{Kind: "tls", Managed: false},
+				},
+			},
+		},
+		&route.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"quay-component": "quay-app-route"},
+			},
+		},
+		&route.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"quay-component": "quay-app-route",
+					"custom-label":   "my-value",
+				},
+				Annotations: map[string]string{
+					"haproxy.router.openshift.io/ip_whitelist": "1.2.3.4",
+				},
+			},
+			Spec: route.RouteSpec{
+				Port: &route.RoutePort{
+					TargetPort: intstr.Parse("https"),
+				},
+				TLS: &route.TLSConfig{
+					Termination:                   route.TLSTerminationPassthrough,
+					InsecureEdgeTerminationPolicy: route.InsecureEdgeTerminationPolicyRedirect,
+				},
+			},
+		},
+		nil,
+	},
+	{
 		"volumeSizeDefault",
 		&v1.QuayRegistry{
 			Spec: v1.QuayRegistrySpec{

--- a/test/chainsaw/reconcile/00-create-quay-registry.yaml
+++ b/test/chainsaw/reconcile/00-create-quay-registry.yaml
@@ -99,8 +99,7 @@ spec:
     managed: false
   - kind: objectstorage
     managed: ($values.managedObjectStorage)
-  - kind: route
-    managed: ($values.managedRoute)
+  - ($values.routeComponent)
   - kind: monitoring
     managed: ($values.managedMonitoring)
   - kind: tls

--- a/test/chainsaw/reconcile/01-unmanage-mirror.yaml
+++ b/test/chainsaw/reconcile/01-unmanage-mirror.yaml
@@ -79,8 +79,7 @@ spec:
     managed: false
   - kind: objectstorage
     managed: ($values.managedObjectStorage)
-  - kind: route
-    managed: ($values.managedRoute)
+  - ($values.routeComponent)
   - kind: monitoring
     managed: ($values.managedMonitoring)
   - kind: tls

--- a/test/chainsaw/reconcile/05-remanage-mirror.yaml
+++ b/test/chainsaw/reconcile/05-remanage-mirror.yaml
@@ -99,8 +99,7 @@ spec:
     managed: false
   - kind: objectstorage
     managed: ($values.managedObjectStorage)
-  - kind: route
-    managed: ($values.managedRoute)
+  - ($values.routeComponent)
   - kind: monitoring
     managed: ($values.managedMonitoring)
   - kind: tls

--- a/test/chainsaw/reconcile/06-scale-to-zero.yaml
+++ b/test/chainsaw/reconcile/06-scale-to-zero.yaml
@@ -81,8 +81,7 @@ spec:
     managed: false
   - kind: objectstorage
     managed: ($values.managedObjectStorage)
-  - kind: route
-    managed: ($values.managedRoute)
+  - ($values.routeComponent)
   - kind: monitoring
     managed: ($values.managedMonitoring)
   - kind: tls

--- a/test/chainsaw/reconcile/07-restore-mirror.yaml
+++ b/test/chainsaw/reconcile/07-restore-mirror.yaml
@@ -100,8 +100,7 @@ spec:
     managed: false
   - kind: objectstorage
     managed: ($values.managedObjectStorage)
-  - kind: route
-    managed: ($values.managedRoute)
+  - ($values.routeComponent)
   - kind: monitoring
     managed: ($values.managedMonitoring)
   - kind: tls

--- a/test/chainsaw/reconcile/chainsaw-test.yaml
+++ b/test/chainsaw/reconcile/chainsaw-test.yaml
@@ -114,6 +114,44 @@ spec:
         file: 00-assert-overrides.yaml
     - assert:
         file: 00-assert-status.yaml
+  - name: assert-route-overrides
+    try:
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euxo pipefail
+
+          if ! kubectl api-resources 2>/dev/null | grep route.openshift.io >/dev/null; then
+            echo "KinD detected — skipping route override assertion (no routes)"
+            exit 0
+          fi
+
+          echo "Verifying route annotation and label overrides..."
+          ROUTE_JSON=$(kubectl get route reconcile-quay -n $NAMESPACE -o json)
+
+          # Check annotation override
+          A1=$(echo "${ROUTE_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin)['metadata'].get('annotations',{}).get('a1',''))")
+          if [ "${A1}" != "TESTING" ]; then
+            echo "FAIL: expected annotation a1=TESTING, got '${A1}'"
+            exit 1
+          fi
+          echo "PASS: annotation a1=TESTING"
+
+          # Check label override
+          L1=$(echo "${ROUTE_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin)['metadata'].get('labels',{}).get('l1',''))")
+          if [ "${L1}" != "TESTING" ]; then
+            echo "FAIL: expected label l1=TESTING, got '${L1}'"
+            exit 1
+          fi
+          echo "PASS: label l1=TESTING"
+
+          # Verify existing annotations were preserved
+          TIMEOUT=$(echo "${ROUTE_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin)['metadata'].get('annotations',{}).get('haproxy.router.openshift.io/timeout',''))")
+          if [ "${TIMEOUT}" != "30m" ]; then
+            echo "FAIL: expected haproxy timeout annotation preserved, got '${TIMEOUT}'"
+            exit 1
+          fi
+          echo "PASS: existing annotations preserved"
   - name: unmanage-mirror
     try:
     - apply:

--- a/test/chainsaw/values-kind.yaml
+++ b/test/chainsaw/values-kind.yaml
@@ -3,3 +3,6 @@ managedObjectStorage: false
 managedMonitoring: false
 managedTLS: false
 configBundle: reconcile-config
+routeComponent:
+  kind: route
+  managed: false

--- a/test/chainsaw/values-openshift.yaml
+++ b/test/chainsaw/values-openshift.yaml
@@ -3,3 +3,11 @@ managedObjectStorage: true
 managedMonitoring: true
 managedTLS: true
 configBundle: ""
+routeComponent:
+  kind: route
+  managed: true
+  overrides:
+    labels:
+      l1: TESTING
+    annotations:
+      a1: TESTING


### PR DESCRIPTION
Apply user-specified annotations and labels from the route component's
Override to managed OpenShift Route objects. The Override struct and
getter functions already existed but were never wired up for Routes
in the middleware layer.

Closes: https://github.com/quay/quay-operator/issues/310

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
