### PR TITLE
NO-ISSUE: chore: use official golangci-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,8 @@ repos:
         types: [go]
         pass_filenames: false
 
-      - id: golangci-lint
-        name: golangci-lint
-        entry: golangci-lint run --timeout=5m
-        language: system
-        types: [go]
-        pass_filenames: false
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.12.2
+    hooks:
+      - id: golangci-lint-full
+        args: [--timeout=5m]


### PR DESCRIPTION
## Summary
- Switches `golangci-lint` pre-commit hook from `language: system` to the official `golangci/golangci-lint` repo with `language: golang`
- Pre-commit now auto-manages the `golangci-lint` binary instead of requiring it on PATH
- Fixes fullsend code agent post-script failures where `golangci-lint` is not installed on the GHA runner

## Test plan
- [x] `pre-commit run golangci-lint-full --all-files` passes locally
- [ ] CI pre-commit check passes
- [ ] Fullsend code agent post-script pre-commit check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)