### PR TITLE
PROJQUAY-11331: fix(deps): bump config-tool to include struct tag fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/openshift/api v0.0.0-20240729140855-0a58f8c30a8c
 	github.com/quay/clair/config v1.4.3
-	github.com/quay/quay/config-tool v0.0.0-20260414152047-cf0c4b0f613b
+	github.com/quay/quay/config-tool v0.0.0-20260416123904-bcb6cd389034
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/sjson v1.2.5
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quay/clair/config v1.4.3 h1:ZrvqKJrAR2Noyl1XcMl9oOucdMJsdjGzqQqT/rzxb50=
 github.com/quay/clair/config v1.4.3/go.mod h1:MyYm2qGw55+I598zEpwpFFmBq1jp5NLIhBhCigv6tRM=
-github.com/quay/quay/config-tool v0.0.0-20260414152047-cf0c4b0f613b h1:99aTDXVblYTGMHS6F7zdA/cKTPZtQChztymtZX9Kjg0=
-github.com/quay/quay/config-tool v0.0.0-20260414152047-cf0c4b0f613b/go.mod h1:CMpwcJNMMauEg3s2DuErY0YNmYTHD43cl6Kg9foN6Bo=
+github.com/quay/quay/config-tool v0.0.0-20260416123904-bcb6cd389034 h1:MW1Iz4zbGcAIGSUN5YJRkV1KCMxqw3i9MXw9bRFYi5M=
+github.com/quay/quay/config-tool v0.0.0-20260416123904-bcb6cd389034/go.mod h1:CMpwcJNMMauEg3s2DuErY0YNmYTHD43cl6Kg9foN6Bo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=

--- a/vendor/github.com/quay/quay/config-tool/pkg/lib/shared/structs.go
+++ b/vendor/github.com/quay/quay/config-tool/pkg/lib/shared/structs.go
@@ -28,7 +28,7 @@ type DistributedStorageArgs struct {
 	SecretKey   string `default:"" validate:"" json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
 	BucketName  string `default:"" validate:"" json:"bucket_name,omitempty" yaml:"bucket_name,omitempty"`
 
-	Signature string `default:"s3v2" validate: "" json:"signature_version,omitempty" yaml:"signature_version,omitempty"`
+	Signature string `default:"s3v2" validate:"" json:"signature_version,omitempty" yaml:"signature_version,omitempty"`
 	// Args for S3Storage
 	S3Bucket    string `default:"" validate:"" json:"s3_bucket,omitempty" yaml:"s3_bucket,omitempty"`
 	S3AccessKey string `default:"" validate:"" json:"s3_access_key,omitempty" yaml:"s3_access_key,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -388,7 +388,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/quay/clair/config v1.4.3
 ## explicit; go 1.22.0
 github.com/quay/clair/config
-# github.com/quay/quay/config-tool v0.0.0-20260414152047-cf0c4b0f613b
+# github.com/quay/quay/config-tool v0.0.0-20260416123904-bcb6cd389034
 ## explicit; go 1.24.8
 github.com/quay/quay/config-tool/pkg/lib/fieldgroups/database
 github.com/quay/quay/config-tool/pkg/lib/fieldgroups/distributedstorage


### PR DESCRIPTION
## Summary
- Bump `github.com/quay/quay/config-tool` to pick up the fix for the malformed validate struct tag on `DistributedStorageArgs.Signature` (quay/quay#5766)

## Root Cause / Rationale
The previous config-tool version had a malformed Go struct tag (`validate: ""` with a space) that broke JSON/YAML serialization of the `Signature` field. This caused the operator-generated config to use the Go field name `Signature` instead of `signature_version`, crashing `RadosGWStorage.__init__()` in quay-app containers.

## Changes
- go.mod: bump config-tool from `cf0c4b0f613b` to `bcb6cd389034`
- Vendor updated accordingly

## Test Plan
- [ ] Operator e2e tests pass
- [ ] Deploy with managed object storage (NooBaa/ODF) and verify quay-app starts

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11331