### PR TITLE
PROJQUAY-11556: feat: add storage overrides for Clair ephemeral volume

### DIFF
--- a/agent_docs/components.md
+++ b/agent_docs/components.md
@@ -45,7 +45,7 @@ Overrides customize managed component resources.
 | Override | quay | clair | mirror | postgres | clairpostgres | redis |
 |----------|------|-------|--------|----------|---------------|-------|
 | `volumeSize` | - | Yes | - | Yes | Yes | - |
-| `storageClassName` | - | - | - | Yes | Yes | - |
+| `storageClassName` | - | Yes | - | Yes | Yes | - |
 | `env` | Yes | Yes | Yes | Yes | Yes | Yes |
 | `replicas` | Yes | Yes | Yes | - | - | - |
 | `affinity` | Yes | Yes | Yes | - | - | - |

--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -558,7 +558,7 @@ func ValidateOverrides(quay *QuayRegistry) error {
 		hasresources := component.Overrides.Resources != nil
 		hassecuritycontext := component.Overrides.SecurityContext != nil
 		hasenvvar := len(component.Overrides.Env) > 0
-		hasoverride := hasaffinity || hasvolume || hasenvvar || hasreplicas || hassecuritycontext
+		hasoverride := hasaffinity || hasvolume || hasstorageclass || hasenvvar || hasreplicas || hasresources || hassecuritycontext
 
 		if hasoverride && !ComponentIsManaged(quay.Spec.Components, component.Kind) {
 			return fmt.Errorf("cannot set overrides on unmanaged %s", component.Kind)

--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -89,6 +89,7 @@ var supportsVolumeOverride = []ComponentKind{
 
 var supportsStorageClassOverride = []ComponentKind{
 	ComponentPostgres,
+	ComponentClair,
 	ComponentClairPostgres,
 }
 

--- a/apis/quay/v1/quayregistry_types_test.go
+++ b/apis/quay/v1/quayregistry_types_test.go
@@ -502,6 +502,49 @@ var validateOverridesTests = []struct {
 		errors.New("component redis does not support storageClassName overrides"),
 	},
 	{
+		"ValidStorageClassNameOverrideOnClair",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "postgres", Managed: true},
+					{Kind: "clairpostgres", Managed: true},
+					{Kind: "redis", Managed: true},
+					{Kind: "clair", Managed: true, Overrides: &Override{StorageClassName: ptr.To("fast-storage")}},
+					{Kind: "objectstorage", Managed: true},
+					{Kind: "route", Managed: true},
+					{Kind: "tls", Managed: true},
+					{Kind: "horizontalpodautoscaler", Managed: true},
+					{Kind: "mirror", Managed: true},
+					{Kind: "monitoring", Managed: true},
+				},
+			},
+		},
+		nil,
+	},
+	{
+		"ValidClairVolumeSizeAndStorageClassOverride",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "postgres", Managed: true},
+					{Kind: "clairpostgres", Managed: true},
+					{Kind: "redis", Managed: true},
+					{Kind: "clair", Managed: true, Overrides: &Override{
+						VolumeSize:       resourcePtr("50Gi"),
+						StorageClassName: ptr.To("fast-storage"),
+					}},
+					{Kind: "objectstorage", Managed: true},
+					{Kind: "route", Managed: true},
+					{Kind: "tls", Managed: true},
+					{Kind: "horizontalpodautoscaler", Managed: true},
+					{Kind: "mirror", Managed: true},
+					{Kind: "monitoring", Managed: true},
+				},
+			},
+		},
+		nil,
+	},
+	{
 		"ValidSecurityContextOverrideOnQuay",
 		QuayRegistry{
 			Spec: QuayRegistrySpec{
@@ -769,4 +812,9 @@ func TestGetSecurityContextOverrideForComponent(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func resourcePtr(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -207,9 +207,10 @@ func Process(quay *v1.QuayRegistry, qctx *quaycontext.QuayRegistryContext, obj c
 			}
 		}
 
-		// TODO we must not set annotations in objects where they are not needed. we also
-		// must stop mangling objects in this "middleware" thingy, what is the point of
-		// using kustomize if we keep changing stuff on the fly ?
+		if strings.HasSuffix(dep.Name, "clair-app") {
+			applyClairEphemeralVolumeOverrides(quay, dep)
+		}
+
 		isQuayDB := strings.Contains(dep.GetName(), "quay-database")
 		isClairDB := strings.Contains(dep.GetName(), "clair-postgres")
 		if isQuayDB || isClairDB {
@@ -404,4 +405,31 @@ func FlattenSecret(configBundle *corev1.Secret) (*corev1.Secret, error) {
 
 	flattenedSecret.Data["config.yaml"] = flattenedConfigYAML
 	return flattenedSecret, nil
+}
+
+const clairEphemeralVolumeName = "indexer-layer-storage"
+
+func applyClairEphemeralVolumeOverrides(quay *v1.QuayRegistry, dep *appsv1.Deployment) {
+	volumeSizeOverride := v1.GetVolumeSizeOverrideForComponent(quay, v1.ComponentClair)
+	storageClassOverride := v1.GetStorageClassNameOverrideForComponent(quay, v1.ComponentClair)
+	if volumeSizeOverride == nil && storageClassOverride == nil {
+		return
+	}
+
+	for i := range dep.Spec.Template.Spec.Volumes {
+		vol := &dep.Spec.Template.Spec.Volumes[i]
+		if vol.Name != clairEphemeralVolumeName || vol.Ephemeral == nil || vol.Ephemeral.VolumeClaimTemplate == nil {
+			continue
+		}
+		vct := &vol.Ephemeral.VolumeClaimTemplate.Spec
+		if volumeSizeOverride != nil {
+			vct.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: *volumeSizeOverride,
+			}
+		}
+		if storageClassOverride != nil {
+			vct.StorageClassName = storageClassOverride
+		}
+		return
+	}
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -207,6 +207,10 @@ func Process(quay *v1.QuayRegistry, qctx *quaycontext.QuayRegistryContext, obj c
 			}
 		}
 
+		// TODO we must not set annotations in objects where they are not needed. we also
+		// must stop mangling objects in this "middleware" thingy, what is the point of
+		// using kustomize if we keep changing stuff on the fly ?
+
 		if strings.HasSuffix(dep.Name, "clair-app") {
 			applyClairEphemeralVolumeOverrides(quay, dep)
 		}

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/quay/quay-operator/apis/quay/v1"
@@ -370,8 +371,6 @@ func newClairDeployment() *appsv1.Deployment {
 }
 
 func TestProcessClairEphemeralVolumeOverrides(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
-
 	tests := []struct {
 		name                 string
 		quay                 *v1.QuayRegistry
@@ -410,13 +409,13 @@ func TestProcessClairEphemeralVolumeOverrides(t *testing.T) {
 				Spec: v1.QuayRegistrySpec{
 					Components: []v1.Component{
 						{Kind: v1.ComponentClair, Managed: true, Overrides: &v1.Override{
-							StorageClassName: strPtr("fast-storage"),
+							StorageClassName: ptr.To("fast-storage"),
 						}},
 					},
 				},
 			},
 			expectedStorage:      "20Gi",
-			expectedStorageClass: strPtr("fast-storage"),
+			expectedStorageClass: ptr.To("fast-storage"),
 		},
 		{
 			name: "BothOverrides",
@@ -425,13 +424,13 @@ func TestProcessClairEphemeralVolumeOverrides(t *testing.T) {
 					Components: []v1.Component{
 						{Kind: v1.ComponentClair, Managed: true, Overrides: &v1.Override{
 							VolumeSize:       parseResourceString("100Gi"),
-							StorageClassName: strPtr("premium-storage"),
+							StorageClassName: ptr.To("premium-storage"),
 						}},
 					},
 				},
 			},
 			expectedStorage:      "100Gi",
-			expectedStorageClass: strPtr("premium-storage"),
+			expectedStorageClass: ptr.To("premium-storage"),
 		},
 	}
 
@@ -503,9 +502,6 @@ func TestHPAWithUnmanagedMirrorAndClair(t *testing.T) {
 }
 
 func TestProcessPVCStorageClassNameOverride(t *testing.T) {
-	// Helper for getting string pointers
-	strPtr := func(s string) *string { return &s }
-
 	tests := []struct {
 		name                   string
 		componentKind          v1.ComponentKind
@@ -518,8 +514,8 @@ func TestProcessPVCStorageClassNameOverride(t *testing.T) {
 			name:                 "Postgres with StorageClassName override",
 			componentKind:        v1.ComponentPostgres,
 			componentLabel:       "postgres",
-			storageClassName:     strPtr("my-fast-storage"),
-			expectedStorageClass: strPtr("my-fast-storage"),
+			storageClassName:     ptr.To("my-fast-storage"),
+			expectedStorageClass: ptr.To("my-fast-storage"),
 		},
 		{
 			name:                 "Postgres without StorageClassName override",
@@ -532,30 +528,30 @@ func TestProcessPVCStorageClassNameOverride(t *testing.T) {
 			name:                 "ClairPostgres with StorageClassName override",
 			componentKind:        v1.ComponentClairPostgres,
 			componentLabel:       "clair-postgres",
-			storageClassName:     strPtr("clair-storage"),
-			expectedStorageClass: strPtr("clair-storage"),
+			storageClassName:     ptr.To("clair-storage"),
+			expectedStorageClass: ptr.To("clair-storage"),
 		},
 		{
 			name:                   "Postgres with initial StorageClassName and no override",
 			componentKind:          v1.ComponentPostgres,
 			componentLabel:         "postgres",
 			storageClassName:       nil,
-			initialPVCStorageClass: strPtr("default-storage"),
-			expectedStorageClass:   strPtr("default-storage"),
+			initialPVCStorageClass: ptr.To("default-storage"),
+			expectedStorageClass:   ptr.To("default-storage"),
 		},
 		{
 			name:                   "Postgres with initial StorageClassName and different override",
 			componentKind:          v1.ComponentPostgres,
 			componentLabel:         "postgres",
-			storageClassName:       strPtr("override-storage"),
-			initialPVCStorageClass: strPtr("initial-storage"),
-			expectedStorageClass:   strPtr("override-storage"),
+			storageClassName:       ptr.To("override-storage"),
+			initialPVCStorageClass: ptr.To("initial-storage"),
+			expectedStorageClass:   ptr.To("override-storage"),
 		},
 		{
 			name:                 "Irrelevant component (redis) with override, postgres PVC without",
 			componentKind:        v1.ComponentRedis,       // Override set for Redis
 			componentLabel:       "postgres",              // PVC is for Postgres
-			storageClassName:     strPtr("redis-storage"), // This should not apply to the postgres PVC
+			storageClassName:     ptr.To("redis-storage"), // This should not apply to the postgres PVC
 			expectedStorageClass: nil,                     // Postgres PVC should not get redis-storage
 		},
 	}

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -328,6 +328,147 @@ func parseResourceString(s string) *resource.Quantity {
 	return &resourceSize
 }
 
+func newClairDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-clair-app",
+			Labels:      map[string]string{"quay-component": "clair-app"},
+			Annotations: map[string]string{"quay-component": "clair"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "clair-app"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "indexer-layer-storage",
+							VolumeSource: corev1.VolumeSource{
+								Ephemeral: &corev1.EphemeralVolumeSource{
+									VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+										Spec: corev1.PersistentVolumeClaimSpec{
+											AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+											Resources: corev1.ResourceRequirements{
+												Requests: corev1.ResourceList{
+													corev1.ResourceStorage: resource.MustParse("20Gi"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestProcessClairEphemeralVolumeOverrides(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name                 string
+		quay                 *v1.QuayRegistry
+		expectedStorage      string
+		expectedStorageClass *string
+	}{
+		{
+			name: "NoOverrides",
+			quay: &v1.QuayRegistry{
+				Spec: v1.QuayRegistrySpec{
+					Components: []v1.Component{
+						{Kind: v1.ComponentClair, Managed: true},
+					},
+				},
+			},
+			expectedStorage:      "20Gi",
+			expectedStorageClass: nil,
+		},
+		{
+			name: "VolumeSizeOverride",
+			quay: &v1.QuayRegistry{
+				Spec: v1.QuayRegistrySpec{
+					Components: []v1.Component{
+						{Kind: v1.ComponentClair, Managed: true, Overrides: &v1.Override{
+							VolumeSize: parseResourceString("50Gi"),
+						}},
+					},
+				},
+			},
+			expectedStorage:      "50Gi",
+			expectedStorageClass: nil,
+		},
+		{
+			name: "StorageClassOverride",
+			quay: &v1.QuayRegistry{
+				Spec: v1.QuayRegistrySpec{
+					Components: []v1.Component{
+						{Kind: v1.ComponentClair, Managed: true, Overrides: &v1.Override{
+							StorageClassName: strPtr("fast-storage"),
+						}},
+					},
+				},
+			},
+			expectedStorage:      "20Gi",
+			expectedStorageClass: strPtr("fast-storage"),
+		},
+		{
+			name: "BothOverrides",
+			quay: &v1.QuayRegistry{
+				Spec: v1.QuayRegistrySpec{
+					Components: []v1.Component{
+						{Kind: v1.ComponentClair, Managed: true, Overrides: &v1.Override{
+							VolumeSize:       parseResourceString("100Gi"),
+							StorageClassName: strPtr("premium-storage"),
+						}},
+					},
+				},
+			},
+			expectedStorage:      "100Gi",
+			expectedStorageClass: strPtr("premium-storage"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dep := newClairDeployment()
+			qctx := quaycontext.NewQuayRegistryContext()
+
+			result, err := Process(tt.quay, qctx, dep, false)
+			assert.NoError(t, err)
+
+			processedDep, ok := result.(*appsv1.Deployment)
+			assert.True(t, ok)
+
+			var found bool
+			for _, vol := range processedDep.Spec.Template.Spec.Volumes {
+				if vol.Name != "indexer-layer-storage" {
+					continue
+				}
+				found = true
+				vct := vol.Ephemeral.VolumeClaimTemplate.Spec
+				actualStorage := vct.Resources.Requests[corev1.ResourceStorage]
+				assert.Equal(t, tt.expectedStorage, actualStorage.String(),
+					"volume size mismatch")
+
+				if tt.expectedStorageClass == nil {
+					assert.Nil(t, vct.StorageClassName, "expected no storageClassName")
+				} else {
+					assert.NotNil(t, vct.StorageClassName, "expected storageClassName to be set")
+					assert.Equal(t, *tt.expectedStorageClass, *vct.StorageClassName)
+				}
+			}
+			assert.True(t, found, "indexer-layer-storage volume not found")
+		})
+	}
+}
+
 func TestHPAWithUnmanagedMirrorAndClair(t *testing.T) {
 	quayRegistry := &v1.QuayRegistry{
 		Spec: v1.QuayRegistrySpec{

--- a/test/chainsaw/clair_ephemeral_volume/00-assert-status.yaml
+++ b/test/chainsaw/clair_ephemeral_volume/00-assert-status.yaml
@@ -1,0 +1,34 @@
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: clair-vol
+status:
+  conditions:
+  - type: ComponentHPAReady
+    status: "True"
+  - type: ComponentRouteReady
+    status: "True"
+  - type: ComponentMonitoringReady
+    status: "True"
+  - type: ComponentPostgresReady
+    status: "True"
+  - type: ComponentObjectStorageReady
+    status: "True"
+  - type: ComponentClairReady
+    status: "True"
+  - type: ComponentClairPostgresReady
+    status: "True"
+  - type: ComponentTLSReady
+    status: "True"
+  - type: ComponentRedisReady
+    status: "True"
+  - type: ComponentQuayReady
+    status: "True"
+  - type: ComponentMirrorReady
+    status: "True"
+  - type: Available
+    status: "True"
+  - type: ComponentsCreated
+    status: "True"
+  - type: RolloutBlocked
+    status: "False"

--- a/test/chainsaw/clair_ephemeral_volume/00-create-quay-registry.yaml
+++ b/test/chainsaw/clair_ephemeral_volume/00-create-quay-registry.yaml
@@ -1,0 +1,31 @@
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: clair-vol
+spec:
+  configBundleSecret: ($values.configBundle)
+  components:
+  - kind: quay
+    managed: true
+  - kind: clair
+    managed: true
+    overrides:
+      volumeSize: 50Gi
+  - kind: clairpostgres
+    managed: true
+  - kind: postgres
+    managed: true
+  - kind: redis
+    managed: true
+  - kind: mirror
+    managed: true
+  - kind: horizontalpodautoscaler
+    managed: false
+  - kind: objectstorage
+    managed: ($values.managedObjectStorage)
+  - kind: route
+    managed: ($values.managedRoute)
+  - kind: monitoring
+    managed: ($values.managedMonitoring)
+  - kind: tls
+    managed: ($values.managedTLS)

--- a/test/chainsaw/clair_ephemeral_volume/chainsaw-test.yaml
+++ b/test/chainsaw/clair_ephemeral_volume/chainsaw-test.yaml
@@ -1,0 +1,89 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: clair-ephemeral-volume
+spec:
+  steps:
+  - name: create-registry-with-clair-volume-overrides
+    try:
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euo pipefail
+
+          # Create config bundle for KinD (no-op on OpenShift)
+          if kubectl api-resources 2>/dev/null | grep route.openshift.io >/dev/null; then
+            echo "OpenShift detected, skipping config bundle setup"
+            exit 0
+          fi
+          echo "KinD detected, creating config bundle..."
+          ACCESS_KEY=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.access-key}')
+          SECRET_KEY=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.secret-key}')
+          BUCKET=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.bucket}')
+          ENDPOINT=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.endpoint}')
+          openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
+            -keyout /tmp/ssl-${NAMESPACE}.key -out /tmp/ssl-${NAMESPACE}.cert -days 1 \
+            -subj "/O=Quay E2E" \
+            -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" 2>/dev/null
+          CONFIG=$(cat <<CFGEOF
+          FEATURE_MAILING: false
+          FEATURE_PROXY_STORAGE: true
+          SERVER_HOSTNAME: "127.0.0.1:30443"
+          PREFERRED_URL_SCHEME: https
+          WORKER_COUNT: 1
+          WORKER_COUNT_WEB: 1
+          WORKER_COUNT_SECSCAN: 1
+          WORKER_COUNT_REGISTRY: 1
+          DB_CONNECTION_POOLING: false
+          DISTRIBUTED_STORAGE_CONFIG:
+            default:
+              - RadosGWStorage
+              - access_key: ${ACCESS_KEY}
+                secret_key: ${SECRET_KEY}
+                bucket_name: ${BUCKET}
+                hostname: ${ENDPOINT}
+                port: 3900
+                is_secure: false
+                storage_path: /datastorage/registry
+          DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
+            - default
+          DISTRIBUTED_STORAGE_PREFERENCE:
+            - default
+          CFGEOF
+          )
+          kubectl create secret generic reconcile-config -n $NAMESPACE \
+            --from-literal=config.yaml="${CONFIG}" \
+            --from-file=ssl.cert=/tmp/ssl-${NAMESPACE}.cert \
+            --from-file=ssl.key=/tmp/ssl-${NAMESPACE}.key \
+            --from-file=extra_ca_cert_e2e-ca.crt=/tmp/ssl-${NAMESPACE}.cert
+          echo "Config bundle created in $NAMESPACE"
+    - apply:
+        file: 00-create-quay-registry.yaml
+    - assert:
+        file: 00-assert-status.yaml
+  - name: verify-clair-ephemeral-volume
+    try:
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euxo pipefail
+
+          DEPLOY_NAME="clair-vol-clair-app"
+
+          # Verify the ephemeral volume storage size
+          STORAGE=$(kubectl get deployment "${DEPLOY_NAME}" -n $NAMESPACE \
+            -o jsonpath='{.spec.template.spec.volumes[?(@.name=="indexer-layer-storage")].ephemeral.volumeClaimTemplate.spec.resources.requests.storage}')
+          echo "Clair ephemeral volume size: ${STORAGE}"
+          [ "${STORAGE}" = "50Gi" ] || { echo "FAIL: expected 50Gi, got ${STORAGE}"; exit 1; }
+          echo "PASS: clair ephemeral volume size is 50Gi"
+
+          # Verify the volume is mounted at /var/tmp
+          MOUNT_PATH=$(kubectl get deployment "${DEPLOY_NAME}" -n $NAMESPACE \
+            -o jsonpath='{.spec.template.spec.containers[?(@.name=="clair-app")].volumeMounts[?(@.name=="indexer-layer-storage")].mountPath}')
+          echo "Clair ephemeral volume mount path: ${MOUNT_PATH}"
+          [ "${MOUNT_PATH}" = "/var/tmp" ] || { echo "FAIL: expected /var/tmp, got ${MOUNT_PATH}"; exit 1; }
+          echo "PASS: clair ephemeral volume mounted at /var/tmp"
+
+          echo "=== All clair ephemeral volume overrides verified ==="


### PR DESCRIPTION
## Summary

Allow Quay administrators to configure `storageClassName` and `volumeSize` overrides on the managed Clair component's ephemeral volume at `/var/tmp`. This enables users to provision larger or faster storage for image layer extraction, addressing environments where large images exhaust default storage.

**Changes:**
- Added `ComponentClair` to `supportsStorageClassOverride` in `quayregistry_types.go`
- Added `applyClairEphemeralVolumeOverrides()` in middleware to patch the `indexer-layer-storage` ephemeral VolumeClaimTemplate with user-specified overrides
- Fixed `ValidateOverrides` to include `hasstorageclass` and `hasresources` in unmanaged-component gating
- Updated `agent_docs/components.md` override support table

**Usage:**
```yaml
spec:
  components:
  - kind: clair
    managed: true
    overrides:
      volumeSize: 50Gi
      storageClassName: fast-ssd
```

### Backwards Compatibility

Fully backward compatible. No new CRD fields — uses existing `volumeSize` and `storageClassName` override fields. Default behavior (20Gi, no storageClassName) is preserved when no overrides are specified.

### Related

- [PROJQUAY-11556](https://redhat.atlassian.net/browse/PROJQUAY-11556) — implementation story
- [PROJQUAY-6684](https://redhat.atlassian.net/browse/PROJQUAY-6684) — parent feature request
- Supersedes #1059 (closed, never merged)
- Builds on #1225 (PROJQUAY-11162, merged — added hardcoded 20Gi ephemeral volume)

## Test plan

- [x] Unit tests: validation accepts `storageClassName` on Clair (`ValidStorageClassNameOverrideOnClair`, `ValidClairVolumeSizeAndStorageClassOverride`)
- [x] Unit tests: middleware patches ephemeral VCT (`TestProcessClairEphemeralVolumeOverrides` — 4 sub-tests: no overrides, volume only, storageClass only, both)
- [x] E2E test: Chainsaw test `clair_ephemeral_volume` — creates QuayRegistry with Clair volumeSize override, asserts deployment has correct ephemeral VCT spec
- [x] No regressions in existing test suite (`go test ./...`, `go vet ./...`)

---
Ambient Session: `session-5bedb61e-f960-4702-b631-1744bca1cf3d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)