### PR TITLE
PROJQUAY-11684: hack: add local development setup with KinD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,29 @@ make fmt && make vet
 make generate && make manifests
 ```
 
+## Local Development (KinD)
+
+For local development without an existing cluster:
+
+```bash
+# Create a local KinD cluster with all dependencies
+make local-dev-up
+
+# Start the operator (in a separate terminal)
+SKIP_RESOURCE_REQUESTS=true make run
+
+# Check environment status
+make local-dev-status
+
+# Tear down when done
+make local-dev-down
+```
+
+Prerequisites: `go`, `podman` (or `docker`), `kind`, `openssl`.
+The setup creates a 3-node KinD cluster with Garage S3 for object
+storage, self-signed TLS, and a ready-to-use QuayRegistry CR.
+After running the operator, Quay is accessible at `https://127.0.0.1:30443`.
+
 ## Project Structure
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Optional auth providers can be added with `LOCAL_DEV_OPTS`:
 LOCAL_DEV_OPTS="--ldap --keycloak" make local-dev-up
 ```
 
-**LDAP users** (password: `password`): admin, user1, testuser, admin\_ldap, testuser\_ldap.
+**LDAP users** (password: `password`): admin, user1, quayadmin, readonly, testuser, admin\_ldap, testuser\_ldap, readonly\_ldap.
 **Keycloak OIDC users** (password: `password`): admin\_oidc, testuser\_oidc, readonly\_oidc.
 Keycloak admin console: `http://127.0.0.1:30080` (admin/admin).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,17 @@ The setup creates a 3-node KinD cluster with Garage S3 for object
 storage, self-signed TLS, and a ready-to-use QuayRegistry CR.
 After running the operator, Quay is accessible at `https://127.0.0.1:30443`.
 
+Optional auth providers can be added with `LOCAL_DEV_OPTS`:
+
+```bash
+# With LDAP (389 Directory Server) and Keycloak (OIDC)
+LOCAL_DEV_OPTS="--ldap --keycloak" make local-dev-up
+```
+
+**LDAP users** (password: `password`): admin, user1, testuser, admin\_ldap, testuser\_ldap.
+**Keycloak OIDC users** (password: `password`): admin\_oidc, testuser\_oidc, readonly\_oidc.
+Keycloak admin console: `http://127.0.0.1:30080` (admin/admin).
+
 ## Project Structure
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ docker-push:
 ##@ Local Development
 
 .PHONY: local-dev-up local-dev-down local-dev-status
-local-dev-up: ## Create a local KinD cluster with Quay dependencies (Garage S3, TLS, config)
-	@./hack/local-dev.sh up
+local-dev-up: ## Create a local KinD cluster with Quay dependencies (Garage S3, TLS, config). Use LOCAL_DEV_OPTS="--ldap --keycloak" for auth providers.
+	@./hack/local-dev.sh up $(LOCAL_DEV_OPTS)
 
 local-dev-down: ## Tear down the local KinD cluster
 	@./hack/local-dev.sh down

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,18 @@ docker-build: test
 docker-push:
 	docker push ${IMG}
 
+##@ Local Development
+
+.PHONY: local-dev-up local-dev-down local-dev-status
+local-dev-up: ## Create a local KinD cluster with Quay dependencies (Garage S3, TLS, config)
+	@./hack/local-dev.sh up
+
+local-dev-down: ## Tear down the local KinD cluster
+	@./hack/local-dev.sh down
+
+local-dev-status: ## Show status of the local development environment
+	@./hack/local-dev.sh status
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to

--- a/hack/keycloak.yaml
+++ b/hack/keycloak.yaml
@@ -1,0 +1,181 @@
+# Keycloak for Quay OIDC authentication testing.
+# Deploys into the quay namespace.
+#
+# Quay reaches it at http://keycloak.quay.svc.cluster.local:8080/realms/quay/
+# Browser access (admin console) at http://127.0.0.1:30080
+#
+# Keycloak admin: admin / admin
+# Test users (password: "password" for all):
+#   admin_oidc, testuser_oidc, readonly_oidc
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm
+data:
+  quay-realm.json: |
+    {
+      "realm": "quay",
+      "enabled": true,
+      "sslRequired": "none",
+      "registrationAllowed": false,
+      "loginWithEmailAllowed": true,
+      "duplicateEmailsAllowed": false,
+      "resetPasswordAllowed": false,
+      "editUsernameAllowed": false,
+      "bruteForceProtected": false,
+      "rememberMe": false,
+      "verifyEmail": false,
+      "loginTheme": "keycloak",
+      "accessTokenLifespan": 300,
+      "clients": [
+        {
+          "clientId": "quay-ui",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": true,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": true,
+          "redirectUris": [
+            "http://localhost:8080/*",
+            "http://localhost:8080/oauth2/someoidc/callback*",
+            "http://localhost:9000/*",
+            "http://localhost:9000/oauth2/someoidc/callback*",
+            "https://127.0.0.1:30443/*",
+            "https://127.0.0.1:30443/oauth2/someoidc/callback*"
+          ],
+          "webOrigins": ["+"],
+          "attributes": {
+            "pkce.code.challenge.method": "S256",
+            "post.logout.redirect.uris": "+"
+          }
+        }
+      ],
+      "users": [
+        {
+          "username": "admin_oidc",
+          "enabled": true,
+          "emailVerified": true,
+          "email": "admin_oidc@example.com",
+          "firstName": "Admin",
+          "lastName": "OIDC",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password",
+              "temporary": false
+            }
+          ]
+        },
+        {
+          "username": "testuser_oidc",
+          "enabled": true,
+          "emailVerified": true,
+          "email": "testuser_oidc@example.com",
+          "firstName": "Test",
+          "lastName": "OIDC",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password",
+              "temporary": false
+            }
+          ]
+        },
+        {
+          "username": "readonly_oidc",
+          "enabled": true,
+          "emailVerified": true,
+          "email": "readonly_oidc@example.com",
+          "firstName": "Readonly",
+          "lastName": "OIDC",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "password",
+              "temporary": false
+            }
+          ]
+        }
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+      - name: keycloak
+        image: quay.io/keycloak/keycloak:26.2
+        args:
+        - start-dev
+        - --import-realm
+        env:
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
+          value: "admin"
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+          value: "admin"
+        - name: KC_HTTP_ENABLED
+          value: "true"
+        - name: KC_HOSTNAME_STRICT
+          value: "false"
+        ports:
+        - name: http
+          containerPort: 8080
+        volumeMounts:
+        - name: realm
+          mountPath: /opt/keycloak/data/import/quay-realm.json
+          subPath: quay-realm.json
+        readinessProbe:
+          httpGet:
+            path: /realms/quay
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+      volumes:
+      - name: realm
+        configMap:
+          name: keycloak-realm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  selector:
+    app: keycloak
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-nodeport
+  labels:
+    app: keycloak
+spec:
+  type: NodePort
+  selector:
+    app: keycloak
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    nodePort: 30080
+    protocol: TCP

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -6,5 +6,8 @@ nodes:
       - containerPort: 30443
         hostPort: 30443
         protocol: TCP
+      - containerPort: 30080
+        hostPort: 30080
+        protocol: TCP
   - role: worker
   - role: worker

--- a/hack/ldap.yaml
+++ b/hack/ldap.yaml
@@ -1,0 +1,280 @@
+# 389 Directory Server for Quay LDAP authentication testing.
+# Deploys into the quay namespace; Quay reaches it at ldap.quay.svc.cluster.local:3389.
+#
+# Test users (password: "password" for all):
+#   admin, user1, quayadmin, readonly, testuser,
+#   admin_ldap, testuser_ldap, readonly_ldap
+#
+# Admin bind DN: cn=Directory Manager / password: admin
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ldap-config
+data:
+  base.ldif: |
+    dn: dc=example,dc=org
+    objectClass: top
+    objectClass: domain
+    dc: example
+
+    dn: ou=users,dc=example,dc=org
+    objectClass: organizationalUnit
+    ou: users
+
+    dn: uid=admin,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    uid: admin
+    sn: Admin
+    givenName: Admin
+    cn: Admin User
+    displayName: Admin User
+    uidNumber: 10000
+    gidNumber: 10000
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/admin
+    mail: admin@example.com
+
+    dn: uid=user1,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    uid: user1
+    sn: One
+    givenName: User
+    cn: User One
+    displayName: User One
+    uidNumber: 10001
+    gidNumber: 10001
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/user1
+    mail: user1@example.com
+
+    dn: uid=quayadmin,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    uid: quayadmin
+    sn: Admin
+    givenName: Quay
+    cn: Quay Admin
+    displayName: Quay Admin
+    uidNumber: 10002
+    gidNumber: 10002
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/quayadmin
+    mail: quayadmin@example.com
+
+    dn: uid=readonly,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    uid: readonly
+    sn: Only
+    givenName: Read
+    cn: Read Only
+    displayName: Read Only
+    uidNumber: 10003
+    gidNumber: 10003
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/readonly
+    mail: readonly@example.com
+
+    dn: uid=testuser,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    uid: testuser
+    sn: User
+    givenName: Test
+    cn: Test User
+    displayName: Test User
+    uidNumber: 10004
+    gidNumber: 10004
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/testuser
+    mail: testuser@example.com
+
+    dn: uid=admin_ldap,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    objectClass: quayUser
+    uid: admin_ldap
+    sn: Ldap
+    givenName: Admin
+    cn: Admin Ldap
+    displayName: Admin Ldap
+    uidNumber: 10005
+    gidNumber: 10005
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/admin_ldap
+    mail: admin_ldap@example.com
+    quayMemberOf: cn=test_ldap_group,ou=groups,dc=example,dc=org
+
+    dn: uid=testuser_ldap,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    objectClass: quayUser
+    uid: testuser_ldap
+    sn: Ldap
+    givenName: Testuser
+    cn: Testuser Ldap
+    displayName: Testuser Ldap
+    uidNumber: 10006
+    gidNumber: 10006
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/testuser_ldap
+    mail: testuser_ldap@example.com
+    quayMemberOf: cn=test_ldap_group,ou=groups,dc=example,dc=org
+
+    dn: uid=readonly_ldap,ou=users,dc=example,dc=org
+    objectClass: inetOrgPerson
+    objectClass: posixAccount
+    objectClass: shadowAccount
+    uid: readonly_ldap
+    sn: Ldap
+    givenName: Readonly
+    cn: Readonly Ldap
+    displayName: Readonly Ldap
+    uidNumber: 10007
+    gidNumber: 10007
+    userPassword: password
+    loginShell: /bin/bash
+    homeDirectory: /home/readonly_ldap
+    mail: readonly_ldap@example.com
+
+    dn: ou=groups,dc=example,dc=org
+    objectClass: organizationalUnit
+    ou: groups
+
+    dn: cn=test_ldap_group,ou=groups,dc=example,dc=org
+    objectClass: groupOfUniqueNames
+    cn: test_ldap_group
+    uniqueMember: uid=testuser_ldap,ou=users,dc=example,dc=org
+    uniqueMember: uid=admin_ldap,ou=users,dc=example,dc=org
+
+  init-389ds.sh: |
+    #!/bin/bash
+    set -e
+    LDAPI_URI="ldapi://%2Fdata%2Frun%2Fslapd-localhost.socket"
+    echo "Waiting for 389 DS to start..."
+    timeout=30
+    while [ $timeout -gt 0 ]; do
+        if ldapsearch -x -H ldap://localhost:3389 -b "" -s base &>/dev/null; then
+            echo "389 DS is ready!"
+            break
+        fi
+        sleep 1
+        timeout=$((timeout - 1))
+    done
+    if [ $timeout -eq 0 ]; then
+        echo "ERROR: 389 DS failed to start"
+        exit 1
+    fi
+    if dsconf localhost backend suffix list | grep -q "dc=example,dc=org"; then
+        echo "Backend already exists, skipping creation"
+    else
+        echo "Creating backend for dc=example,dc=org..."
+        dsconf localhost backend create --suffix "dc=example,dc=org" --be-name userroot
+    fi
+    echo "Adding custom schema for Quay group membership queries..."
+    ldapmodify -H "$LDAPI_URI" -Y EXTERNAL 2>&1 << 'SCHEMA_EOF' | grep -v "^SASL" || true
+    dn: cn=schema
+    changetype: modify
+    add: attributeTypes
+    attributeTypes: ( 1.3.6.1.4.1.99999.1 NAME 'quayMemberOf' DESC 'Quay group membership reference' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+    -
+    add: objectClasses
+    objectClasses: ( 1.3.6.1.4.1.99999.2 NAME 'quayUser' DESC 'Quay user auxiliary class' SUP top AUXILIARY MAY ( quayMemberOf ) )
+    SCHEMA_EOF
+    if ldapsearch -x -H ldap://localhost:3389 -b "dc=example,dc=org" -s base &>/dev/null; then
+        echo "Base DN already exists, skipping LDIF import"
+    else
+        echo "Importing LDIF from /data/ldif/base.ldif..."
+        ldapadd -H "$LDAPI_URI" -Y EXTERNAL -f /data/ldif/base.ldif 2>&1 | grep -v "^SASL" || true
+        echo "LDIF imported successfully!"
+    fi
+    echo "389 DS initialization complete!"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ldap
+  labels:
+    app: ldap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ldap
+  template:
+    metadata:
+      labels:
+        app: ldap
+    spec:
+      containers:
+      - name: dirsrv
+        image: docker.io/389ds/dirsrv:latest
+        env:
+        - name: DS_DM_PASSWORD
+          value: "admin"
+        ports:
+        - name: ldap
+          containerPort: 3389
+        volumeMounts:
+        - name: config
+          mountPath: /data/ldif/base.ldif
+          subPath: base.ldif
+        - name: config
+          mountPath: /data/init-389ds.sh
+          subPath: init-389ds.sh
+        command:
+        - bash
+        - -c
+        - |
+          /usr/lib/dirsrv/dscontainer -r &
+          sleep 10
+          bash /data/init-389ds.sh
+          wait
+        readinessProbe:
+          exec:
+            command:
+            - ldapsearch
+            - -x
+            - -H
+            - ldap://localhost:3389
+            - -b
+            - ""
+            - -s
+            - base
+          initialDelaySeconds: 15
+          periodSeconds: 10
+      volumes:
+      - name: config
+        configMap:
+          name: ldap-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ldap
+  labels:
+    app: ldap
+spec:
+  selector:
+    app: ldap
+  ports:
+  - name: ldap
+    port: 3389
+    targetPort: 3389

--- a/hack/local-dev.sh
+++ b/hack/local-dev.sh
@@ -91,6 +91,7 @@ cmd_up() {
   echo ""
   echo "Installing QuayRegistry CRD..."
   kubectl apply -f "${CRD_PATH}"
+  kubectl wait --for=condition=Established -f "${CRD_PATH}" --timeout=60s
 
   echo ""
   echo "Creating namespace '${NAMESPACE}'..."
@@ -150,10 +151,10 @@ FEATURE_PROXY_STORAGE: true
 DISTRIBUTED_STORAGE_CONFIG:
   default:
     - RadosGWStorage
-    - access_key: ${access_key}
-      secret_key: ${secret_key}
-      bucket_name: ${bucket}
-      hostname: ${endpoint}
+    - access_key: \"${access_key}\"
+      secret_key: \"${secret_key}\"
+      bucket_name: \"${bucket}\"
+      hostname: \"${endpoint}\"
       port: 3900
       is_secure: false
       storage_path: /datastorage/registry
@@ -278,7 +279,7 @@ EOF
   echo ""
   if [ "${enable_ldap}" = true ]; then
     echo "  LDAP is enabled (389 Directory Server)."
-    echo "    Users (password 'password'): admin, user1, testuser, admin_ldap, testuser_ldap"
+    echo "    Users (password 'password'): admin, user1, quayadmin, readonly, testuser, admin_ldap, testuser_ldap, readonly_ldap"
     echo "    Bind DN: cn=Directory Manager / password: admin"
     echo ""
   fi
@@ -316,7 +317,7 @@ cmd_status() {
   fi
 
   echo "=== Cluster ==="
-  kubectl cluster-info --context "kind-${CLUSTER_NAME}" 2>&1 | head -2
+  kubectl cluster-info --context "kind-${CLUSTER_NAME}" 2>&1 | { head -2 || true; }
   echo ""
 
   echo "=== Pods (namespace: ${NAMESPACE}) ==="

--- a/hack/local-dev.sh
+++ b/hack/local-dev.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+# local-dev.sh — Create a local KinD development environment for the Quay Operator.
+#
+# Usage:
+#   ./hack/local-dev.sh up      Create cluster, deploy dependencies, create QuayRegistry
+#   ./hack/local-dev.sh down    Tear down the KinD cluster
+#   ./hack/local-dev.sh status  Show environment status
+#
+# After 'up', start the operator in a separate terminal:
+#   SKIP_RESOURCE_REQUESTS=true make run
+set -euo pipefail
+
+CLUSTER_NAME="quay-dev"
+NAMESPACE="quay"
+REGISTRY_NAME="local"
+KIND_CONFIG="hack/kind-config.yaml"
+CRD_PATH="bundle/manifests/quayregistries.crd.yaml"
+
+# Use podman as kind provider when docker is unavailable.
+if ! command -v docker &>/dev/null && command -v podman &>/dev/null; then
+  export KIND_EXPERIMENTAL_PROVIDER=podman
+fi
+
+check_prerequisites() {
+  local missing=()
+  for cmd in go kind openssl; do
+    command -v "$cmd" &>/dev/null || missing+=("$cmd")
+  done
+  # Accept either kubectl or oc.
+  if ! command -v kubectl &>/dev/null && ! command -v oc &>/dev/null; then
+    missing+=("kubectl (or oc)")
+  fi
+  if ! command -v docker &>/dev/null && ! command -v podman &>/dev/null; then
+    missing+=("podman (or docker)")
+  fi
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: missing prerequisites: ${missing[*]}"
+    exit 1
+  fi
+
+  # Alias oc as kubectl when kubectl is absent.
+  if ! command -v kubectl &>/dev/null; then
+    shim_dir="$(mktemp -d)"
+    ln -s "$(command -v oc)" "${shim_dir}/kubectl"
+    export PATH="${shim_dir}:${PATH}"
+  fi
+}
+
+ensure_podman_running() {
+  if [ "${KIND_EXPERIMENTAL_PROVIDER:-}" != "podman" ]; then
+    return
+  fi
+  if ! podman info &>/dev/null 2>&1; then
+    echo "Starting Podman machine..."
+    podman machine start 2>&1 || true
+  fi
+  local mem
+  mem=$(podman machine inspect 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['Resources']['Memory'])" 2>/dev/null || echo 0)
+  if [ "${mem}" -lt 8192 ]; then
+    echo "WARNING: Podman machine has ${mem} MB RAM. 8192+ MB recommended."
+    echo "  Resize with: podman machine stop && podman machine set --memory 16384 && podman machine start"
+  fi
+}
+
+cluster_exists() {
+  kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"
+}
+
+cmd_up() {
+  check_prerequisites
+  ensure_podman_running
+
+  if cluster_exists; then
+    echo "KinD cluster '${CLUSTER_NAME}' already exists, reusing it."
+  else
+    echo "Creating KinD cluster '${CLUSTER_NAME}'..."
+    kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}"
+  fi
+
+  echo ""
+  echo "Installing QuayRegistry CRD..."
+  kubectl apply -f "${CRD_PATH}"
+
+  echo ""
+  echo "Creating namespace '${NAMESPACE}'..."
+  kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+  echo ""
+  echo "Setting up Garage S3 storage..."
+  bash hack/setup-kind-e2e.sh
+
+  echo ""
+  echo "Reading Garage credentials..."
+  local access_key secret_key bucket endpoint
+  access_key=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.access-key}')
+  secret_key=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.secret-key}')
+  bucket=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.bucket}')
+  endpoint=$(kubectl get configmap garage-creds -n garage-system -o jsonpath='{.data.endpoint}')
+
+  echo "Generating self-signed TLS certificate..."
+  local certdir
+  certdir="$(mktemp -d)"
+  openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
+    -keyout "${certdir}/ssl.key" -out "${certdir}/ssl.cert" -days 30 \
+    -subj "/O=Quay Dev" \
+    -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" 2>/dev/null
+
+  echo "Creating config bundle secret..."
+  kubectl create secret generic "${REGISTRY_NAME}-config-bundle" -n "${NAMESPACE}" \
+    --from-literal=config.yaml="$(cat <<EOF
+FEATURE_MAILING: false
+SERVER_HOSTNAME: "127.0.0.1:30443"
+PREFERRED_URL_SCHEME: https
+WORKER_COUNT: 1
+WORKER_COUNT_WEB: 1
+WORKER_COUNT_SECSCAN: 1
+WORKER_COUNT_REGISTRY: 1
+DB_CONNECTION_POOLING: false
+CREATE_NAMESPACE_ON_PUSH: true
+FEATURE_USER_INITIALIZE: true
+FEATURE_PROXY_STORAGE: true
+DISTRIBUTED_STORAGE_CONFIG:
+  default:
+    - RadosGWStorage
+    - access_key: ${access_key}
+      secret_key: ${secret_key}
+      bucket_name: ${bucket}
+      hostname: ${endpoint}
+      port: 3900
+      is_secure: false
+      storage_path: /datastorage/registry
+DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
+  - default
+DISTRIBUTED_STORAGE_PREFERENCE:
+  - default
+EOF
+)" \
+    --from-file=ssl.cert="${certdir}/ssl.cert" \
+    --from-file=ssl.key="${certdir}/ssl.key" \
+    --from-file=extra_ca_cert_dev-ca.crt="${certdir}/ssl.cert" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  rm -rf "${certdir}"
+
+  echo ""
+  echo "Creating QuayRegistry '${REGISTRY_NAME}'..."
+  cat <<EOF | kubectl apply -f -
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: ${REGISTRY_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  configBundleSecret: ${REGISTRY_NAME}-config-bundle
+  components:
+  - kind: quay
+    managed: true
+  - kind: postgres
+    managed: true
+  - kind: redis
+    managed: true
+  - kind: clair
+    managed: true
+  - kind: clairpostgres
+    managed: true
+  - kind: mirror
+    managed: true
+  - kind: horizontalpodautoscaler
+    managed: false
+  - kind: objectstorage
+    managed: false
+  - kind: route
+    managed: false
+  - kind: monitoring
+    managed: false
+  - kind: tls
+    managed: false
+EOF
+
+  echo ""
+  echo "Creating NodePort service..."
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${REGISTRY_NAME}-quay-nodeport
+  namespace: ${NAMESPACE}
+spec:
+  type: NodePort
+  selector:
+    quay-component: quay-app
+    quay-operator/quayregistry: ${REGISTRY_NAME}
+  ports:
+  - name: https
+    port: 8443
+    targetPort: 8443
+    nodePort: 30443
+    protocol: TCP
+EOF
+
+  echo ""
+  echo "============================================"
+  echo " Local development environment is ready!"
+  echo "============================================"
+  echo ""
+  echo "Next steps:"
+  echo ""
+  echo "  1. Start the operator (in a separate terminal):"
+  echo "     SKIP_RESOURCE_REQUESTS=true make run"
+  echo ""
+  echo "  2. Wait for pods to be ready:"
+  echo "     make local-dev-status"
+  echo ""
+  echo "  3. Initialize the superuser:"
+  echo "     curl -sk https://127.0.0.1:30443/api/v1/user/initialize \\"
+  echo "       -X POST -H 'Content-Type: application/json' \\"
+  echo "       -d '{\"username\":\"admin\",\"password\":\"password123\",\"email\":\"admin@test.com\"}'"
+  echo ""
+  echo "  4. Push a test image:"
+  echo "     crane auth login --insecure 127.0.0.1:30443 -u admin -p password123"
+  echo "     crane copy --insecure --platform linux/amd64 \\"
+  echo "       quay.io/quay/busybox:latest 127.0.0.1:30443/admin/test:latest"
+  echo ""
+  echo "  Registry: https://127.0.0.1:30443 (self-signed cert)"
+  echo ""
+}
+
+cmd_down() {
+  if cluster_exists; then
+    echo "Deleting KinD cluster '${CLUSTER_NAME}'..."
+    kind delete cluster --name "${CLUSTER_NAME}"
+    echo "Cluster deleted."
+  else
+    echo "KinD cluster '${CLUSTER_NAME}' does not exist."
+  fi
+}
+
+cmd_status() {
+  if ! cluster_exists; then
+    echo "KinD cluster '${CLUSTER_NAME}' does not exist. Run 'make local-dev-up' to create it."
+    exit 1
+  fi
+
+  echo "=== Cluster ==="
+  kubectl cluster-info --context "kind-${CLUSTER_NAME}" 2>&1 | head -2
+  echo ""
+
+  echo "=== Pods (namespace: ${NAMESPACE}) ==="
+  kubectl get pods -n "${NAMESPACE}" 2>&1 || echo "(namespace not found)"
+  echo ""
+
+  echo "=== QuayRegistry Status ==="
+  kubectl get quayregistry "${REGISTRY_NAME}" -n "${NAMESPACE}" \
+    -o jsonpath='{range .status.conditions[*]}{.type}: {.status} - {.message}{"\n"}{end}' 2>&1 \
+    || echo "(QuayRegistry not found)"
+  echo ""
+}
+
+case "${1:-}" in
+  up)     cmd_up ;;
+  down)   cmd_down ;;
+  status) cmd_status ;;
+  *)
+    echo "Usage: $0 {up|down|status}"
+    echo ""
+    echo "  up      Create KinD cluster and deploy Quay dependencies"
+    echo "  down    Tear down the KinD cluster"
+    echo "  status  Show environment status"
+    exit 1
+    ;;
+esac

--- a/hack/local-dev.sh
+++ b/hack/local-dev.sh
@@ -2,9 +2,9 @@
 # local-dev.sh — Create a local KinD development environment for the Quay Operator.
 #
 # Usage:
-#   ./hack/local-dev.sh up      Create cluster, deploy dependencies, create QuayRegistry
-#   ./hack/local-dev.sh down    Tear down the KinD cluster
-#   ./hack/local-dev.sh status  Show environment status
+#   ./hack/local-dev.sh up [--ldap] [--keycloak]   Create cluster and deploy dependencies
+#   ./hack/local-dev.sh down                        Tear down the KinD cluster
+#   ./hack/local-dev.sh status                      Show environment status
 #
 # After 'up', start the operator in a separate terminal:
 #   SKIP_RESOURCE_REQUESTS=true make run
@@ -68,6 +68,16 @@ cluster_exists() {
 }
 
 cmd_up() {
+  local enable_ldap=false
+  local enable_keycloak=false
+
+  for arg in "$@"; do
+    case "$arg" in
+      --ldap)     enable_ldap=true ;;
+      --keycloak) enable_keycloak=true ;;
+    esac
+  done
+
   check_prerequisites
   ensure_podman_running
 
@@ -90,6 +100,24 @@ cmd_up() {
   echo "Setting up Garage S3 storage..."
   bash hack/setup-kind-e2e.sh
 
+  # --- Optional: LDAP ---
+  if [ "${enable_ldap}" = true ]; then
+    echo ""
+    echo "Deploying LDAP (389 Directory Server)..."
+    kubectl apply -n "${NAMESPACE}" -f hack/ldap.yaml
+    echo "Waiting for LDAP deployment..."
+    kubectl rollout status deployment/ldap -n "${NAMESPACE}" --timeout=120s
+  fi
+
+  # --- Optional: Keycloak ---
+  if [ "${enable_keycloak}" = true ]; then
+    echo ""
+    echo "Deploying Keycloak..."
+    kubectl apply -n "${NAMESPACE}" -f hack/keycloak.yaml
+    echo "Waiting for Keycloak deployment..."
+    kubectl rollout status deployment/keycloak -n "${NAMESPACE}" --timeout=180s
+  fi
+
   echo ""
   echo "Reading Garage credentials..."
   local access_key secret_key bucket endpoint
@@ -106,11 +134,10 @@ cmd_up() {
     -subj "/O=Quay Dev" \
     -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" 2>/dev/null
 
-  echo "Creating config bundle secret..."
-  kubectl create secret generic "${REGISTRY_NAME}-config-bundle" -n "${NAMESPACE}" \
-    --from-literal=config.yaml="$(cat <<EOF
-FEATURE_MAILING: false
-SERVER_HOSTNAME: "127.0.0.1:30443"
+  # Build config.yaml — base config plus optional auth blocks.
+  local config_yaml
+  config_yaml="FEATURE_MAILING: false
+SERVER_HOSTNAME: \"127.0.0.1:30443\"
 PREFERRED_URL_SCHEME: https
 WORKER_COUNT: 1
 WORKER_COUNT_WEB: 1
@@ -133,9 +160,46 @@ DISTRIBUTED_STORAGE_CONFIG:
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
   - default
 DISTRIBUTED_STORAGE_PREFERENCE:
-  - default
-EOF
-)" \
+  - default"
+
+  if [ "${enable_ldap}" = true ]; then
+    config_yaml="${config_yaml}
+AUTHENTICATION_TYPE: LDAP
+FEATURE_TEAM_SYNCING: true
+LDAP_ADMIN_DN: cn=Directory Manager
+LDAP_ADMIN_PASSWD: admin
+LDAP_ALLOW_INSECURE_FALLBACK: true
+LDAP_BASE_DN:
+  - dc=example
+  - dc=org
+LDAP_EMAIL_ATTR: mail
+LDAP_MEMBEROF_ATTR: quayMemberOf
+LDAP_UID_ATTR: uid
+LDAP_URI: ldap://ldap.${NAMESPACE}.svc.cluster.local:3389
+LDAP_USER_RDN:
+  - ou=users"
+  fi
+
+  if [ "${enable_keycloak}" = true ]; then
+    config_yaml="${config_yaml}
+SOMEOIDC_LOGIN_CONFIG:
+  SERVICE_NAME: Keycloak
+  OIDC_SERVER: http://keycloak.${NAMESPACE}.svc.cluster.local:8080/realms/quay/
+  CLIENT_ID: quay-ui
+  CLIENT_SECRET: unused-public-client
+  LOGIN_SCOPES:
+    - openid
+    - profile
+    - email
+  DEBUGGING: true
+  USE_PKCE: true
+  PKCE_METHOD: S256
+  PUBLIC_CLIENT: true"
+  fi
+
+  echo "Creating config bundle secret..."
+  kubectl create secret generic "${REGISTRY_NAME}-config-bundle" -n "${NAMESPACE}" \
+    --from-literal=config.yaml="${config_yaml}" \
     --from-file=ssl.cert="${certdir}/ssl.cert" \
     --from-file=ssl.key="${certdir}/ssl.key" \
     --from-file=extra_ca_cert_dev-ca.crt="${certdir}/ssl.cert" \
@@ -212,16 +276,25 @@ EOF
   echo "  2. Wait for pods to be ready:"
   echo "     make local-dev-status"
   echo ""
-  echo "  3. Initialize the superuser:"
-  echo "     curl -sk https://127.0.0.1:30443/api/v1/user/initialize \\"
-  echo "       -X POST -H 'Content-Type: application/json' \\"
-  echo "       -d '{\"username\":\"admin\",\"password\":\"password123\",\"email\":\"admin@test.com\"}'"
-  echo ""
-  echo "  4. Push a test image:"
-  echo "     crane auth login --insecure 127.0.0.1:30443 -u admin -p password123"
-  echo "     crane copy --insecure --platform linux/amd64 \\"
-  echo "       quay.io/quay/busybox:latest 127.0.0.1:30443/admin/test:latest"
-  echo ""
+  if [ "${enable_ldap}" = true ]; then
+    echo "  LDAP is enabled (389 Directory Server)."
+    echo "    Users (password 'password'): admin, user1, testuser, admin_ldap, testuser_ldap"
+    echo "    Bind DN: cn=Directory Manager / password: admin"
+    echo ""
+  fi
+  if [ "${enable_keycloak}" = true ]; then
+    echo "  Keycloak OIDC is enabled."
+    echo "    Admin console: http://127.0.0.1:30080 (admin/admin)"
+    echo "    OIDC users (password 'password'): admin_oidc, testuser_oidc, readonly_oidc"
+    echo ""
+  fi
+  if [ "${enable_ldap}" = false ]; then
+    echo "  3. Initialize the superuser:"
+    echo "     curl -sk https://127.0.0.1:30443/api/v1/user/initialize \\"
+    echo "       -X POST -H 'Content-Type: application/json' \\"
+    echo "       -d '{\"username\":\"admin\",\"password\":\"password123\",\"email\":\"admin@test.com\"}'"
+    echo ""
+  fi
   echo "  Registry: https://127.0.0.1:30443 (self-signed cert)"
   echo ""
 }
@@ -257,16 +330,20 @@ cmd_status() {
   echo ""
 }
 
-case "${1:-}" in
-  up)     cmd_up ;;
+# Parse subcommand and pass remaining args.
+subcmd="${1:-}"
+shift || true
+
+case "${subcmd}" in
+  up)     cmd_up "$@" ;;
   down)   cmd_down ;;
   status) cmd_status ;;
   *)
-    echo "Usage: $0 {up|down|status}"
+    echo "Usage: $0 {up|down|status} [options]"
     echo ""
-    echo "  up      Create KinD cluster and deploy Quay dependencies"
-    echo "  down    Tear down the KinD cluster"
-    echo "  status  Show environment status"
+    echo "  up [--ldap] [--keycloak]  Create KinD cluster and deploy Quay dependencies"
+    echo "  down                      Tear down the KinD cluster"
+    echo "  status                    Show environment status"
     exit 1
     ;;
 esac

--- a/hack/setup-kind-e2e.sh
+++ b/hack/setup-kind-e2e.sh
@@ -151,8 +151,8 @@ KEY_OUTPUT=$(garage_exec key create "${KEY_NAME}")
 echo "Key output: ${KEY_OUTPUT}"
 
 # Parse key ID and secret from output
-ACCESS_KEY=$(echo "${KEY_OUTPUT}" | grep -oP 'Key ID: \K\S+' || echo "${KEY_OUTPUT}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('accessKeyId',''))" 2>/dev/null || true)
-SECRET_KEY=$(echo "${KEY_OUTPUT}" | grep -oP 'Secret key: \K\S+' || echo "${KEY_OUTPUT}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('secretAccessKey',''))" 2>/dev/null || true)
+ACCESS_KEY=$(echo "${KEY_OUTPUT}" | grep "Key ID:" | sed 's/.*Key ID: //' | awk '{print $1}')
+SECRET_KEY=$(echo "${KEY_OUTPUT}" | grep "Secret key:" | sed 's/.*Secret key: //' | awk '{print $1}')
 
 if [ -z "${ACCESS_KEY}" ] || [ -z "${SECRET_KEY}" ]; then
   echo "ERROR: Failed to parse access key from output"


### PR DESCRIPTION
## Summary
- Add `make local-dev-up` / `local-dev-down` / `local-dev-status` targets backed by `hack/local-dev.sh` that create a fully working Quay dev environment on a local KinD cluster (Garage S3, self-signed TLS, QuayRegistry CR, NodePort on 30443)
- Add `--ldap` and `--keycloak` flags for optional auth provider deployment:
  - `hack/ldap.yaml` — 389 Directory Server with pre-configured test users and groups
  - `hack/keycloak.yaml` — Keycloak with `quay` realm, OIDC client, and test users
  - Usage: `LOCAL_DEV_OPTS="--ldap --keycloak" make local-dev-up`
- Fix `hack/setup-kind-e2e.sh` to use portable `grep`/`sed`/`awk` instead of `grep -oP` (unavailable on macOS)
- Add port 30080 mapping to `hack/kind-config.yaml` for Keycloak browser access
- Document the local dev workflow in `AGENTS.md`

## Test plan
- [ ] `make local-dev-down` (clean slate)
- [ ] `make local-dev-up` completes without errors (base setup)
- [ ] `LOCAL_DEV_OPTS="--ldap --keycloak" make local-dev-up` deploys auth providers
- [ ] `SKIP_RESOURCE_REQUESTS=true make run` starts the operator
- [ ] `make local-dev-status` shows all components healthy
- [ ] LDAP: `ldapsearch` returns pre-configured users
- [ ] Keycloak: OIDC discovery at `http://127.0.0.1:30080/realms/quay/.well-known/openid-configuration`
- [ ] Push an image with `crane copy --insecure`
- [ ] Verify digest and catalog via v2 API
- [ ] `make local-dev-down` tears down cleanly
- [ ] Verify `hack/setup-kind-e2e.sh` still works on Linux (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)