### PR TITLE
NO-ISSUE: ci(ci): add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,11 @@ jobs:
           mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
       - name: Tests
-        run: go test -v ./...
+        run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   validate-build:
     name: Validate Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `-coverprofile=coverage.out -covermode=atomic` flags to `go test` in the `tests` CI job so a coverage report is generated on every PR
- Uploads the report to Codecov using `codecov/codecov-action` pinned at the same commit SHA used in quay/quay (`57e3a136b779b570ffcdbf80b3bdc90e7fab3de2` / v6.0.0)
- Requires the `CODECOV_TOKEN` secret to be set in the repo's Actions settings (same pattern as quay/quay)

## Test plan

- [ ] Confirm `CODECOV_TOKEN` secret exists in quay/quay-operator Actions settings
- [ ] Open a test PR and verify the `Tests` job uploads a coverage report to Codecov
- [ ] Check Codecov dashboard for quay/quay-operator to see coverage appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)