### PR TITLE
NO-ISSUE: fix: set channel.default.v1 annotation to bundle's own channel

### DIFF
--- a/hack/prepare-upstream.sh
+++ b/hack/prepare-upstream.sh
@@ -54,7 +54,7 @@ yq eval -i '
 ' ./bundle/manifests/quay-operator.clusterserviceversion.yaml
 
 yq eval -i '
-    .annotations["operators.operatorframework.io.bundle.channel.default.v1"] = strenv(DEFAULT_CHANNEL) |
+    .annotations["operators.operatorframework.io.bundle.channel.default.v1"] = strenv(CHANNEL) |
     .annotations["operators.operatorframework.io.bundle.channels.v1"] = strenv(CHANNEL) |
     .annotations["operators.operatorframework.io.bundle.package.v1"] = "project-quay"
 ' ./bundle/metadata/annotations.yaml


### PR DESCRIPTION
## Summary

- Fix `hack/prepare-upstream.sh` to set the bundle's `channel.default.v1` annotation to `CHANNEL` (the bundle's own channel) instead of `DEFAULT_CHANNEL` (the package-level default channel).
- When releasing a z-stream for an older channel (e.g. `stable-3.9`), the bundle annotations were previously set to `channel.default.v1: stable-3.17` and `channels.v1: stable-3.9`. This caused the community-operators-prod FBC pipeline to fail.
- This aligns `prepare-upstream.sh` with `hack/build.sh`, which already uses `CHANNEL` for both annotations.

## Problem

The [`build_scratch_catalog.py`](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operatorcert/entrypoints/build_scratch_catalog.py) step in the operator-pipelines FBC validation creates a minimal scratch catalog containing only the bundle's declared channel (`channels.v1`). It then reads `channel.default.v1` from the bundle annotations and sets that as the `defaultChannel` in the catalog. When `channel.default.v1` points to a channel that doesn't exist in the scratch catalog (e.g. `stable-3.17` when the bundle only belongs to `stable-3.9`), OPM rejects the catalog with a validation error.

The package-level default channel is managed in the FBC catalog template (`catalogs/*/catalog-template.yaml`), not in individual bundle annotations. Setting `channel.default.v1` to the bundle's own channel is the correct behavior for bundle-level metadata.

Discovered while investigating community-operators-prod failures: [#9576](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9576), [#9572](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9572), [#9570](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9570).

## Test plan

- [ ] Verify that running `prepare-release` with `CHANNEL=stable-3.9` and `DEFAULT_CHANNEL=stable-3.17` now produces `channel.default.v1: stable-3.9` in `bundle/metadata/annotations.yaml`
- [ ] Confirm that the generated bundle passes the FBC scratch catalog validation in operator-pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)