### PR TITLE
PROJQUAY-12005: fix(mirror): add pushgateway Service and auto-configure URL

### DIFF
--- a/kustomize/components/mirror/kustomization.yaml
+++ b/kustomize/components/mirror/kustomization.yaml
@@ -1,8 +1,9 @@
 # Mirror component adds repository mirroring to the Quay registry.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-resources: 
+resources:
   - ./mirror.deployment.yaml
+  - ./mirror-pushgateway.service.yaml
 vars:
   - name: QUAY_APP_SERVICE_HOST
     objref:

--- a/kustomize/components/mirror/mirror-pushgateway.service.yaml
+++ b/kustomize/components/mirror/mirror-pushgateway.service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: quay-mirror-pushgateway
+  labels:
+    quay-component: mirror
+  annotations:
+    quay-component: mirror
+spec:
+  ports:
+    - name: pushgateway
+      port: 9091
+      targetPort: 9091
+      protocol: TCP
+  selector:
+    quay-component: quay-mirror
+  type: ClusterIP

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -1008,6 +1008,14 @@ func Inflate(
 		injectProgrammaticBootstrapTokenConfig(quay, parsedUserConfig)
 	}
 
+	if v1.ComponentIsManaged(quay.Spec.Components, v1.ComponentMirror) {
+		if _, ok := parsedUserConfig["PROMETHEUS_PUSHGATEWAY_URL"]; !ok {
+			parsedUserConfig["PROMETHEUS_PUSHGATEWAY_URL"] = fmt.Sprintf(
+				"http://%s-quay-mirror-pushgateway:9091", quay.GetName(),
+			)
+		}
+	}
+
 	componentConfigFiles["config.yaml"] = encode(parsedUserConfig)
 
 	for _, component := range quay.Spec.Components {

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -487,6 +487,7 @@ var quayComponents = map[string][]client.Object{
 	},
 	"mirror": {
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "quay-mirror"}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "quay-mirror-pushgateway"}},
 	},
 	"horizontalpodautoscaler": {
 		&autoscaling.HorizontalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "quay-app"}},
@@ -950,6 +951,91 @@ func TestInflate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInflatePushgatewayURLInjected(t *testing.T) {
+	log := testlogr.NewTestLogger(t)
+	ctx := quaycontext.QuayRegistryContext{}
+
+	quayRegistry := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: v1.QuayRegistrySpec{
+			Components: []v1.Component{
+				{Kind: "postgres", Managed: true},
+				{Kind: "clair", Managed: false},
+				{Kind: "clairpostgres", Managed: false},
+				{Kind: "redis", Managed: true},
+				{Kind: "objectstorage", Managed: false},
+				{Kind: "mirror", Managed: true},
+				{Kind: "horizontalpodautoscaler", Managed: false},
+			},
+		},
+	}
+
+	configBundle := &corev1.Secret{
+		Data: map[string][]byte{
+			"config.yaml": encode(map[string]interface{}{"SERVER_HOSTNAME": "quay.io"}),
+		},
+	}
+
+	pieces, err := Inflate(&ctx, quayRegistry, configBundle, log, false)
+	assert.Nil(t, err)
+	assert.NotNil(t, pieces)
+
+	for _, obj := range pieces {
+		objectMeta, _ := meta.Accessor(obj)
+		if strings.Contains(objectMeta.GetName(), configSecretPrefix) {
+			secret := obj.(*corev1.Secret)
+			config := decode(secret.Data["config.yaml"]).(map[string]interface{})
+			assert.Equal(t, "http://test-quay-mirror-pushgateway:9091", config["PROMETHEUS_PUSHGATEWAY_URL"])
+			return
+		}
+	}
+	t.Fatal("config secret not found in inflated objects")
+}
+
+func TestInflatePushgatewayURLNotOverridden(t *testing.T) {
+	log := testlogr.NewTestLogger(t)
+	ctx := quaycontext.QuayRegistryContext{}
+
+	quayRegistry := &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: v1.QuayRegistrySpec{
+			Components: []v1.Component{
+				{Kind: "postgres", Managed: true},
+				{Kind: "clair", Managed: false},
+				{Kind: "clairpostgres", Managed: false},
+				{Kind: "redis", Managed: true},
+				{Kind: "objectstorage", Managed: false},
+				{Kind: "mirror", Managed: true},
+				{Kind: "horizontalpodautoscaler", Managed: false},
+			},
+		},
+	}
+
+	configBundle := &corev1.Secret{
+		Data: map[string][]byte{
+			"config.yaml": encode(map[string]interface{}{
+				"SERVER_HOSTNAME":            "quay.io",
+				"PROMETHEUS_PUSHGATEWAY_URL": "http://custom-pushgateway:9091",
+			}),
+		},
+	}
+
+	pieces, err := Inflate(&ctx, quayRegistry, configBundle, log, false)
+	assert.Nil(t, err)
+	assert.NotNil(t, pieces)
+
+	for _, obj := range pieces {
+		objectMeta, _ := meta.Accessor(obj)
+		if strings.Contains(objectMeta.GetName(), configSecretPrefix) {
+			secret := obj.(*corev1.Secret)
+			config := decode(secret.Data["config.yaml"]).(map[string]interface{})
+			assert.Equal(t, "http://custom-pushgateway:9091", config["PROMETHEUS_PUSHGATEWAY_URL"])
+			return
+		}
+	}
+	t.Fatal("config secret not found in inflated objects")
 }
 
 func TestProgrammaticBootstrapEnabledStrictBool(t *testing.T) {


### PR DESCRIPTION
## Summary

Companion to [quay/quay#6249](https://github.com/quay/quay/pull/6249). That PR fixes stale mirror health data by having the API pod fetch metrics from the mirror worker's PushGateway via `PROMETHEUS_PUSHGATEWAY_URL`. However, the operator does not create a Service for the mirror worker's pushgateway or set this config value — customers would have to configure both manually.

The existing `quay-metrics` Service (from the monitoring component) cannot be used because its `quay-monitor: "true"` selector routes to both quay-app and mirror pods. The API pod would randomly connect to itself instead of the mirror worker.

## Changes

- Add `quay-mirror-pushgateway` Service to the mirror component, targeting only `quay-component: quay-mirror` on port 9091
- Auto-inject `PROMETHEUS_PUSHGATEWAY_URL` into the generated Quay config when mirror is managed (user-provided values take precedence)

## Why the mirror component, not monitoring

- The pushgateway URL is needed for the health endpoint regardless of whether Prometheus monitoring is enabled
- `monitoring: managed: true` requires AllNamespaces OperatorGroup mode — many deployments disable it
- The mirror component already owns mirror-related config (`FEATURE_REPO_MIRROR`, `REPO_MIRROR_INTERVAL`)

## Test plan

- [x] Deployed on OCP 4.20 with local operator (`make run` with `RELATED_IMAGE_COMPONENT_QUAY` override)
- [x] Verified Service created: `quay-test-quay-mirror-pushgateway` with correct selector
- [x] Verified config injected: `PROMETHEUS_PUSHGATEWAY_URL: http://<name>-quay-mirror-pushgateway:9091`
- [x] Verified health endpoint returns `workers.active: 1` (was `0` without this fix)
- [x] Verified API values match direct pushgateway scrape

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Kubernetes Service for the mirror component’s metrics push gateway.
  * Automatically sets the default `PROMETHEUS_PUSHGATEWAY_URL` for the mirror component when it isn’t already configured.
* **Bug Fixes**
  * Ensures the mirror component’s push gateway Service is included when deploying the mirror component.
* **Tests**
  * Added coverage to verify default push gateway URL injection and that user-provided values are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->