### PR TITLE
NO-ISSUE: chore(ci): pin crane version

### DIFF
--- a/.github/workflows/e2e-kind.yaml
+++ b/.github/workflows/e2e-kind.yaml
@@ -27,7 +27,7 @@ jobs:
           cache: true
 
       - name: Install crane
-        run: go install github.com/google/go-containerregistry/cmd/crane@latest
+        run: go install github.com/google/go-containerregistry/cmd/crane@v0.21.3
 
       - name: Build operator
         run: go build -o bin/manager main.go


### PR DESCRIPTION
newer version broke CI due to our use of localhost/127.0.0.1

Signed-off-by: Brady Pratt <bpratt@redhat.com>
