### PR TITLE
[redhat-3.16] PROJQUAY-10730: feat(overrides): allow resource overrides for Redis component

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -106,6 +106,7 @@ var supportsResourceOverrides = []ComponentKind{
 	ComponentMirror,
 	ComponentPostgres,
 	ComponentClairPostgres,
+	ComponentRedis,
 }
 
 var supportsReplicasOverride = []ComponentKind{


### PR DESCRIPTION
Backport of #1111 to redhat-3.16.

Cherry-pick of merge commit 3fd3c8d9 with conflict resolution:
- `apis/quay/v1/quayregistry_types.go`: Added `ComponentRedis` to `supportsResourceOverrides` (clean merge)
- `e2e/resource_overrides/` files: Dropped — e2e test directory does not exist on this branch

/cc @jbpratt