### PR TITLE
PROJQUAY-12322: tls: separate TLS 1.3 ciphersuites from TLS 1.2 ciphers

### DIFF
--- a/controllers/quay/tls.go
+++ b/controllers/quay/tls.go
@@ -39,6 +39,9 @@ func (r *QuayRegistryReconciler) checkTLSSecurityProfile(
 	if _, ok := config["SSL_CIPHERS"]; ok {
 		return nil
 	}
+	if _, ok := config["SSL_CIPHERSUITES"]; ok {
+		return nil
+	}
 
 	// Try to read the APIServer "cluster" resource.
 	var apiServer configv1.APIServer
@@ -56,38 +59,38 @@ func (r *QuayRegistryReconciler) checkTLSSecurityProfile(
 	}
 
 	// Translate the profile into nginx/OpenSSL formatted strings.
-	protocols, ciphers := translateTLSProfile(apiServer.Spec.TLSSecurityProfile)
+	protocols, ciphers, ciphersuites := translateTLSProfile(apiServer.Spec.TLSSecurityProfile)
 	qctx.SSLProtocols = protocols
 	qctx.SSLCiphers = ciphers
+	qctx.SSLCiphersuites = ciphersuites
 	return nil
 }
 
 // translateTLSProfile converts an OpenShift TLSSecurityProfile into
 // space-separated protocol versions (nginx format) and colon-separated cipher
 // names (OpenSSL format).
-func translateTLSProfile(profile *configv1.TLSSecurityProfile) (protocols string, ciphers string) {
-	// A nil profile means the cluster default, which is Intermediate.
+func translateTLSProfile(profile *configv1.TLSSecurityProfile) (protocols, ciphers, ciphersuites string) {
+	translate := func(spec *configv1.TLSProfileSpec) (string, string, string) {
+		tls12, tls13 := splitCiphers(spec.Ciphers)
+		return tlsVersionToProtocols(spec.MinTLSVersion), joinCiphers(tls12), joinCiphers(tls13)
+	}
+
 	if profile == nil {
-		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-		return tlsVersionToProtocols(spec.MinTLSVersion), tlsCiphersToString(spec.Ciphers)
+		return translate(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
 	}
 
 	switch profile.Type {
 	case configv1.TLSProfileCustomType:
 		if profile.Custom != nil {
-			return tlsVersionToProtocols(profile.Custom.MinTLSVersion),
-				tlsCiphersToString(profile.Custom.Ciphers)
+			return translate(&profile.Custom.TLSProfileSpec)
 		}
-		// Custom type without custom spec — fall through to Intermediate.
-		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-		return tlsVersionToProtocols(spec.MinTLSVersion), tlsCiphersToString(spec.Ciphers)
+		return translate(configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
 	default:
 		spec, ok := configv1.TLSProfiles[profile.Type]
 		if !ok {
-			// Unknown profile type — default to Intermediate.
 			spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 		}
-		return tlsVersionToProtocols(spec.MinTLSVersion), tlsCiphersToString(spec.Ciphers)
+		return translate(spec)
 	}
 }
 
@@ -110,8 +113,17 @@ func tlsVersionToProtocols(minVersion configv1.TLSProtocolVersion) string {
 	}
 }
 
-// tlsCiphersToString joins cipher suite names with colons, producing the
-// format expected by OpenSSL (and therefore nginx's ssl_ciphers directive).
-func tlsCiphersToString(ciphers []string) string {
+func splitCiphers(ciphers []string) (tls12, tls13 []string) {
+	for _, c := range ciphers {
+		if strings.HasPrefix(c, "TLS_") {
+			tls13 = append(tls13, c)
+		} else {
+			tls12 = append(tls12, c)
+		}
+	}
+	return
+}
+
+func joinCiphers(ciphers []string) string {
 	return strings.Join(ciphers, ":")
 }

--- a/controllers/quay/tls_test.go
+++ b/controllers/quay/tls_test.go
@@ -15,39 +15,49 @@ import (
 
 func TestTranslateTLSProfile(t *testing.T) {
 	for _, tt := range []struct {
-		name              string
-		profile           *configv1.TLSSecurityProfile
-		expectedProtocols string
-		expectedCiphers   string
+		name                 string
+		profile              *configv1.TLSSecurityProfile
+		expectedProtocols    string
+		expectedCiphers      string
+		expectedCiphersuites string
+		ciphersEmpty         bool
+		ciphersuitesEmpty    bool
 	}{
 		{
-			name:              "nil profile defaults to Intermediate",
-			profile:           nil,
-			expectedProtocols: "TLSv1.2 TLSv1.3",
+			name:                 "nil profile defaults to Intermediate",
+			profile:              nil,
+			expectedProtocols:    "TLSv1.2 TLSv1.3",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384",
+			expectedCiphersuites: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",
 		},
 		{
 			name: "Old profile",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileOldType,
 			},
-			expectedProtocols: "TLSv1 TLSv1.1 TLSv1.2 TLSv1.3",
+			expectedProtocols:    "TLSv1 TLSv1.1 TLSv1.2 TLSv1.3",
+			expectedCiphersuites: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",
 		},
 		{
 			name: "Intermediate profile",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileIntermediateType,
 			},
-			expectedProtocols: "TLSv1.2 TLSv1.3",
+			expectedProtocols:    "TLSv1.2 TLSv1.3",
+			expectedCiphers:      "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384",
+			expectedCiphersuites: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",
 		},
 		{
-			name: "Modern profile",
+			name: "Modern profile has empty ciphers and non-empty ciphersuites",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileModernType,
 			},
-			expectedProtocols: "TLSv1.3",
+			expectedProtocols:    "TLSv1.3",
+			ciphersEmpty:         true,
+			expectedCiphersuites: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",
 		},
 		{
-			name: "Custom profile with TLS 1.2",
+			name: "Custom profile with TLS 1.2 ciphers only",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileCustomType,
 				Custom: &configv1.CustomTLSProfile{
@@ -59,6 +69,25 @@ func TestTranslateTLSProfile(t *testing.T) {
 			},
 			expectedProtocols: "TLSv1.2 TLSv1.3",
 			expectedCiphers:   "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384",
+			ciphersuitesEmpty: true,
+		},
+		{
+			name: "Custom profile with mixed TLS 1.2 and 1.3 ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+						},
+					},
+				},
+			},
+			expectedProtocols:    "TLSv1.2 TLSv1.3",
+			expectedCiphers:      "ECDHE-RSA-AES128-GCM-SHA256",
+			expectedCiphersuites: "TLS_AES_128_GCM_SHA256",
 		},
 		{
 			name: "Custom profile with empty minTLSVersion defaults to TLS 1.2",
@@ -73,6 +102,7 @@ func TestTranslateTLSProfile(t *testing.T) {
 			},
 			expectedProtocols: "TLSv1.2 TLSv1.3",
 			expectedCiphers:   "ECDHE-RSA-AES128-GCM-SHA256",
+			ciphersuitesEmpty: true,
 		},
 		{
 			name: "Custom type with nil Custom spec defaults to Intermediate",
@@ -83,19 +113,21 @@ func TestTranslateTLSProfile(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			protocols, ciphers := translateTLSProfile(tt.profile)
+			protocols, ciphers, ciphersuites := translateTLSProfile(tt.profile)
 			if protocols != tt.expectedProtocols {
 				t.Errorf("protocols = %q, want %q", protocols, tt.expectedProtocols)
 			}
 			if tt.expectedCiphers != "" && ciphers != tt.expectedCiphers {
 				t.Errorf("ciphers = %q, want %q", ciphers, tt.expectedCiphers)
 			}
-			// For named profiles, just verify ciphers are non-empty.
-			if tt.expectedCiphers == "" && tt.profile != nil &&
-				tt.profile.Type != configv1.TLSProfileCustomType {
-				if ciphers == "" {
-					t.Error("expected non-empty ciphers for named profile")
-				}
+			if tt.ciphersEmpty && ciphers != "" {
+				t.Errorf("ciphers should be empty, got %q", ciphers)
+			}
+			if tt.expectedCiphersuites != "" && ciphersuites != tt.expectedCiphersuites {
+				t.Errorf("ciphersuites = %q, want %q", ciphersuites, tt.expectedCiphersuites)
+			}
+			if tt.ciphersuitesEmpty && ciphersuites != "" {
+				t.Errorf("ciphersuites should be empty, got %q", ciphersuites)
 			}
 		})
 	}
@@ -121,15 +153,35 @@ func TestTlsVersionToProtocols(t *testing.T) {
 	}
 }
 
-func TestTlsCiphersToString(t *testing.T) {
-	result := tlsCiphersToString([]string{"A", "B", "C"})
-	if result != "A:B:C" {
-		t.Errorf("tlsCiphersToString = %q, want %q", result, "A:B:C")
+func TestSplitCiphers(t *testing.T) {
+	tls12, tls13 := splitCiphers([]string{
+		"TLS_AES_128_GCM_SHA256",
+		"ECDHE-RSA-AES128-GCM-SHA256",
+		"TLS_CHACHA20_POLY1305_SHA256",
+		"ECDHE-RSA-AES256-GCM-SHA384",
+	})
+	if len(tls12) != 2 {
+		t.Errorf("expected 2 TLS 1.2 ciphers, got %d: %v", len(tls12), tls12)
+	}
+	if len(tls13) != 2 {
+		t.Errorf("expected 2 TLS 1.3 ciphers, got %d: %v", len(tls13), tls13)
 	}
 
-	result = tlsCiphersToString(nil)
+	tls12, tls13 = splitCiphers(nil)
+	if len(tls12) != 0 || len(tls13) != 0 {
+		t.Errorf("expected empty slices for nil input, got tls12=%v tls13=%v", tls12, tls13)
+	}
+}
+
+func TestJoinCiphers(t *testing.T) {
+	result := joinCiphers([]string{"A", "B", "C"})
+	if result != "A:B:C" {
+		t.Errorf("joinCiphers = %q, want %q", result, "A:B:C")
+	}
+
+	result = joinCiphers(nil)
 	if result != "" {
-		t.Errorf("tlsCiphersToString(nil) = %q, want empty", result)
+		t.Errorf("joinCiphers(nil) = %q, want empty", result)
 	}
 }
 
@@ -155,6 +207,10 @@ func TestCheckTLSSecurityProfile_UserOverride(t *testing.T) {
 		{
 			name:       "user set SSL_CIPHERS",
 			configYAML: "SSL_CIPHERS:\n- ECDHE-RSA-AES128-GCM-SHA256",
+		},
+		{
+			name:       "user set SSL_CIPHERSUITES",
+			configYAML: "SSL_CIPHERSUITES:\n- TLS_AES_128_GCM_SHA256",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -242,8 +298,11 @@ func TestCheckTLSSecurityProfile_WithAPIServer(t *testing.T) {
 	if qctx.SSLProtocols != "TLSv1.3" {
 		t.Errorf("SSLProtocols = %q, want %q", qctx.SSLProtocols, "TLSv1.3")
 	}
-	if qctx.SSLCiphers == "" {
-		t.Error("expected non-empty SSLCiphers for Modern profile")
+	if qctx.SSLCiphers != "" {
+		t.Errorf("SSLCiphers should be empty for Modern profile (TLS 1.3 only), got %q", qctx.SSLCiphers)
+	}
+	if qctx.SSLCiphersuites == "" {
+		t.Error("expected non-empty SSLCiphersuites for Modern profile")
 	}
 }
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -19,8 +19,9 @@ type QuayRegistryContext struct {
 	TLSSecretHash       string
 
 	// TLS Security Profile (from OpenShift APIServer)
-	SSLProtocols string // e.g. "TLSv1.2 TLSv1.3" (nginx format)
-	SSLCiphers   string // e.g. "ECDHE-RSA-AES128-GCM-SHA256:..." (OpenSSL format)
+	SSLProtocols    string // e.g. "TLSv1.2 TLSv1.3" (nginx format)
+	SSLCiphers      string // e.g. "ECDHE-RSA-AES128-GCM-SHA256:..." (TLS 1.2 ciphers, OpenSSL format)
+	SSLCiphersuites string // e.g. "TLS_AES_128_GCM_SHA256:..." (TLS 1.3 ciphersuites, OpenSSL format)
 
 	// Object Storage
 	SupportsObjectStorage    bool

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -1002,6 +1002,11 @@ func Inflate(
 			parsedUserConfig["SSL_CIPHERS"] = strings.Split(ctx.SSLCiphers, ":")
 		}
 	}
+	if ctx.SSLCiphersuites != "" {
+		if _, ok := parsedUserConfig["SSL_CIPHERSUITES"]; !ok {
+			parsedUserConfig["SSL_CIPHERSUITES"] = strings.Split(ctx.SSLCiphersuites, ":")
+		}
+	}
 
 	programmaticBootstrapEnabled := ProgrammaticBootstrapEnabled(parsedUserConfig)
 	if programmaticBootstrapEnabled {


### PR DESCRIPTION
## Summary

- **Bug:** When OpenShift APIServer `tlsSecurityProfile` is set to `Modern` (TLS 1.3 only), the operator passes TLS 1.3 cipher names (`TLS_AES_128_GCM_SHA256`, etc.) to Quay's `SSL_CIPHERS` config. This maps to nginx's `ssl_ciphers` directive, which calls `SSL_CTX_set_cipher_list()` — but TLS 1.3 ciphers require `SSL_CTX_set_ciphersuites()`. Nginx crashes with `no cipher match`.
- **Fix:** Split `translateTLSProfile()` to return separate TLS 1.2 ciphers and TLS 1.3 ciphersuites (distinguished by the `TLS_` prefix). TLS 1.3 ciphers are now emitted as `SSL_CIPHERSUITES` in Quay config, which maps to nginx's `ssl_conf_command Ciphersuites` directive.
- Old/Intermediate/Custom profiles continue to work correctly — TLS 1.3 ciphers in mixed lists are automatically routed to the correct directive.

**JIRA:** https://issues.redhat.com/browse/PROJQUAY-12322

## Changed Files

| File | Change |
|------|--------|
| `pkg/context/context.go` | Added `SSLCiphersuites` field to `QuayRegistryContext` |
| `controllers/quay/tls.go` | `translateTLSProfile` returns 3 values; added `splitCiphers()` / `joinCiphers()` |
| `pkg/kustomize/kustomize.go` | Inject `SSL_CIPHERSUITES` into generated Quay config |
| `controllers/quay/tls_test.go` | Updated tests for new signature; added Modern and mixed-cipher regression tests |

## Test plan

- [x] `make fmt` passes
- [x] `make vet` passes
- [x] `make test` — all unit tests pass
- [ ] Deploy on OpenShift 4.22 with APIServer `tlsSecurityProfile: Modern` — verify Quay pods start without nginx crash
- [ ] Verify Intermediate profile still works (TLS 1.2 ciphers in `SSL_CIPHERS`, TLS 1.3 in `SSL_CIPHERSUITES`)
- [ ] Verify Custom profile with mixed ciphers splits correctly
- [ ] Verify user-provided `SSL_CIPHERS`/`SSL_CIPHERSUITES` in configBundleSecret still takes precedence

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring TLS cipher suites separately from TLS 1.2 ciphers.
  * Modern TLS profiles now populate cipher suites and related settings.
  * Generated registry configuration injects `SSL_CIPHERSUITES` when configured, without overriding existing user values.

* **Bug Fixes**
  * Improved TLS profile translation and override handling, including skipping inheritance when users already specify cipher suites.
  * Updated TLS cipher processing to correctly split and join cipher groups.

* **Tests**
  * Expanded TLS profile translation tests to validate cipher-suites behavior.
  * Added unit tests for cipher splitting/joining logic and updated existing TLS security profile expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->