### PR TITLE
NOISSUE: fix(e2e): reduce chainsaw parallelism to prevent flaky migrations

### DIFF
--- a/test/chainsaw/.chainsaw.yaml
+++ b/test/chainsaw/.chainsaw.yaml
@@ -5,7 +5,7 @@ metadata:
   creationTimestamp: null
   name: configuration
 spec:
-  parallel: 2
+  parallel: 1
   template: true
   timeouts:
     apply: 10m0s


### PR DESCRIPTION
## Summary
- Reduces chainsaw test parallelism from 2 to 1 to prevent flaky migration job failures in CI
- Two simultaneous Quay deployments (postgres, redis, quay-app, migration jobs) compete for cluster resources, causing migration jobs to hit backoff limits intermittently

## Test plan
- [ ] Verify chainsaw e2e tests pass consistently in CI with `parallel: 1`
- [ ] Confirm total test runtime is acceptable with sequential execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)