### PR TITLE
PROJQUAY-11892: fix(monitoring): add scraping for quay-monitor pods

### DIFF
--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -995,7 +995,7 @@ func GetLabelsOverrideForComponent(quay *QuayRegistry, kind ComponentKind) map[s
 
 // ExceptionLabel checks if attempt to override label affects exceptional labels
 func ExceptionLabel(override string) bool {
-	for _, label := range []string{"quay-component", "app", "quay-operator/quayregistry"} {
+	for _, label := range []string{"quay-component", "app", "quay-operator/quayregistry", "quay-monitor"} {
 		if override != label {
 			continue
 		}

--- a/apis/quay/v1/quayregistry_types_test.go
+++ b/apis/quay/v1/quayregistry_types_test.go
@@ -1044,6 +1044,18 @@ func TestGetTLSOverrideForComponent(t *testing.T) {
 	}
 }
 
+func TestExceptionLabel(t *testing.T) {
+	protected := []string{"quay-component", "app", "quay-operator/quayregistry", "quay-monitor"}
+	for _, label := range protected {
+		assert.True(t, ExceptionLabel(label), "expected %q to be protected from overrides", label)
+	}
+
+	allowed := []string{"custom-label", "team", "environment", "quay-monitoring"}
+	for _, label := range allowed {
+		assert.False(t, ExceptionLabel(label), "expected %q to be allowed as an override", label)
+	}
+}
+
 func resourcePtr(s string) *resource.Quantity {
 	q := resource.MustParse(s)
 	return &q

--- a/kustomize/base/quay.deployment.yaml
+++ b/kustomize/base/quay.deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        quay-monitor: "true"
         quay-component: quay-app
     spec:
       serviceAccountName: quay-app

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         quay-component: quay-mirror
+        quay-monitor: "true"
     spec:
       serviceAccountName: quay-app
       affinity:

--- a/kustomize/components/mirror/mirror.deployment.yaml
+++ b/kustomize/components/mirror/mirror.deployment.yaml
@@ -123,6 +123,9 @@ spec:
                 secretKeyRef:
                   name: quay-proxy-config
                   key: NO_PROXY
+          ports:
+            - containerPort: 9091
+              protocol: TCP
           # TODO: Determine if we need to set resource requirements
           volumeMounts:
             - name: config

--- a/kustomize/components/monitoring/quay-metrics.service.yaml
+++ b/kustomize/components/monitoring/quay-metrics.service.yaml
@@ -16,5 +16,5 @@ spec:
       targetPort: 9091
       protocol: TCP
   selector:
-    quay-monitoring: "true"
+    quay-monitor: "true"
   type: ClusterIP

--- a/kustomize/components/monitoring/quay-metrics.service.yaml
+++ b/kustomize/components/monitoring/quay-metrics.service.yaml
@@ -16,5 +16,5 @@ spec:
       targetPort: 9091
       protocol: TCP
   selector:
-    quay-component: quay-app
+    quay-monitoring: "true"
   type: ClusterIP

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -14,6 +14,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -329,6 +330,74 @@ func TestKustomizationFor(t *testing.T) {
 	}
 }
 
+func TestMonitoringLabelChain(t *testing.T) {
+	log := testlogr.NewTestLogger(t)
+
+	ctx := quaycontext.QuayRegistryContext{
+		SupportsObjectStorage:    true,
+		ObjectStorageInitialized: true,
+		SupportsMonitoring:       true,
+	}
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: v1.QuayRegistrySpec{
+			Components: []v1.Component{
+				{Kind: "postgres", Managed: true},
+				{Kind: "redis", Managed: true},
+				{Kind: "objectstorage", Managed: true},
+				{Kind: "mirror", Managed: true},
+				{Kind: "monitoring", Managed: true},
+			},
+		},
+	}
+	configBundle := &corev1.Secret{
+		Data: map[string][]byte{
+			"config.yaml": encode(map[string]interface{}{"SERVER_HOSTNAME": "quay.io"}),
+		},
+	}
+
+	pieces, err := Inflate(&ctx, quay, configBundle, log, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, pieces)
+
+	var (
+		metricsService *corev1.Service
+		appDep         *appsv1.Deployment
+		mirrorDep      *appsv1.Deployment
+	)
+
+	for _, obj := range pieces {
+		accessor, _ := meta.Accessor(obj)
+		name := accessor.GetName()
+
+		switch dep := obj.(type) {
+		case *corev1.Service:
+			if strings.Contains(name, "quay-metrics") {
+				metricsService = dep
+			}
+		case *appsv1.Deployment:
+			if strings.Contains(name, "quay-app") && !strings.Contains(name, "upgrade") {
+				appDep = dep
+			}
+			if strings.Contains(name, "quay-mirror") {
+				mirrorDep = dep
+			}
+		}
+	}
+
+	require.NotNil(t, metricsService, "quay-metrics Service should be present")
+	assert.Equal(t, "true", metricsService.Spec.Selector["quay-monitor"],
+		"quay-metrics Service selector should use quay-monitor label")
+
+	require.NotNil(t, appDep, "quay-app Deployment should be present")
+	assert.Equal(t, "true", appDep.Spec.Template.Labels["quay-monitor"],
+		"quay-app pod template should have quay-monitor label")
+
+	require.NotNil(t, mirrorDep, "quay-mirror Deployment should be present")
+	assert.Equal(t, "true", mirrorDep.Spec.Template.Labels["quay-monitor"],
+		"quay-mirror pod template should have quay-monitor label")
+}
+
 func TestFlattenSecret(t *testing.T) {
 	assert := assert.New(t)
 
@@ -427,6 +496,26 @@ var quayComponents = map[string][]client.Object{
 	"clairpostgres": {
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "clairpostgres-config-secret"}},
 	},
+	"monitoring": {
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-metrics"}},
+		&rbac.Role{ObjectMeta: metav1.ObjectMeta{Name: "quay-metrics"}},
+		&rbac.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "quay-metrics"}},
+		func() *unstructured.Unstructured {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"})
+			obj.SetName("quay-metrics-monitor")
+			return obj
+		}(),
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "quay-grafana-dashboard"}},
+		&rbac.Role{ObjectMeta: metav1.ObjectMeta{Name: "quay-alerts"}},
+		&rbac.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "quay-alerts"}},
+		func() *unstructured.Unstructured {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "PrometheusRule"})
+			obj.SetName("quay-alerts")
+			return obj
+		}(),
+	},
 	"job": {
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "quay-app-upgrade"}},
 	},
@@ -462,19 +551,21 @@ var inflateTests = []struct {
 					{Kind: "objectstorage", Managed: true},
 					{Kind: "mirror", Managed: true},
 					{Kind: "horizontalpodautoscaler", Managed: true},
+					{Kind: "monitoring", Managed: true},
 				},
 			},
 		},
 		ctx: quaycontext.QuayRegistryContext{
 			SupportsObjectStorage:    true,
 			ObjectStorageInitialized: true,
+			SupportsMonitoring:       true,
 		},
 		configBundle: &corev1.Secret{
 			Data: map[string][]byte{
 				"config.yaml": encode(map[string]interface{}{"SERVER_HOSTNAME": "quay.io"}),
 			},
 		},
-		expected:    withComponents([]string{"job", "quay", "clair", "postgres", "redis", "objectstorage", "mirror", "horizontalpodautoscaler", "clairpostgres"}),
+		expected:    withComponents([]string{"job", "quay", "clair", "postgres", "redis", "objectstorage", "mirror", "horizontalpodautoscaler", "clairpostgres", "monitoring"}),
 		expectedErr: nil,
 	},
 	{


### PR DESCRIPTION
## Summary

Supersedes #1283. Includes all changes from that PR plus:

- **Protects `quay-monitor` label from CR overrides** — adds `quay-monitor` to the `ExceptionLabel` guard list in `quayregistry_types.go`. Without this, a user could override the label via component overrides and silently break metrics collection.
- **Adds test coverage** — unit test for `ExceptionLabel` and an inflate-level `TestMonitoringLabelChain` that verifies the full Service selector → pod template label chain (quay-app + mirror).

### Changes from #1283
- `quay-monitor: "true"` label added to quay-app and mirror pod templates
- `quay-metrics` Service selector changed from `quay-component: quay-app` to `quay-monitor: "true"`
- Mirror deployment containerPort 9091 declaration added

### New in this PR
- `quay-monitor` added to `ExceptionLabel` protected list (`apis/quay/v1/quayregistry_types.go`)
- `TestExceptionLabel` unit test (`apis/quay/v1/quayregistry_types_test.go`)
- `TestMonitoringLabelChain` inflate test (`pkg/kustomize/kustomize_test.go`)
- `monitoring` entry added to `quayComponents` test fixture

## Test plan
- [x] `go test ./apis/quay/v1/` — 22 tests pass
- [x] `go test ./pkg/kustomize/` — 28 tests pass
- [x] Pre-commit hooks pass (go fmt, go vet, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)