### PR TITLE
PROJQUAY-11852: fix: nil map panic on empty configBundleSecret

### DIFF
--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -254,6 +254,9 @@ func parseServerHostname(
 	if err := yaml.Unmarshal(bundle.Data["config.yaml"], &config); err != nil {
 		return fmt.Errorf("unable to parse config.yaml: %w", err)
 	}
+	if config == nil {
+		config = make(map[string]interface{})
+	}
 
 	fieldGroup, err := hostsettings.NewHostSettingsFieldGroup(config)
 	if err != nil {

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -771,6 +771,20 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.Requeue, nil
 	}
 
+	if _, ok := cbundle.Data["config.yaml"]; !ok {
+		return r.reconcileWithCondition(
+			ctx,
+			&quay,
+			v1.ConditionTypeRolloutBlocked,
+			metav1.ConditionTrue,
+			v1.ConditionReasonConfigInvalid,
+			fmt.Sprintf(
+				"configBundleSecret %q does not contain a config.yaml key",
+				quay.Spec.ConfigBundleSecret,
+			),
+		)
+	}
+
 	var usercfg map[string]interface{}
 	if err = yaml.Unmarshal(cbundle.Data["config.yaml"], &usercfg); err != nil {
 		return r.reconcileWithCondition(
@@ -781,6 +795,9 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			v1.ConditionReasonConfigInvalid,
 			err.Error(),
 		)
+	}
+	if usercfg == nil {
+		usercfg = make(map[string]interface{})
 	}
 
 	updatedQuay.Status.Conditions = v1.RemoveCondition(

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -618,10 +618,16 @@ func Inflate(
 	// Each managed component brings its own generated `config.yaml` fields which are
 	// accumulated under the key <component>.config.yaml and then added to the base `Secret`.
 	componentConfigFiles := bundle.DeepCopy().Data
+	if componentConfigFiles == nil {
+		componentConfigFiles = make(map[string][]byte)
+	}
 
 	var parsedUserConfig map[string]interface{}
 	if err := yaml.Unmarshal(bundle.Data["config.yaml"], &parsedUserConfig); err != nil {
 		return nil, err
+	}
+	if parsedUserConfig == nil {
+		parsedUserConfig = make(map[string]interface{})
 	}
 
 	// Generate or pull out the `SECRET_KEY` and `DATABASE_SECRET_KEY`. Since these must be

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -739,6 +739,62 @@ var inflateTests = []struct {
 	},
 }
 
+func TestInflateEmptyConfigYAML(t *testing.T) {
+	log := testlogr.NewTestLogger(t)
+
+	tests := []struct {
+		name         string
+		configBundle *corev1.Secret
+	}{
+		{
+			name: "EmptyConfigYAML",
+			configBundle: &corev1.Secret{
+				Data: map[string][]byte{
+					"config.yaml": {},
+				},
+			},
+		},
+		{
+			name: "MissingConfigYAMLKey",
+			configBundle: &corev1.Secret{
+				Data: map[string][]byte{},
+			},
+		},
+		{
+			name:         "NilData",
+			configBundle: &corev1.Secret{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := quaycontext.QuayRegistryContext{
+				SupportsObjectStorage:    true,
+				ObjectStorageInitialized: true,
+			}
+			quay := &v1.QuayRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1.QuayRegistrySpec{
+					Components: []v1.Component{
+						{Kind: "postgres", Managed: true},
+						{Kind: "clair", Managed: true},
+						{Kind: "clairpostgres", Managed: true},
+						{Kind: "redis", Managed: true},
+						{Kind: "objectstorage", Managed: true},
+						{Kind: "mirror", Managed: true},
+					},
+				},
+			}
+
+			pieces, err := Inflate(&ctx, quay, tt.configBundle, log, false)
+			assert.NoError(t, err, tt.name)
+			assert.NotNil(t, pieces, tt.name)
+		})
+	}
+}
+
 func TestInflate(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/kustomize/secrets.go
+++ b/pkg/kustomize/secrets.go
@@ -294,6 +294,9 @@ func ContainsComponentConfig(
 	if err != nil {
 		return false, err
 	}
+	if quayConfig == nil {
+		return false, nil
+	}
 
 	// FIXME: Only checking for the existance of a single field
 	for _, field := range fields {


### PR DESCRIPTION
## Summary
- Guard against nil map panic in `Inflate()` when `config.yaml` is empty or missing from a user-provided `configBundleSecret`
- Fail closed with `RolloutBlocked/ConfigInvalid` condition when the `config.yaml` key is absent from the referenced Secret
- Add defense-in-depth nil guards in `ContainsComponentConfig`, `parseServerHostname`, and the controller's pre-validation unmarshal

## Root Cause
`yaml.Unmarshal` returns a nil `map[string]interface{}` (not an empty map) when the input bytes are empty or nil. The operator then panics writing auto-generated keys (`DATABASE_SECRET_KEY`, `SECRET_KEY`, etc.) into the nil map, crashing the entire operator and blocking reconciliation of all `QuayRegistry` instances.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `config.yaml` key missing from Secret | Panic, operator crash | `RolloutBlocked`: "configBundleSecret does not contain a config.yaml key" |
| `config.yaml` present but empty | Panic, operator crash | Proceeds with defaults (auto-generates all managed keys) |
| `config.yaml` has partial user config | Works | Works (no change) |

## Test Plan
- [x] `TestInflateEmptyConfigYAML` reproduces all 3 nil-map variants (empty value, missing key, nil Data)
- [x] Full `kustomize` test suite passes (27 tests)
- [x] Full controller unit test suite passes (131 tests)
- [x] `make vet` clean
- [x] Pre-commit hooks pass (go fmt, go vet, golangci-lint)

Fixes: https://issues.redhat.com/browse/PROJQUAY-11852