### PR TITLE
PROJQUAY-11621: docs: add repo context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,19 @@ Commit message format:
 - Run `make fmt` before committing
 - Keep CRD backward compatible
 - Test component changes with e2e tests in `e2e/`
+
+## Contextification Addendum
+
+Low-token routing:
+
+- API type: `apis/quay/v1/`
+- Reconciler: `controllers/quay/`
+- Manifest generation: `pkg/kustomize/`
+- Component status: `pkg/cmpstatus/`
+- Runtime context: `pkg/context/`
+- Chainsaw tests: `test/chainsaw/`
+- Deeper docs: `agent_docs/`
+
+Commands: `make manager`, `make run`, `make test`, `make fmt && make vet`, `make generate && make manifests`.
+
+Guardrails: keep reconcile logic idempotent and preserve existing `QuayRegistry` compatibility.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,183 @@
+# quay-operator Architecture
+
+`quay-operator` deploys and reconciles Quay on OpenShift/Kubernetes through the `QuayRegistry` custom resource. It owns Kubernetes resource generation, managed component lifecycle, status reporting, and upgrade-safe CRD behavior.
+
+```mermaid
+flowchart TB
+    cr[QuayRegistry custom resource]
+    controller[quay-operator reconciler]
+    config[generated Quay config Secret]
+    components[managed components]
+    app[Quay application Deployment]
+    status[QuayRegistry status]
+
+    cr --> controller
+    controller --> config
+    controller --> components
+    controller --> app
+    components --> status
+    app --> status
+    status --> cr
+```
+
+## High-Level Design
+
+```
+QuayRegistry CR
+    ↓ Reconciliation
+quay-operator
+    ↓ Manage components
+[Postgres, Redis, Clair, Quay app, Quay config, Clair postgres]
+```
+
+## Repository Layout
+
+```text
+apis/quay/v1/          QuayRegistry API types and generated DeepCopy code
+controllers/quay/      reconciler, feature handling, TLS logic, status controller
+pkg/kustomize/         Kubernetes object generation from QuayRegistry context
+pkg/cmpstatus/         component readiness and condition evaluation
+pkg/context/           derived runtime context used by reconciliation
+pkg/tls/               TLS validation helpers
+config/                Kubebuilder CRD, RBAC, manager, webhook, sample manifests
+kustomize/             component base and overlay manifests rendered by the operator
+bundle/                OLM bundle manifests and metadata
+test/chainsaw/         cluster-level Chainsaw tests
+hack/                  local deployment, formatting, release, and utility scripts
+```
+
+## Reconciliation Loop
+
+```text
+1. Watch QuayRegistry CR changes
+2. Validate spec (required fields, component dependencies)
+3. For each component:
+   a. Check if managed or unmanaged
+   b. If managed: create/update Deployment/StatefulSet/Service
+   c. If unmanaged: validate external connection
+4. Generate Quay config (config.yaml as Secret)
+5. Deploy Quay application Deployment
+6. Update QuayRegistry.status with component health
+7. Requeue if not ready, otherwise wait for next change
+```
+
+The reconciler must stay idempotent. Repeated runs should converge resources to the desired state without breaking user-provided unmanaged component configuration.
+
+## Managed Components
+
+### Postgres (managed)
+- StatefulSet with persistent volume
+- Database init (schema creation)
+- Credentials in Secret
+
+### Postgres (unmanaged)
+- User provides connection string
+- Operator validates connectivity
+- Schema must exist
+
+### Redis (managed)
+- Deployment + Service
+- No persistence (cache only)
+
+### Redis (unmanaged)
+- User provides endpoint
+- Operator validates connectivity
+
+### Clair (managed)
+- Separate Postgres for Clair
+- Clair deployment + updater
+- Vulnerability database sync
+
+### Object Storage (managed)
+- RHOCS/NooBaa integration (OpenShift only)
+- ObjectBucketClaim creation
+
+### Object Storage (unmanaged)
+- S3/GCS/Azure credentials from Secret
+- Operator validates bucket access
+
+### Quay Application
+- Deployment and supporting Kubernetes resources
+- Generated Quay configuration from the config bundle and managed component data
+- Service plus Route/Ingress where applicable
+
+## Configuration Management
+
+```text
+QuayRegistry.spec.configBundleSecret → operator merges →
+  [Component configs + user overrides] → Quay config Secret
+    → Mounted in Quay pod at /conf/stack/config.yaml
+```
+
+## Upgrade Handling
+
+```text
+1. Detect Quay version change in CR
+2. Update Quay deployment image
+3. Run migration job (if required)
+4. Rolling restart Quay pods
+5. Update status with new version
+```
+
+## Generated Artifacts
+
+API and manifest changes require regenerated output:
+
+- API types in `apis/quay/v1/*_types.go` feed generated DeepCopy code through `make generate`.
+- CRD, RBAC, and webhook manifests are generated with `make manifests`.
+- `make manifests` also syncs the QuayRegistry CRD into `bundle/manifests/`.
+- Kustomize manifests under `config/` and `kustomize/` are consumed by local deploy and bundle workflows.
+
+## CRD Example
+
+```yaml
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: example-quay
+spec:
+  components:
+    - kind: postgres
+      managed: true
+    - kind: redis
+      managed: true
+    - kind: clair
+      managed: true
+    - kind: objectstorage
+      managed: false
+  configBundleSecret: quay-config-override
+```
+
+## Status Reporting
+
+```yaml
+status:
+  currentVersion: 3.11.0
+  conditions:
+    - type: Available
+      status: "True"
+      reason: ComponentsReady
+  registryEndpoint: https://quay.example.com
+  configEditorEndpoint: https://quay.example.com/config
+```
+
+## Validation
+
+- `make test` runs unit tests with envtest assets.
+- `make manager` builds the controller binary after generation, formatting, and vetting.
+- `make run` runs the controller against the active `KUBECONFIG`.
+- Chainsaw tests under `test/chainsaw/` cover cluster behavior such as reconciliation, TLS, HPA, storage, and unmanaged components.
+
+## Integration Points
+
+- `quay/quay`: application image and runtime configuration expectations.
+- `quay-fbcs`: file-based catalog content for released operator bundles.
+- `quay-konflux-components`: Konflux build definitions for operator and bundle images.
+- `quay-tests`: broader Quay validation outside this operator repo.
+
+## Review Risks
+
+- CRD changes must preserve compatibility for existing `QuayRegistry` resources.
+- Reconcile changes can loop or overwrite user-owned resources if managed/unmanaged boundaries are wrong.
+- Generated CRD and bundle files can drift if `make generate` or `make manifests` is skipped.
+- Status logic changes can block upgrades or hide unhealthy components.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to quay-operator
+
+## Setup
+
+```bash
+# Requires OpenShift/K8s cluster
+make install   # Install CRDs
+make deploy    # Deploy operator
+
+# Local development
+make run       # Run against configured cluster
+```
+
+## Development
+
+Operator for deploying Quay on Kubernetes/OpenShift. Most code changes should start in one of these areas:
+
+- API changes: `apis/quay/v1/`
+- Reconcile changes: `controllers/quay/`
+- Rendered Kubernetes resources: `pkg/kustomize/` and `kustomize/`
+- Component readiness: `pkg/cmpstatus/`
+- Cluster tests: `test/chainsaw/`
+
+## Testing
+
+```bash
+# Unit tests
+make test
+
+# E2E tests (requires cluster)
+make chainsaw-test
+
+# Scorecard
+operator-sdk scorecard bundle
+```
+
+## Making Changes
+
+### CRD Changes
+1. Update `apis/quay/v1/*_types.go`
+2. Run `make generate` to update generated code
+3. Run `make manifests` to regenerate CRDs, RBAC, webhooks, and bundle CRD output
+4. Test upgrade path from previous version
+
+### Controller Changes
+- Update `controllers/quay/`
+- Add tests in `controllers/*_test.go`
+- Verify reconciliation doesn't fight with manual edits
+
+### Manifest Changes
+- Update base manifests under `kustomize/` or Kubebuilder manifests under `config/`
+- Run `make manifests` when generated CRD/RBAC/webhook output is affected
+- Verify bundle output under `bundle/` when operator packaging changes
+
+## Pull Requests
+
+- Test on OpenShift (primary) and vanilla K8s
+- Document new QuayRegistry fields in API comments
+- Breaking changes require migration guide
+- Update docs/ for user-facing changes
+- Keep managed and unmanaged component behavior explicit in the PR description
+
+## Code Structure
+
+- `apis/quay/v1/` - CRD types
+- `controllers/quay/` - reconciliation logic
+- `pkg/` - component management (postgres, redis, clair, etc.)
+- `kustomize/` - deployment manifests
+- `test/chainsaw/` - cluster behavior tests

--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ Or run the steps one by one.
 $ kubectl create -n openshift-marketplace -f ./bundle/quay-operator.catalogsource.yaml
 ```
 
+## Contextification Addendum
+
+```mermaid
+flowchart TB
+    cr[QuayRegistry CR]
+    operator[quay-operator]
+    config[generated config Secret]
+    components[managed components]
+    quay[Quay app]
+    status[status]
+
+    cr --> operator
+    operator --> config
+    operator --> components
+    operator --> quay
+    components --> status
+    quay --> status
+```
+
+Key paths: `apis/quay/v1/`, `controllers/quay/`, `pkg/kustomize/`, `pkg/cmpstatus/`, `pkg/context/`, `config/`, `kustomize/`, `bundle/`, and `test/chainsaw/`.
+
+Use `make manager`, `make run`, `SKIP_RESOURCE_REQUESTS=true make run`, `make test`, `make fmt && make vet`, and `make generate && make manifests`.
+
+Related repos: [quay](https://github.com/quay/quay), [quay-fbcs](https://github.com/quay/quay-fbcs), [quay-konflux-components](https://github.com/quay/quay-konflux-components), and [quay-tests](https://github.com/quay/quay-tests).
+
 **Wait a few seconds for the package to become available**:
 ```sh
 $ kubectl get packagemanifest --all-namespaces | grep quay


### PR DESCRIPTION
## Summary
Adds required contextification docs for `quay-operator` as part of [PROJQUAY-11621](https://redhat.atlassian.net/browse/PROJQUAY-11621).

 ## Changes
  - Updates `AGENTS.md` with low-token routing for API, reconciler, manifest, status, context, and Chainsaw test
  paths.
  - Adds `ARCHITECTURE.md` describing the QuayRegistry reconciliation flow, managed components, generated artifacts,
  validation, integrations, and review risks.
  - Adds `CONTRIBUTING.md` with setup, testing, CRD, controller, manifest, and PR guidance.
  - Updates `README.md` with a contextification addendum, Mermaid diagram, key paths, commands, and linked related
  repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded project docs with clearer architecture, contribution, and onboarding guidance.
  * Added a high-level flow diagram and key repository paths to help explain how the operator, config, managed components, and status relate.
  * Included practical checklists, build/test commands, and upgrade-safe development notes for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->