### PR TITLE
PROJQUAY-12150: operator: wire programmatic bootstrap token storage

### DIFF
--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -853,14 +853,7 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if !kustomize.ProgrammaticBootstrapEnabled(usercfg) {
 		if err := r.cleanupProgrammaticBootstrapTokenResources(ctx, updatedQuay, log); err != nil {
-			return r.reconcileWithCondition(
-				ctx,
-				&quay,
-				v1.ConditionTypeRolloutBlocked,
-				metav1.ConditionTrue,
-				v1.ConditionReasonComponentCreationFailed,
-				fmt.Sprintf("could not clean up stale programmatic bootstrap token resources: %s", err),
-			)
+			log.Error(err, "could not clean up stale programmatic bootstrap token resources, continuing reconciliation")
 		}
 	}
 

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -34,6 +34,7 @@ import (
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -482,6 +483,29 @@ func (r *QuayRegistryReconciler) GetOldConfigBundleSecrets(
 	return oldConfigBundleSecrets, nil
 }
 
+func (r *QuayRegistryReconciler) cleanupProgrammaticBootstrapTokenResources(
+	ctx context.Context, quay *v1.QuayRegistry, log logr.Logger,
+) error {
+	name := kustomize.BootstrapTokenSecretName(quay)
+	objects := []struct {
+		kind string
+		obj  client.Object
+	}{
+		{kind: "Secret", obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: quay.GetNamespace()}}},
+		{kind: "Role", obj: &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: quay.GetNamespace()}}},
+		{kind: "RoleBinding", obj: &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: quay.GetNamespace()}}},
+	}
+
+	for _, object := range objects {
+		if err := r.Delete(ctx, object.obj); err != nil && !errors.IsNotFound(err) {
+			log.Error(err, "could not delete stale programmatic bootstrap token resource", "kind", object.kind, "name", object.obj.GetName())
+			return err
+		}
+	}
+
+	return nil
+}
+
 // quayAppDeploymentRolledOut returns true when the quay-app Deployment has fully
 // rolled out — that is, every desired replica is both updated and available. It is
 // used to gate the deletion of old rendered config secrets so that no running pod
@@ -825,6 +849,19 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	if usercfg == nil {
 		usercfg = make(map[string]interface{})
+	}
+
+	if !kustomize.ProgrammaticBootstrapEnabled(usercfg) {
+		if err := r.cleanupProgrammaticBootstrapTokenResources(ctx, updatedQuay, log); err != nil {
+			return r.reconcileWithCondition(
+				ctx,
+				&quay,
+				v1.ConditionTypeRolloutBlocked,
+				metav1.ConditionTrue,
+				v1.ConditionReasonComponentCreationFailed,
+				fmt.Sprintf("could not clean up stale programmatic bootstrap token resources: %s", err),
+			)
+		}
 	}
 
 	updatedQuay.Status.Conditions = v1.RemoveCondition(

--- a/controllers/quay/quayregistry_controller_test.go
+++ b/controllers/quay/quayregistry_controller_test.go
@@ -13,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
 
 	v1 "github.com/quay/quay-operator/apis/quay/v1"
 	quaycontext "github.com/quay/quay-operator/pkg/context"
@@ -169,6 +171,29 @@ func TestCreateOrUpdateObject_Job(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCleanupProgrammaticBootstrapTokenResources(t *testing.T) {
+	quay := newQuayRegistry("test-registry", "default")
+	name := kustomize.BootstrapTokenSecretName(quay)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: quay.GetNamespace()}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: quay.GetNamespace()}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: quay.GetNamespace()}},
+	).Build()
+	reconciler := &QuayRegistryReconciler{Client: fakeClient}
+
+	if err := reconciler.cleanupProgrammaticBootstrapTokenResources(context.Background(), quay, testLogger); err != nil {
+		t.Fatalf("cleanupProgrammaticBootstrapTokenResources returned error: %v", err)
+	}
+
+	for _, obj := range []client.Object{&corev1.Secret{}, &rbacv1.Role{}, &rbacv1.RoleBinding{}} {
+		err := fakeClient.Get(context.Background(), types.NamespacedName{Name: name, Namespace: quay.GetNamespace()}, obj)
+		if !k8serrors.IsNotFound(err) {
+			t.Fatalf("expected %T to be deleted, got error: %v", obj, err)
+		}
 	}
 }
 
@@ -474,6 +499,109 @@ var _ = Describe("Reconciling a QuayRegistry", func() {
 			}
 
 			Expect(found).To(BeTrue())
+		})
+	})
+
+	When("programmatic bootstrap is disabled", func() {
+		var bootstrapTokenResourceName string
+
+		BeforeEach(func() {
+			quayRegistry = newQuayRegistry("test-registry", namespace)
+			configBundle = newConfigBundle("quay-config-secret-abc123", namespace, true)
+			quayRegistry.Spec.ConfigBundleSecret = configBundle.GetName()
+			quayRegistryName = types.NamespacedName{
+				Name:      quayRegistry.Name,
+				Namespace: quayRegistry.Namespace,
+			}
+			bootstrapTokenResourceName = kustomize.BootstrapTokenSecretName(quayRegistry)
+
+			Expect(k8sClient.Create(context.Background(), &configBundle)).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenResourceName, Namespace: namespace},
+				Data:       map[string][]byte{kustomize.BootstrapTokenSecretKey: []byte(`{"access_token":"stale"}`)},
+				Type:       corev1.SecretTypeOpaque,
+			})).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenResourceName, Namespace: namespace},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups:     []string{""},
+						Resources:     []string{"secrets"},
+						ResourceNames: []string{bootstrapTokenResourceName},
+						Verbs:         []string{"get", "update"},
+					},
+				},
+			})).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenResourceName, Namespace: namespace},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     bootstrapTokenResourceName,
+				},
+				Subjects: []rbacv1.Subject{
+					{Kind: rbacv1.ServiceAccountKind, Name: quayRegistry.GetName() + "-quay-app", Namespace: namespace},
+				},
+			})).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), quayRegistry)).Should(Succeed())
+
+			result, err = controller.Reconcile(context.Background(), reconcile.Request{NamespacedName: quayRegistryName})
+		})
+
+		It("does not return an error", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+		})
+
+		It("deletes stale bootstrap-token Secret and RBAC resources", func() {
+			getErr := k8sClient.Get(context.Background(), types.NamespacedName{Name: bootstrapTokenResourceName, Namespace: namespace}, &corev1.Secret{})
+			Expect(k8serrors.IsNotFound(getErr)).To(BeTrue())
+			getErr = k8sClient.Get(context.Background(), types.NamespacedName{Name: bootstrapTokenResourceName, Namespace: namespace}, &rbacv1.Role{})
+			Expect(k8serrors.IsNotFound(getErr)).To(BeTrue())
+			getErr = k8sClient.Get(context.Background(), types.NamespacedName{Name: bootstrapTokenResourceName, Namespace: namespace}, &rbacv1.RoleBinding{})
+			Expect(k8serrors.IsNotFound(getErr)).To(BeTrue())
+		})
+	})
+
+	When("programmatic bootstrap is enabled", func() {
+		var bootstrapTokenResourceName string
+		var existingTokenData []byte
+
+		BeforeEach(func() {
+			quayRegistry = newQuayRegistry("test-registry", namespace)
+			configBundle = newConfigBundle("quay-config-secret-abc123", namespace, true)
+			config := map[string]interface{}{}
+			Expect(yaml.Unmarshal(configBundle.Data["config.yaml"], &config)).To(Succeed())
+			config[kustomize.ProgrammaticBootstrapFeatureConfigField] = true
+			configBundle.Data["config.yaml"] = encode(config)
+			quayRegistry.Spec.ConfigBundleSecret = configBundle.GetName()
+			quayRegistryName = types.NamespacedName{
+				Name:      quayRegistry.Name,
+				Namespace: quayRegistry.Namespace,
+			}
+			bootstrapTokenResourceName = kustomize.BootstrapTokenSecretName(quayRegistry)
+			existingTokenData = []byte(`{"access_token":"preserve-me"}`)
+
+			Expect(k8sClient.Create(context.Background(), &configBundle)).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenResourceName, Namespace: namespace},
+				Data:       map[string][]byte{kustomize.BootstrapTokenSecretKey: existingTokenData},
+				Type:       corev1.SecretTypeOpaque,
+			})).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), quayRegistry)).Should(Succeed())
+
+			result, err = controller.Reconcile(context.Background(), reconcile.Request{NamespacedName: quayRegistryName})
+		})
+
+		It("does not return an error", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+		})
+
+		It("preserves existing bootstrap-token Secret data", func() {
+			var bootstrapTokenSecret corev1.Secret
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: bootstrapTokenResourceName, Namespace: namespace}, &bootstrapTokenSecret)).To(Succeed())
+			Expect(bootstrapTokenSecret.Data).To(HaveKeyWithValue(kustomize.BootstrapTokenSecretKey, existingTokenData))
 		})
 	})
 

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -18,6 +18,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -43,6 +44,17 @@ const (
 	operatorServiceEndpointAnnotation = "quay-operator-service-endpoint"
 
 	podNamespaceKey = "MY_POD_NAMESPACE"
+
+	ProgrammaticBootstrapFeatureConfigField = "FEATURE_PROGRAMMATIC_BOOTSTRAP"
+	ProgrammaticTokenK8sSecretConfigField   = "PROGRAMMATIC_TOKEN_K8S_SECRET"
+	ProgrammaticTokenK8sKeyConfigField      = "PROGRAMMATIC_TOKEN_K8S_KEY"
+	ProgrammaticTokenPathConfigField        = "PROGRAMMATIC_TOKEN_PATH"
+	BootstrapTokenSecretKey                 = "token.json"
+	BootstrapTokenMountPath                 = "/var/lib/quay/bootstrap-token"
+	BootstrapTokenConfigPath                = BootstrapTokenMountPath + "/" + BootstrapTokenSecretKey
+
+	bootstrapTokenResourceSuffix = "bootstrap-token"
+	bootstrapTokenVolumeName     = "bootstrap-token"
 
 	componentImagePrefix = "RELATED_IMAGE_COMPONENT_"
 )
@@ -172,6 +184,143 @@ func decode(bytes []byte) interface{} {
 	var value interface{}
 	_ = yaml.Unmarshal(bytes, &value)
 	return value
+}
+
+// BootstrapTokenSecretName returns the deterministic Secret name used for programmatic bootstrap token storage.
+func BootstrapTokenSecretName(quay *v1.QuayRegistry) string {
+	return quay.GetName() + "-" + bootstrapTokenResourceSuffix
+}
+
+// ProgrammaticBootstrapEnabled returns true only when FEATURE_PROGRAMMATIC_BOOTSTRAP is boolean true.
+func ProgrammaticBootstrapEnabled(config map[string]interface{}) bool {
+	enabled, ok := config[ProgrammaticBootstrapFeatureConfigField].(bool)
+	return ok && enabled
+}
+
+func injectProgrammaticBootstrapTokenConfig(quay *v1.QuayRegistry, config map[string]interface{}) {
+	config[ProgrammaticTokenK8sSecretConfigField] = BootstrapTokenSecretName(quay)
+	config[ProgrammaticTokenK8sKeyConfigField] = BootstrapTokenSecretKey
+	config[ProgrammaticTokenPathConfigField] = BootstrapTokenConfigPath
+}
+
+func bootstrapTokenLabels(quay *v1.QuayRegistry) map[string]string {
+	return map[string]string{
+		QuayRegistryNameLabel: quay.GetName(),
+	}
+}
+
+func addProgrammaticBootstrapTokenResources(quay *v1.QuayRegistry, resources []client.Object) []client.Object {
+	secretName := BootstrapTokenSecretName(quay)
+
+	for _, resource := range resources {
+		deployment, ok := resource.(*apps.Deployment)
+		if !ok || deployment.GetName() != quay.GetName()+"-quay-app" {
+			continue
+		}
+		ensureBootstrapTokenDeploymentMount(deployment, secretName)
+	}
+
+	labels := bootstrapTokenLabels(quay)
+	resources = append(resources,
+		&corev1.Secret{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: quay.GetNamespace(),
+				Labels:    labels,
+			},
+			Type: corev1.SecretTypeOpaque,
+		},
+		&rbac.Role{
+			TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: quay.GetNamespace(),
+				Labels:    labels,
+			},
+			Rules: []rbac.PolicyRule{
+				{
+					APIGroups:     []string{""},
+					Resources:     []string{"secrets"},
+					ResourceNames: []string{secretName},
+					Verbs:         []string{"get", "update"},
+				},
+			},
+		},
+		&rbac.RoleBinding{
+			TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: quay.GetNamespace(),
+				Labels:    labels,
+			},
+			RoleRef: rbac.RoleRef{
+				APIGroup: rbac.GroupName,
+				Kind:     "Role",
+				Name:     secretName,
+			},
+			Subjects: []rbac.Subject{
+				{
+					Kind:      rbac.ServiceAccountKind,
+					Name:      quay.GetName() + "-quay-app",
+					Namespace: quay.GetNamespace(),
+				},
+			},
+		},
+	)
+
+	return resources
+}
+
+func ensureBootstrapTokenDeploymentMount(deployment *apps.Deployment, secretName string) {
+	volumeFound := false
+	for index := range deployment.Spec.Template.Spec.Volumes {
+		if deployment.Spec.Template.Spec.Volumes[index].Name != bootstrapTokenVolumeName {
+			continue
+		}
+		deployment.Spec.Template.Spec.Volumes[index].VolumeSource = corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: secretName},
+		}
+		volumeFound = true
+		break
+	}
+	if !volumeFound {
+		deployment.Spec.Template.Spec.Volumes = append(
+			deployment.Spec.Template.Spec.Volumes,
+			corev1.Volume{
+				Name: bootstrapTokenVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: secretName},
+				},
+			},
+		)
+	}
+
+	for containerIndex := range deployment.Spec.Template.Spec.Containers {
+		container := &deployment.Spec.Template.Spec.Containers[containerIndex]
+		if container.Name != "quay-app" {
+			continue
+		}
+
+		mountFound := false
+		for mountIndex := range container.VolumeMounts {
+			if container.VolumeMounts[mountIndex].Name != bootstrapTokenVolumeName {
+				continue
+			}
+			container.VolumeMounts[mountIndex].MountPath = BootstrapTokenMountPath
+			container.VolumeMounts[mountIndex].ReadOnly = true
+			container.VolumeMounts[mountIndex].SubPath = ""
+			mountFound = true
+			break
+		}
+		if !mountFound {
+			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+				Name:      bootstrapTokenVolumeName,
+				MountPath: BootstrapTokenMountPath,
+				ReadOnly:  true,
+			})
+		}
+	}
 }
 
 // EnsureCreationOrder sorts the given slice of Kubernetes objects so that when created in order,
@@ -854,6 +1003,11 @@ func Inflate(
 		}
 	}
 
+	programmaticBootstrapEnabled := ProgrammaticBootstrapEnabled(parsedUserConfig)
+	if programmaticBootstrapEnabled {
+		injectProgrammaticBootstrapTokenConfig(quay, parsedUserConfig)
+	}
+
 	componentConfigFiles["config.yaml"] = encode(parsedUserConfig)
 
 	for _, component := range quay.Spec.Components {
@@ -915,6 +1069,10 @@ func Inflate(
 			continue
 		}
 		filteredResources = append(filteredResources, resource)
+	}
+
+	if programmaticBootstrapEnabled {
+		filteredResources = addProgrammaticBootstrapTokenResources(quay, filteredResources)
 	}
 
 	for index, resource := range filteredResources {

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -952,6 +952,254 @@ func TestInflate(t *testing.T) {
 	}
 }
 
+func TestProgrammaticBootstrapEnabledStrictBool(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		config map[string]interface{}
+		want   bool
+	}{
+		{
+			name:   "boolean true enables programmatic bootstrap",
+			config: map[string]interface{}{ProgrammaticBootstrapFeatureConfigField: true},
+			want:   true,
+		},
+		{
+			name:   "string true does not enable programmatic bootstrap",
+			config: map[string]interface{}{ProgrammaticBootstrapFeatureConfigField: "true"},
+			want:   false,
+		},
+		{
+			name:   "nil value does not enable programmatic bootstrap",
+			config: map[string]interface{}{ProgrammaticBootstrapFeatureConfigField: nil},
+			want:   false,
+		},
+		{
+			name:   "missing key does not enable programmatic bootstrap",
+			config: map[string]interface{}{},
+			want:   false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ProgrammaticBootstrapEnabled(tt.config))
+		})
+	}
+}
+
+func TestInflateProgrammaticBootstrapTokenEnabled(t *testing.T) {
+	log := testlogr.NewTestLogger(t)
+	ctx := quaycontext.QuayRegistryContext{
+		DbUri: "postgresql://user:pass@db:5432/db",
+	}
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+		Spec:       v1.QuayRegistrySpec{},
+		Status:     v1.QuayRegistryStatus{CurrentVersion: v1.QuayVersionCurrent},
+	}
+	configBundle := &corev1.Secret{
+		Data: map[string][]byte{
+			"config.yaml": encode(map[string]interface{}{
+				"SERVER_HOSTNAME":                       "quay.io",
+				"DB_URI":                                ctx.DbUri,
+				ProgrammaticBootstrapFeatureConfigField: true,
+			}),
+		},
+	}
+
+	pieces, err := Inflate(&ctx, quay, configBundle, log, false)
+	require.NoError(t, err)
+
+	secretName := BootstrapTokenSecretName(quay)
+	config := renderedQuayConfig(t, pieces)
+	assert.Equal(t, secretName, config[ProgrammaticTokenK8sSecretConfigField])
+	assert.Equal(t, BootstrapTokenSecretKey, config[ProgrammaticTokenK8sKeyConfigField])
+	assert.Equal(t, BootstrapTokenConfigPath, config[ProgrammaticTokenPathConfigField])
+	assert.NotContains(t, config, "PROGRAMMATIC_TOKEN_K8S_NAMESPACE")
+
+	bootstrapSecret := findSecretByName(pieces, secretName)
+	require.NotNil(t, bootstrapSecret)
+	assert.Equal(t, corev1.SecretTypeOpaque, bootstrapSecret.Type)
+	assert.NotContains(t, bootstrapSecret.Data, BootstrapTokenSecretKey)
+
+	role := findRoleByName(pieces, secretName)
+	require.NotNil(t, role)
+	require.Len(t, role.Rules, 1)
+	assert.Equal(t, []string{""}, role.Rules[0].APIGroups)
+	assert.Equal(t, []string{"secrets"}, role.Rules[0].Resources)
+	assert.Equal(t, []string{secretName}, role.Rules[0].ResourceNames)
+	assert.ElementsMatch(t, []string{"get", "update"}, role.Rules[0].Verbs)
+
+	roleBinding := findRoleBindingByName(pieces, secretName)
+	require.NotNil(t, roleBinding)
+	assert.Equal(t, rbac.GroupName, roleBinding.RoleRef.APIGroup)
+	assert.Equal(t, "Role", roleBinding.RoleRef.Kind)
+	assert.Equal(t, secretName, roleBinding.RoleRef.Name)
+	require.Len(t, roleBinding.Subjects, 1)
+	assert.Equal(t, rbac.ServiceAccountKind, roleBinding.Subjects[0].Kind)
+	assert.Equal(t, "test-quay-app", roleBinding.Subjects[0].Name)
+	assert.Equal(t, "test-ns", roleBinding.Subjects[0].Namespace)
+
+	deployment := findDeploymentByName(pieces, "test-quay-app")
+	require.NotNil(t, deployment)
+	volume := findVolumeByName(deployment, bootstrapTokenVolumeName)
+	require.NotNil(t, volume)
+	require.NotNil(t, volume.Secret)
+	assert.Equal(t, secretName, volume.Secret.SecretName)
+
+	mount := findVolumeMountByName(deployment, "quay-app", bootstrapTokenVolumeName)
+	require.NotNil(t, mount)
+	assert.Equal(t, BootstrapTokenMountPath, mount.MountPath)
+	assert.True(t, mount.ReadOnly)
+	assert.Empty(t, mount.SubPath)
+}
+
+func TestInflateProgrammaticBootstrapTokenDisabled(t *testing.T) {
+	log := testlogr.NewTestLogger(t)
+	ctx := quaycontext.QuayRegistryContext{
+		DbUri: "postgresql://user:pass@db:5432/db",
+	}
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+		Spec:       v1.QuayRegistrySpec{},
+		Status:     v1.QuayRegistryStatus{CurrentVersion: v1.QuayVersionCurrent},
+	}
+	configBundle := &corev1.Secret{
+		Data: map[string][]byte{
+			"config.yaml": encode(map[string]interface{}{
+				"SERVER_HOSTNAME":                       "quay.io",
+				"DB_URI":                                ctx.DbUri,
+				ProgrammaticBootstrapFeatureConfigField: false,
+			}),
+		},
+	}
+
+	pieces, err := Inflate(&ctx, quay, configBundle, log, false)
+	require.NoError(t, err)
+
+	secretName := BootstrapTokenSecretName(quay)
+	config := renderedQuayConfig(t, pieces)
+	assert.NotContains(t, config, ProgrammaticTokenK8sSecretConfigField)
+	assert.NotContains(t, config, ProgrammaticTokenK8sKeyConfigField)
+	assert.NotContains(t, config, ProgrammaticTokenPathConfigField)
+
+	assert.Nil(t, findSecretByName(pieces, secretName))
+	assert.Nil(t, findRoleByName(pieces, secretName))
+	assert.Nil(t, findRoleBindingByName(pieces, secretName))
+
+	deployment := findDeploymentByName(pieces, "test-quay-app")
+	require.NotNil(t, deployment)
+	assert.Nil(t, findVolumeByName(deployment, bootstrapTokenVolumeName))
+	assert.Nil(t, findVolumeMountByName(deployment, "quay-app", bootstrapTokenVolumeName))
+}
+
+func TestInflateProgrammaticBootstrapTokenOverridesConflictingConfig(t *testing.T) {
+	log := testlogr.NewTestLogger(t)
+	ctx := quaycontext.QuayRegistryContext{
+		DbUri: "postgresql://user:pass@db:5432/db",
+	}
+	quay := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+		Spec:       v1.QuayRegistrySpec{},
+		Status:     v1.QuayRegistryStatus{CurrentVersion: v1.QuayVersionCurrent},
+	}
+	configBundle := &corev1.Secret{
+		Data: map[string][]byte{
+			"config.yaml": encode(map[string]interface{}{
+				"SERVER_HOSTNAME":                       "quay.io",
+				"DB_URI":                                ctx.DbUri,
+				ProgrammaticBootstrapFeatureConfigField: true,
+				ProgrammaticTokenK8sSecretConfigField:   "user-secret",
+				ProgrammaticTokenK8sKeyConfigField:      "user-key.json",
+				ProgrammaticTokenPathConfigField:        "/tmp/user-token.json",
+			}),
+		},
+	}
+
+	pieces, err := Inflate(&ctx, quay, configBundle, log, false)
+	require.NoError(t, err)
+
+	config := renderedQuayConfig(t, pieces)
+	assert.Equal(t, BootstrapTokenSecretName(quay), config[ProgrammaticTokenK8sSecretConfigField])
+	assert.Equal(t, BootstrapTokenSecretKey, config[ProgrammaticTokenK8sKeyConfigField])
+	assert.Equal(t, BootstrapTokenConfigPath, config[ProgrammaticTokenPathConfigField])
+}
+
+func renderedQuayConfig(t *testing.T, pieces []client.Object) map[string]interface{} {
+	t.Helper()
+	for _, obj := range pieces {
+		secret, ok := obj.(*corev1.Secret)
+		if !ok || !strings.Contains(secret.GetName(), configSecretPrefix) {
+			continue
+		}
+		return decode(secret.Data["config.yaml"]).(map[string]interface{})
+	}
+	t.Fatal("rendered Quay config Secret not found")
+	return nil
+}
+
+func findSecretByName(pieces []client.Object, name string) *corev1.Secret {
+	for _, obj := range pieces {
+		secret, ok := obj.(*corev1.Secret)
+		if ok && secret.GetName() == name {
+			return secret
+		}
+	}
+	return nil
+}
+
+func findRoleByName(pieces []client.Object, name string) *rbac.Role {
+	for _, obj := range pieces {
+		role, ok := obj.(*rbac.Role)
+		if ok && role.GetName() == name {
+			return role
+		}
+	}
+	return nil
+}
+
+func findRoleBindingByName(pieces []client.Object, name string) *rbac.RoleBinding {
+	for _, obj := range pieces {
+		roleBinding, ok := obj.(*rbac.RoleBinding)
+		if ok && roleBinding.GetName() == name {
+			return roleBinding
+		}
+	}
+	return nil
+}
+
+func findDeploymentByName(pieces []client.Object, name string) *appsv1.Deployment {
+	for _, obj := range pieces {
+		deployment, ok := obj.(*appsv1.Deployment)
+		if ok && deployment.GetName() == name {
+			return deployment
+		}
+	}
+	return nil
+}
+
+func findVolumeByName(deployment *appsv1.Deployment, name string) *corev1.Volume {
+	for index := range deployment.Spec.Template.Spec.Volumes {
+		if deployment.Spec.Template.Spec.Volumes[index].Name == name {
+			return &deployment.Spec.Template.Spec.Volumes[index]
+		}
+	}
+	return nil
+}
+
+func findVolumeMountByName(deployment *appsv1.Deployment, containerName, name string) *corev1.VolumeMount {
+	for containerIndex := range deployment.Spec.Template.Spec.Containers {
+		container := &deployment.Spec.Template.Spec.Containers[containerIndex]
+		if container.Name != containerName {
+			continue
+		}
+		for mountIndex := range container.VolumeMounts {
+			if container.VolumeMounts[mountIndex].Name == name {
+				return &container.VolumeMounts[mountIndex]
+			}
+		}
+	}
+	return nil
+}
+
 func TestInflateTLSCertGeneration(t *testing.T) {
 	log := testlogr.NewTestLogger(t)
 


### PR DESCRIPTION
Create deterministic bootstrap-token Secret/RBAC resources and mount wiring when programmatic bootstrap is enabled. Clean up stale resources when disabled and cover rendering/reconcile behavior with focused tests.

Example outputs:

```bash
# Shows the bootstrap-token Secret volume and read-only quay-app mount.
   oc get deploy skynet-quay-app -n quay-enterprise -o json | jq '{
     volumes: [.spec.template.spec.volumes[] | select(.name == "bootstrap-token")],
     quayAppMounts: [.spec.template.spec.containers[] | select(.name == "quay-app") | .volumeMounts[] | select(.name == "bootstrap-token")]
   }'

{
  "volumes": [
    {
      "name": "bootstrap-token",
      "secret": {
        "defaultMode": 420,
        "secretName": "skynet-bootstrap-token"
      }
    }
  ],
  "quayAppMounts": [
    {
      "mountPath": "/var/lib/quay/bootstrap-token",
      "name": "bootstrap-token",
      "readOnly": true
    }
  ]
}
```


```bash
# Shows the narrow Role: only get/update on the skynet-bootstrap-token Secret.
oc get role skynet-bootstrap-token -n quay-enterprise -o yaml
```
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  creationTimestamp: "2026-07-02T13:49:37Z"
  labels:
    quay-operator/quayregistry: skynet
  name: skynet-bootstrap-token
  namespace: quay-enterprise
  ownerReferences:
  - apiVersion: quay.redhat.com/v1
    kind: QuayRegistry
    name: skynet
    uid: 78b6cc46-cb0e-4229-86e6-f4fd353a8d6d
  resourceVersion: "67928"
  uid: 06e36f38-3b57-4f06-9b31-6797fb50a231
rules:
- apiGroups:
  - ""
  resourceNames:
  - skynet-bootstrap-token
  resources:
  - secrets
  verbs:
  - get
  - update
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for programmatic bootstrap token handling in deployments and generated configuration.
  * When enabled, the app now mounts a dedicated token volume and includes the required access settings automatically.

* **Bug Fixes**
  * Disabled programmatic bootstrap now cleans up stale token-related resources instead of blocking reconciliation.
  * Existing token data is preserved when the feature is enabled, avoiding unintended overwrites.

* **Tests**
  * Added coverage for enable/disable behavior, generated resource wiring, and cleanup of obsolete resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->