### PR TITLE
PROJQUAY-11375: kustomize: ensure deterministic config secret generation

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -341,8 +341,17 @@ func KustomizationFor(
 		return nil, errors.New("given QuayRegistry should not be nil")
 	}
 
+	// Sort keys to ensure deterministic ordering. Without this, map iteration
+	// is randomized (by Go design), causing Kustomize to compute a different
+	// content hash on every reconcile, which creates a new config secret name
+	// each time even when the content hasn't changed.
 	configFiles := []string{}
+	configKeys := make([]string, 0, len(quayConfigFiles))
 	for key := range quayConfigFiles {
+		configKeys = append(configKeys, key)
+	}
+	sort.Strings(configKeys)
+	for _, key := range configKeys {
 		configFiles = append(configFiles, filepath.Join("bundle", key))
 	}
 
@@ -377,11 +386,17 @@ func KustomizationFor(
 		ctx.DbRootPw = rootpw
 	}
 
+	// Sort keys to ensure deterministic ordering of CA certs
 	userProvidedCaCerts := []string{}
-	for key, val := range quayConfigFiles {
-		if !strings.HasPrefix(key, "extra_ca_cert_") {
-			continue
+	caCertKeys := make([]string, 0)
+	for key := range quayConfigFiles {
+		if strings.HasPrefix(key, "extra_ca_cert_") {
+			caCertKeys = append(caCertKeys, key)
 		}
+	}
+	sort.Strings(caCertKeys)
+	for _, key := range caCertKeys {
+		val := quayConfigFiles[key]
 		userProvidedCaCerts = append(userProvidedCaCerts, strings.TrimPrefix(key, "extra_ca_cert_")+"="+string(val))
 	}
 

--- a/pkg/kustomize/kustomize_deterministic_test.go
+++ b/pkg/kustomize/kustomize_deterministic_test.go
@@ -1,0 +1,144 @@
+package kustomize
+
+import (
+	"strings"
+	"testing"
+
+	testlogr "github.com/go-logr/logr/testing"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/quay/quay-operator/apis/quay/v1"
+	quaycontext "github.com/quay/quay-operator/pkg/context"
+)
+
+// TestKustomizationDeterministicSecretGeneration verifies that KustomizationFor
+// generates the same secret names across multiple invocations when the input
+// configuration is identical. This addresses the bug where non-deterministic
+// map iteration caused Kustomize to compute different content hashes on each
+// reconcile, resulting in unnecessary secret recreation.
+func TestKustomizationDeterministicSecretGeneration(t *testing.T) {
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-registry",
+			Namespace: "test-ns",
+		},
+		Spec: v1.QuayRegistrySpec{
+			Components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: true},
+				{Kind: v1.ComponentRedis, Managed: true},
+			},
+		},
+	}
+
+	ctx := &quaycontext.QuayRegistryContext{
+		ServerHostname: "quay.example.com",
+		DbUri:          "postgresql://user:pass@host:5432/db",
+	}
+
+	// Config bundle with multiple files to ensure map iteration matters
+	configFiles := map[string][]byte{
+		"config.yaml":       []byte("FEATURE_MAILING: false"),
+		"extra_ca_cert_rh":  []byte("-----BEGIN CERTIFICATE-----\nRH_CERT\n-----END CERTIFICATE-----"),
+		"extra_ca_cert_foo": []byte("-----BEGIN CERTIFICATE-----\nFOO_CERT\n-----END CERTIFICATE-----"),
+		"extra_ca_cert_bar": []byte("-----BEGIN CERTIFICATE-----\nBAR_CERT\n-----END CERTIFICATE-----"),
+		"custom.cert":       []byte("custom cert content"),
+	}
+
+	// Generate kustomization multiple times
+	results := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		kustomization, err := KustomizationFor(testlogr.NewTestLogger(t), ctx, quay, configFiles, overlayDir())
+		assert.NoError(t, err, "KustomizationFor should not error")
+		assert.NotNil(t, kustomization, "Kustomization should not be nil")
+
+		// Extract the config secret generator
+		var configSecretFileSources []string
+		for _, secret := range kustomization.SecretGenerator {
+			if secret.Name == configSecretPrefix {
+				configSecretFileSources = secret.FileSources
+				break
+			}
+		}
+
+		// Convert to string for comparison
+		results[i] = strings.Join(configSecretFileSources, "|")
+	}
+
+	// All results should be identical
+	for i := 1; i < len(results); i++ {
+		assert.Equal(t, results[0], results[i],
+			"File source ordering must be deterministic across multiple invocations (iteration %d)", i)
+	}
+}
+
+// TestKustomizationDeterministicCACerts verifies that CA certificates
+// are processed in a deterministic order regardless of map iteration order.
+func TestKustomizationDeterministicCACerts(t *testing.T) {
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-registry",
+			Namespace: "test-ns",
+		},
+		Spec: v1.QuayRegistrySpec{
+			Components: []v1.Component{
+				{Kind: v1.ComponentPostgres, Managed: true},
+			},
+		},
+	}
+
+	ctx := &quaycontext.QuayRegistryContext{
+		ServerHostname: "quay.example.com",
+		DbUri:          "postgresql://user:pass@host:5432/db",
+	}
+
+	// Config bundle with multiple CA certs
+	configFiles := map[string][]byte{
+		"config.yaml":         []byte("FEATURE_MAILING: false"),
+		"extra_ca_cert_zebra": []byte("ZEBRA_CERT"),
+		"extra_ca_cert_apple": []byte("APPLE_CERT"),
+		"extra_ca_cert_mango": []byte("MANGO_CERT"),
+	}
+
+	// Generate kustomization multiple times
+	results := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		kustomization, err := KustomizationFor(testlogr.NewTestLogger(t), ctx, quay, configFiles, overlayDir())
+		assert.NoError(t, err, "KustomizationFor should not error")
+
+		// Extract the extra-ca-certs secret generator
+		var caCertSources []string
+		for _, secret := range kustomization.SecretGenerator {
+			if secret.Name == "extra-ca-certs" {
+				caCertSources = secret.LiteralSources
+				break
+			}
+		}
+
+		results[i] = strings.Join(caCertSources, "|")
+	}
+
+	// All results should be identical
+	for i := 1; i < len(results); i++ {
+		assert.Equal(t, results[0], results[i],
+			"CA cert ordering must be deterministic across multiple invocations (iteration %d)", i)
+	}
+
+	// Verify alphabetical ordering is maintained
+	kustomization, err := KustomizationFor(testlogr.NewTestLogger(t), ctx, quay, configFiles, overlayDir())
+	assert.NoError(t, err, "KustomizationFor should not error")
+	assert.NotNil(t, kustomization, "Kustomization should not be nil")
+	var caCertSources []string
+	for _, secret := range kustomization.SecretGenerator {
+		if secret.Name == "extra-ca-certs" {
+			caCertSources = secret.LiteralSources
+			break
+		}
+	}
+	assert.GreaterOrEqual(t, len(caCertSources), 3, "expected at least 3 CA cert sources")
+
+	// Should be in alphabetical order: apple, mango, zebra
+	assert.Contains(t, caCertSources[0], "apple", "First CA cert should be apple (alphabetically first)")
+	assert.Contains(t, caCertSources[1], "mango", "Second CA cert should be mango")
+	assert.Contains(t, caCertSources[2], "zebra", "Third CA cert should be zebra (alphabetically last)")
+}

--- a/test/chainsaw/reconcile/chainsaw-test.yaml
+++ b/test/chainsaw/reconcile/chainsaw-test.yaml
@@ -118,6 +118,19 @@ spec:
         file: 00-assert-overrides.yaml
     - assert:
         file: 00-assert-status.yaml
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euo pipefail
+          SECRET_NAME=$(kubectl get secret -n $NAMESPACE -o name \
+            | grep "reconcile-quay-config-secret" | head -1)
+          if [ -z "${SECRET_NAME}" ]; then
+            echo "ERROR: no config secret found"
+            exit 1
+          fi
+          kubectl create configmap e2e-config-secret-tracker -n $NAMESPACE \
+            --from-literal=secret-name="${SECRET_NAME}"
+          echo "Recorded config secret: ${SECRET_NAME}"
   - name: assert-route-overrides
     try:
     - script:
@@ -440,6 +453,37 @@ spec:
           done
     - assert:
         file: 00-assert-status.yaml
+  - name: assert-config-secret-stable
+    try:
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euo pipefail
+
+          INITIAL=$(kubectl get configmap e2e-config-secret-tracker -n $NAMESPACE \
+            -o jsonpath='{.data.secret-name}')
+          CURRENT=$(kubectl get secret -n $NAMESPACE -o name \
+            | grep "reconcile-quay-config-secret" | head -1 || true)
+
+          echo "Initial config secret: ${INITIAL}"
+          echo "Current config secret: ${CURRENT}"
+
+          if [ "${INITIAL}" != "${CURRENT}" ]; then
+            echo "FAIL: config secret name changed without config change (non-deterministic hash)"
+            echo "  This indicates the Kustomize secret generator is producing different"
+            echo "  content hashes across reconcile loops despite identical input."
+            exit 1
+          fi
+          echo "PASS: config secret name stable across reconcile cycles"
+
+          COUNT=$(kubectl get secret -n $NAMESPACE -o name \
+            | grep -c "reconcile-quay-config-secret" || true)
+          if [ "${COUNT}" -ne 1 ]; then
+            echo "FAIL: expected 1 config secret, found ${COUNT}"
+            kubectl get secret -n $NAMESPACE -o name | grep "reconcile-quay-config-secret" || true
+            exit 1
+          fi
+          echo "PASS: exactly 1 config secret exists (no stale copies)"
   - name: rotate-config
     try:
     - script:


### PR DESCRIPTION
The operator was observed to reconcile and recreate the calculated config secret every minute even when there were no changes to the source configuration. This caused unnecessary churn in the cluster.

**Root cause:** 

Go's map iteration order is non-deterministic by design. When building the Kustomize secret generator's FileSources list, the code iterated over the quayConfigFiles map without sorting the keys. This resulted in a different file ordering on each reconcile loop, which caused Kustomize to compute a different content hash (used as the secret name suffix) even though the actual content hadn't changed.

**Fix:** 

Sort map keys before iterating to ensure consistent ordering of:
1. Config bundle files used in the secret generator
2. User-provided CA certificates

This ensures Kustomize generates the same secret name on every reconcile when the content is unchanged, eliminating unnecessary secret recreation.

**Testing:** 

Added unit tests to verify deterministic behavior across multiple invocations with the same input configuration.

**JIRA:** 

https://redhat.atlassian.net/browse/PROJQUAY-11375