### PR TITLE
PROJQUAY-11892: fix: add scraping for quay-monitor pods

### DIFF
--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        quay-monitor: "true"
         quay-component: quay-app
     spec:
       serviceAccountName: quay-app

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         quay-component: quay-mirror
+        quay-monitor: "true"
     spec:
       serviceAccountName: quay-app
       affinity:

--- a/kustomize/components/monitoring/quay-metrics.service.yaml
+++ b/kustomize/components/monitoring/quay-metrics.service.yaml
@@ -16,5 +16,5 @@ spec:
       targetPort: 9091
       protocol: TCP
   selector:
-    quay-monitoring: "true"
+    quay-monitor: "true"
   type: ClusterIP

--- a/kustomize/components/monitoring/quay-metrics.service.yaml
+++ b/kustomize/components/monitoring/quay-metrics.service.yaml
@@ -16,5 +16,5 @@ spec:
       targetPort: 9091
       protocol: TCP
   selector:
-    quay-component: quay-app
+    quay-monitoring: "true"
   type: ClusterIP


### PR DESCRIPTION
Now every pod created by the operator that should be monitored, is included in the service selector.