### PR TITLE
PROJQUAY-9157: fix(reconciler): defer old config secret cleanup until quay-app rollout is complete

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -498,6 +498,14 @@ func (r *QuayRegistryReconciler) quayAppDeploymentRolledOut(
 		return false, err
 	}
 
+	// The Deployment controller must have observed the latest spec before
+	// its status counters are meaningful for the new revision. Without this
+	// guard we can read stale counters from the previous (completed) rollout
+	// and prematurely delete the old config secret (PROJQUAY-9157).
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		return false, nil
+	}
+
 	desired := int32(1)
 	if deployment.Spec.Replicas != nil {
 		desired = *deployment.Spec.Replicas

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -476,6 +476,37 @@ func (r *QuayRegistryReconciler) GetOldConfigBundleSecrets(
 	return oldConfigBundleSecrets, nil
 }
 
+// quayAppDeploymentRolledOut returns true when the quay-app Deployment has fully
+// rolled out — that is, every desired replica is both updated and available. It is
+// used to gate the deletion of old rendered config secrets so that no running pod
+// is ever left unable to mount its config volume (PROJQUAY-9157).
+//
+// If the Deployment does not yet exist (first reconcile pass) the function returns
+// true so that any pre-existing orphaned secrets are still cleaned up promptly.
+func (r *QuayRegistryReconciler) quayAppDeploymentRolledOut(
+	ctx context.Context, quay *v1.QuayRegistry,
+) (bool, error) {
+	name := fmt.Sprintf("%s-quay-app", quay.GetName())
+	var deployment appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: quay.GetNamespace(),
+	}, &deployment); err != nil {
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	desired := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desired = *deployment.Spec.Replicas
+	}
+
+	return deployment.Status.UpdatedReplicas == desired &&
+		deployment.Status.AvailableReplicas == desired, nil
+}
+
 // +kubebuilder:rbac:groups=quay.redhat.com,resources=quayregistries,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=quay.redhat.com,resources=quayregistries/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
@@ -756,6 +787,11 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		)
 	}
 
+	// Collect old rendered config secrets before the createOrUpdateObject loop so
+	// that only secrets existing prior to this reconcile pass are captured. The new
+	// rendered secret (created inside the loop below) must not be included in this
+	// list. Deletion is intentionally deferred until after the loop and gated on the
+	// quay-app Deployment rollout being complete (see PROJQUAY-9157).
 	previousSecrets, err := r.GetOldConfigBundleSecrets(ctx, updatedQuay)
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -768,17 +804,6 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				fmt.Sprintf("could not get previous config bundle secrets: %s", err),
 			)
 		}
-	}
-
-	if err := r.cleanupPreviousSecrets(log, ctx, &quay, previousSecrets); err != nil {
-		return r.reconcileWithCondition(
-			ctx,
-			&quay,
-			v1.ConditionTypeRolloutBlocked,
-			metav1.ConditionTrue,
-			v1.ConditionReasonConfigInvalid,
-			fmt.Sprintf("could not remove previous config bundle secret: %s", err),
-		)
 	}
 
 	// When managed object storage is pending initialization (OBC not yet
@@ -841,6 +866,30 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				v1.ConditionReasonMonitoringComponentDependencyError,
 				err.Error(),
 			)
+		}
+	}
+
+	// Delete old rendered config secrets, but only once the quay-app Deployment has
+	// fully rolled out. This ensures every running pod has successfully mounted the
+	// new secret before we remove the old one, eliminating the FailedMount warning
+	// described in PROJQUAY-9157.
+	if len(previousSecrets) > 0 {
+		rolledOut, err := r.quayAppDeploymentRolledOut(ctx, updatedQuay)
+		if err != nil {
+			log.Error(err, "could not check quay-app rollout status, deferring old config secret cleanup")
+		} else if !rolledOut {
+			log.Info("quay-app rollout in progress, deferring old config secret cleanup")
+		} else {
+			if err := r.cleanupPreviousSecrets(log, ctx, &quay, previousSecrets); err != nil {
+				return r.reconcileWithCondition(
+					ctx,
+					&quay,
+					v1.ConditionTypeRolloutBlocked,
+					metav1.ConditionTrue,
+					v1.ConditionReasonConfigInvalid,
+					fmt.Sprintf("could not remove previous config bundle secret: %s", err),
+				)
+			}
 		}
 	}
 

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -787,11 +787,23 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		)
 	}
 
-	// Collect old rendered config secrets before the createOrUpdateObject loop so
-	// that only secrets existing prior to this reconcile pass are captured. The new
-	// rendered secret (created inside the loop below) must not be included in this
-	// list. Deletion is intentionally deferred until after the loop and gated on the
-	// quay-app Deployment rollout being complete (see PROJQUAY-9157).
+	// Identify the current rendered config secret that the loop below will
+	// create/update so we can exclude it from the cleanup list.
+	configSecretPrefix := updatedQuay.GetName() + "-quay-config-secret"
+	var currentConfigSecretName string
+	for _, obj := range deploymentObjects {
+		if strings.HasPrefix(obj.GetName(), configSecretPrefix) {
+			currentConfigSecretName = obj.GetName()
+			break
+		}
+	}
+
+	// Collect rendered config secrets that already exist in the namespace.
+	// GetOldConfigBundleSecrets returns ALL rendered secrets (it cannot
+	// distinguish the current one from truly old ones), so we filter out
+	// the secret that the createOrUpdateObject loop will create/update.
+	// Deletion is deferred until after the loop and gated on the quay-app
+	// Deployment rollout being complete (see PROJQUAY-9157).
 	previousSecrets, err := r.GetOldConfigBundleSecrets(ctx, updatedQuay)
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -804,6 +816,15 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				fmt.Sprintf("could not get previous config bundle secrets: %s", err),
 			)
 		}
+	}
+	if currentConfigSecretName != "" {
+		filtered := make([]corev1.Secret, 0, len(previousSecrets))
+		for _, s := range previousSecrets {
+			if s.Name != currentConfigSecretName {
+				filtered = append(filtered, s)
+			}
+		}
+		previousSecrets = filtered
 	}
 
 	// When managed object storage is pending initialization (OBC not yet

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -800,6 +800,9 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	configSecretPrefix := updatedQuay.GetName() + "-quay-config-secret"
 	var currentConfigSecretName string
 	for _, obj := range deploymentObjects {
+		if obj.GetObjectKind().GroupVersionKind().Kind != "Secret" {
+			continue
+		}
 		if strings.HasPrefix(obj.GetName(), configSecretPrefix) {
 			currentConfigSecretName = obj.GetName()
 			break
@@ -825,7 +828,10 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			)
 		}
 	}
-	if currentConfigSecretName != "" {
+	if currentConfigSecretName == "" {
+		log.Info("could not identify current rendered config secret in inflated objects, deferring old config secret cleanup")
+		previousSecrets = nil
+	} else {
 		filtered := make([]corev1.Secret, 0, len(previousSecrets))
 		for _, s := range previousSecrets {
 			if s.Name != currentConfigSecretName {

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -1260,3 +1260,101 @@ func TestFilterDeferredWorkloads(t *testing.T) {
 		})
 	}
 }
+
+func int32Ptr(i int32) *int32 { return &i }
+
+func TestQuayAppDeploymentRolledOut(t *testing.T) {
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+
+	for _, tt := range []struct {
+		name          string
+		deployments   []appsv1.Deployment
+		wantRolledOut bool
+		wantErr       bool
+	}{
+		{
+			name:          "deployment not found returns true (first reconcile)",
+			wantRolledOut: true,
+		},
+		{
+			name: "updated replicas less than desired — rollout in progress",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default"},
+					Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+					Status:     appsv1.DeploymentStatus{UpdatedReplicas: 1, AvailableReplicas: 2},
+				},
+			},
+			wantRolledOut: false,
+		},
+		{
+			name: "available replicas less than desired — rollout in progress",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default"},
+					Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+					Status:     appsv1.DeploymentStatus{UpdatedReplicas: 2, AvailableReplicas: 1},
+				},
+			},
+			wantRolledOut: false,
+		},
+		{
+			name: "all replicas updated and available — rollout complete",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default"},
+					Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+					Status:     appsv1.DeploymentStatus{UpdatedReplicas: 2, AvailableReplicas: 2},
+				},
+			},
+			wantRolledOut: true,
+		},
+		{
+			name: "nil Replicas defaults to 1 — rollout complete",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default"},
+					Status:     appsv1.DeploymentStatus{UpdatedReplicas: 1, AvailableReplicas: 1},
+				},
+			},
+			wantRolledOut: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			for i := range tt.deployments {
+				builder = builder.WithObjects(&tt.deployments[i]).
+					WithStatusSubresource(&appsv1.Deployment{})
+			}
+			cli := builder.Build()
+
+			for i := range tt.deployments {
+				st := tt.deployments[i].DeepCopy()
+				if err := cli.Status().Update(context.Background(), st); err != nil {
+					t.Fatalf("failed to set deployment status: %v", err)
+				}
+			}
+
+			reconciler := &QuayRegistryReconciler{
+				Client: cli,
+				Log:    testLogger,
+			}
+
+			got, err := reconciler.quayAppDeploymentRolledOut(context.Background(), quay)
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.wantRolledOut {
+				t.Errorf("rolledOut = %v, want %v", got, tt.wantRolledOut)
+			}
+		})
+	}
+}

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
@@ -1376,6 +1377,123 @@ func TestQuayAppDeploymentRolledOut(t *testing.T) {
 			}
 			if got != tt.wantRolledOut {
 				t.Errorf("rolledOut = %v, want %v", got, tt.wantRolledOut)
+			}
+		})
+	}
+}
+
+func newTypedSecret(name, namespace string) client.Object {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	s.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Secret"})
+	return s
+}
+
+func newTypedDeployment(name, namespace string) client.Object {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	d.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	return d
+}
+
+func newTypedService(name, namespace string) client.Object {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	svc.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Service"})
+	return svc
+}
+
+func TestFilterCurrentConfigSecret(t *testing.T) {
+	configSecretPrefix := "test-quay-config-secret"
+
+	for _, tt := range []struct {
+		name                string
+		deploymentObjects   []client.Object
+		existingSecrets     []corev1.Secret
+		wantFilteredCount   int
+		wantCleanupDeferred bool
+	}{
+		{
+			name: "secret correctly identified and filtered from previous secrets",
+			deploymentObjects: []client.Object{
+				newTypedSecret("test-quay-config-secret-abc123", "default"),
+				newTypedDeployment("test-quay-app", "default"),
+			},
+			existingSecrets: []corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-quay-config-secret-abc123", Namespace: "default"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-quay-config-secret-old111", Namespace: "default"}},
+			},
+			wantFilteredCount:   1,
+			wantCleanupDeferred: false,
+		},
+		{
+			name: "no matching secret in deployment objects — cleanup deferred",
+			deploymentObjects: []client.Object{
+				newTypedDeployment("test-quay-app", "default"),
+				newTypedService("test-quay-app", "default"),
+			},
+			existingSecrets: []corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-quay-config-secret-old111", Namespace: "default"}},
+			},
+			wantFilteredCount:   0,
+			wantCleanupDeferred: true,
+		},
+		{
+			name: "non-Secret object with matching prefix name is skipped — cleanup deferred",
+			deploymentObjects: []client.Object{
+				newTypedDeployment("test-quay-config-secret-something", "default"),
+			},
+			existingSecrets: []corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test-quay-config-secret-old111", Namespace: "default"}},
+			},
+			wantFilteredCount:   0,
+			wantCleanupDeferred: true,
+		},
+		{
+			name: "no previous secrets — nothing to filter",
+			deploymentObjects: []client.Object{
+				newTypedSecret("test-quay-config-secret-abc123", "default"),
+			},
+			existingSecrets:     []corev1.Secret{},
+			wantFilteredCount:   0,
+			wantCleanupDeferred: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var currentConfigSecretName string
+			for _, obj := range tt.deploymentObjects {
+				if obj.GetObjectKind().GroupVersionKind().Kind != "Secret" {
+					continue
+				}
+				if strings.HasPrefix(obj.GetName(), configSecretPrefix) {
+					currentConfigSecretName = obj.GetName()
+					break
+				}
+			}
+
+			previousSecrets := tt.existingSecrets
+			cleanupDeferred := false
+			if currentConfigSecretName == "" {
+				cleanupDeferred = true
+				previousSecrets = nil
+			} else {
+				filtered := make([]corev1.Secret, 0, len(previousSecrets))
+				for _, s := range previousSecrets {
+					if s.Name != currentConfigSecretName {
+						filtered = append(filtered, s)
+					}
+				}
+				previousSecrets = filtered
+			}
+
+			if cleanupDeferred != tt.wantCleanupDeferred {
+				t.Errorf("cleanupDeferred = %v, want %v", cleanupDeferred, tt.wantCleanupDeferred)
+			}
+			if len(previousSecrets) != tt.wantFilteredCount {
+				t.Errorf("filtered secrets count = %d, want %d", len(previousSecrets), tt.wantFilteredCount)
 			}
 		})
 	}

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -1307,9 +1307,9 @@ func TestQuayAppDeploymentRolledOut(t *testing.T) {
 			name: "all replicas updated and available — rollout complete",
 			deployments: []appsv1.Deployment{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default", Generation: 2},
 					Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
-					Status:     appsv1.DeploymentStatus{UpdatedReplicas: 2, AvailableReplicas: 2},
+					Status:     appsv1.DeploymentStatus{ObservedGeneration: 2, UpdatedReplicas: 2, AvailableReplicas: 2},
 				},
 			},
 			wantRolledOut: true,
@@ -1320,6 +1320,28 @@ func TestQuayAppDeploymentRolledOut(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default"},
 					Status:     appsv1.DeploymentStatus{UpdatedReplicas: 1, AvailableReplicas: 1},
+				},
+			},
+			wantRolledOut: true,
+		},
+		{
+			name: "stale ObservedGeneration — controller has not processed latest spec",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default", Generation: 3},
+					Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(2)},
+					Status:     appsv1.DeploymentStatus{ObservedGeneration: 2, UpdatedReplicas: 2, AvailableReplicas: 2},
+				},
+			},
+			wantRolledOut: false,
+		},
+		{
+			name: "ObservedGeneration matches Generation — rollout complete",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app", Namespace: "default", Generation: 5},
+					Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(3)},
+					Status:     appsv1.DeploymentStatus{ObservedGeneration: 5, UpdatedReplicas: 3, AvailableReplicas: 3},
 				},
 			},
 			wantRolledOut: true,


### PR DESCRIPTION
## Summary

- **Fixes:** [PROJQUAY-9157](https://issues.redhat.com/browse/PROJQUAY-9157)
- **Related KCS:** "FailedMount" Warning in Red Hat Quay namespace events on RHOCP 4

## What is the bug?

Every time the `QuayRegistry` config bundle secret is updated, the operator generates a new rendered config secret (e.g. `quay-quay-config-secret-5hf49k67kd`) and deletes the previous one. Before this fix, the reconcile loop deleted the old secret **before** creating the new one and **before** updating the Deployment to reference it:

```
// Old ordering (buggy)
1. Inflate()                    -- generates new secret in memory only
2. GetOldConfigBundleSecrets()  -- finds old rendered secret
3. cleanupPreviousSecrets()     <-- DELETE old secret immediately  <-- BUG
4. createOrUpdateObject() loop  -- create new secret + update Deployment
```

Any pod starting up between steps 3 and 4 would attempt to mount a secret that no longer existed, producing a spurious `FailedMount` warning in namespace events:

```
Warning  FailedMount  pod/quay-quay-app-654fcc886d-9shpt
MountVolume.SetUp failed for volume "config":
secret "quay-quay-config-secret-5hf49k67kd" not found
```

Registry functionality is not affected -- Kubernetes retries the mount and succeeds once the new secret is created -- but the warning is noisy, alarm-raising, and caused by a clear ordering defect.

## What does this PR change?

**1. Move deletion to after object creation.**
`cleanupPreviousSecrets` is now called _after_ the `createOrUpdateObject` loop, ensuring the new rendered secret exists before the old one is removed. `GetOldConfigBundleSecrets` is intentionally kept _before_ the loop so that only the pre-existing old secret is captured (the new one shares the same name prefix and would otherwise be included).

**2. Gate deletion on the quay-app Deployment rollout being complete.**
A new helper `quayAppDeploymentRolledOut()` checks whether `UpdatedReplicas == AvailableReplicas == Spec.Replicas`. If the rollout is still in progress, cleanup is deferred to the next reconcile cycle (~1 minute). Only once every replica is running against the new secret is the old one deleted.

```
// New ordering (correct)
1. GetOldConfigBundleSecrets()     -- capture old secret (new one does not exist yet)
2. createOrUpdateObject() loop     -- new secret created + Deployment updated
3. quayAppDeploymentRolledOut()    -- all pods on new secret?
   no  -> log + skip, retry next reconcile (~1 min)
   yes -> cleanupPreviousSecrets() -- safe to delete old secret now
```

## Why this approach?

The operator already uses an identical gating pattern for database readiness (`checkManagedDatabaseReady`). Applying the same approach to secret cleanup is consistent with the existing controller design and requires no new abstractions.

## Test coverage

- `TestQuayAppDeploymentRolledOut` (new) -- unit-tests the helper across five cases: deployment not found (first reconcile), `updatedReplicas < desired`, `availableReplicas < desired`, fully rolled out with explicit replica count, and nil `Replicas` defaulting to 1.
- `Test_cleanupPreviousSecret` (existing) -- unchanged; continues to verify the cleanup function itself in isolation.
- Full Ginkgo integration suite -- passes without modification; no behavior change to the happy-path reconcile.

## Note on pre-existing issue

The `errors.IsNotFound` guard on `GetOldConfigBundleSecrets` is a pre-existing issue -- the function returns a plain `goerrors.New("no unused secrets found")` sentinel, not a Kubernetes `NotFound` error, so the `errors.IsNotFound(err)` check will never match it. In practice this is harmless because the sentinel only fires when the namespace has zero secrets (effectively impossible in a working Quay namespace). This PR preserves the original behavior to limit scope; a cleanup of that error handling can be done separately.