### PR TITLE
PROJQUAY-11867: fix(apis): restrict secretRef to tls component only

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -133,6 +133,10 @@ var supportsTLSOverride = []ComponentKind{
 	ComponentClairPostgres,
 }
 
+var supportsSecretRef = []ComponentKind{
+	ComponentTLS,
+}
+
 const (
 	ManagedKeysName             = "quay-registry-managed-secret-keys"
 	QuayConfigTLSSecretName     = "quay-config-tls"
@@ -160,6 +164,7 @@ type QuayRegistrySpec struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.secretRef) || self.secretRef.name.size() != 0",message="secretRef.name must not be empty"
 // +kubebuilder:validation:XValidation:rule="!has(self.overrides) || !has(self.overrides.tls) || !has(self.overrides.tls.secretRef) || self.overrides.tls.enabled",message="tls.secretRef requires tls.enabled to be true"
 // +kubebuilder:validation:XValidation:rule="!has(self.overrides) || !has(self.overrides.tls) || !has(self.overrides.tls.secretRef) || self.overrides.tls.secretRef.name.size() != 0",message="tls.secretRef.name must not be empty"
+// +kubebuilder:validation:XValidation:rule="!has(self.secretRef) || self.kind == 'tls'",message="secretRef is only supported for the tls component"
 type Component struct {
 	// Kind is the unique name of this type of component.
 	Kind ComponentKind `json:"kind"`
@@ -560,6 +565,14 @@ func hasAffinity(component Component) bool {
 func ValidateOverrides(quay *QuayRegistry) error {
 	for _, component := range quay.Spec.Components {
 
+		// secretRef is independent of Overrides; check it for every component.
+		if component.SecretRef != nil && !ComponentSupportsOverride(component.Kind, "secretRef") {
+			return fmt.Errorf(
+				"component %s does not support secretRef",
+				component.Kind,
+			)
+		}
+
 		// No overrides provided
 		if component.Overrides == nil {
 			continue
@@ -838,6 +851,8 @@ func ComponentSupportsOverride(component ComponentKind, override string) bool {
 		components = supportsSecurityContextOverride
 	case "tls":
 		components = supportsTLSOverride
+	case "secretRef":
+		components = supportsSecretRef
 	}
 
 	for _, cmp := range components {

--- a/apis/quay/v1/quayregistry_types_test.go
+++ b/apis/quay/v1/quayregistry_types_test.go
@@ -755,6 +755,63 @@ var validateOverridesTests = []struct {
 		},
 		nil,
 	},
+	{
+		"SecretRefOnTLSComponentUnmanaged",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "tls", Managed: false, SecretRef: &corev1.LocalObjectReference{Name: "my-tls-secret"}},
+				},
+			},
+		},
+		nil,
+	},
+	{
+		"SecretRefOnPostgresRejected",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "postgres", Managed: false, SecretRef: &corev1.LocalObjectReference{Name: "pg-secret"}},
+				},
+			},
+		},
+		errors.New("component postgres does not support secretRef"),
+	},
+	{
+		"SecretRefOnRedisRejected",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "redis", Managed: false, SecretRef: &corev1.LocalObjectReference{Name: "redis-secret"}},
+				},
+			},
+		},
+		errors.New("component redis does not support secretRef"),
+	},
+	{
+		"SecretRefOnClairRejected",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "clair", Managed: false, SecretRef: &corev1.LocalObjectReference{Name: "clair-secret"}},
+				},
+			},
+		},
+		errors.New("component clair does not support secretRef"),
+	},
+	{
+		"NoSecretRefNoError",
+		QuayRegistry{
+			Spec: QuayRegistrySpec{
+				Components: []Component{
+					{Kind: "postgres", Managed: true},
+					{Kind: "redis", Managed: true},
+					{Kind: "tls", Managed: true},
+				},
+			},
+		},
+		nil,
+	},
 }
 
 func TestValidOverrides(t *testing.T) {
@@ -1040,6 +1097,27 @@ func TestGetTLSOverrideForComponent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetTLSOverrideForComponent(tt.quay, tt.kind)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestComponentSupportsSecretRefOverride(t *testing.T) {
+	tests := []struct {
+		kind     ComponentKind
+		expected bool
+	}{
+		{ComponentTLS, true},
+		{ComponentPostgres, false},
+		{ComponentRedis, false},
+		{ComponentClair, false},
+		{ComponentQuay, false},
+		{ComponentMirror, false},
+		{ComponentObjectStorage, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.kind), func(t *testing.T) {
+			assert.Equal(t, tt.expected, ComponentSupportsOverride(tt.kind, "secretRef"))
 		})
 	}
 }

--- a/bundle/manifests/quayregistries.crd.yaml
+++ b/bundle/manifests/quayregistries.crd.yaml
@@ -1238,6 +1238,8 @@ spec:
                   - message: tls.secretRef.name must not be empty
                     rule: '!has(self.overrides) || !has(self.overrides.tls) || !has(self.overrides.tls.secretRef)
                       || self.overrides.tls.secretRef.name.size() != 0'
+                  - message: secretRef is only supported for the tls component
+                    rule: '!has(self.secretRef) || self.kind == ''tls'''
                 type: array
               configBundleSecret:
                 description: |-

--- a/config/crd/bases/quay.redhat.com_quayregistries.yaml
+++ b/config/crd/bases/quay.redhat.com_quayregistries.yaml
@@ -1238,6 +1238,8 @@ spec:
                   - message: tls.secretRef.name must not be empty
                     rule: '!has(self.overrides) || !has(self.overrides.tls) || !has(self.overrides.tls.secretRef)
                       || self.overrides.tls.secretRef.name.size() != 0'
+                  - message: secretRef is only supported for the tls component
+                    rule: '!has(self.secretRef) || self.kind == ''tls'''
                 type: array
               configBundleSecret:
                 description: |-


### PR DESCRIPTION
secretRef was exposed on the generic Component struct without any kind-level guard, allowing it to be set on components such as postgres, redis, and clair where it has no effect. The only consumer of SecretRef in the codebase is GetTLSSecretRef, which already gates on kind == tls.

Add a supportsSecretRef allowlist (tls only), a new CEL admission rule that rejects secretRef on any component whose kind is not tls, and a ValidateOverrides runtime check that fires during reconciliation as a belt-and-suspenders guard.