### PR TITLE
Removing fake test data to not fool security scanners

### DIFF
--- a/controllers/quay/features_test.go
+++ b/controllers/quay/features_test.go
@@ -757,7 +757,7 @@ func TestCheckPostgresTLSSecrets(t *testing.T) {
 					Data: map[string][]byte{
 						"ca.crt":  caPEM,
 						"tls.crt": certPEM,
-						"tls.key": []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAH\n-----END RSA PRIVATE KEY-----\n"),
+						"tls.key": []byte("FAKE-KEY-DATA-FOR-TESTING"),
 					},
 				},
 			},


### PR DESCRIPTION
Private key isn't real but it's enough to fool some security scanners. Let's just remove it to avoid confusion