### PR TITLE
PROJQUAY-12383: fix(cmpstatus): handle unmanaged component HPAs

### DIFF
--- a/pkg/cmpstatus/evaluator_test.go
+++ b/pkg/cmpstatus/evaluator_test.go
@@ -83,7 +83,7 @@ func TestEvaluate(t *testing.T) {
 					Type:    qv1.ComponentHPAReady,
 					Status:  metav1.ConditionFalse,
 					Reason:  qv1.ConditionReasonComponentNotReady,
-					Message: "Horizontal pod autoscaler not found",
+					Message: "Horizontal pod autoscaler registry-quay-app not found",
 				},
 				{
 					Type:    qv1.ComponentRouteReady,

--- a/pkg/cmpstatus/hpa.go
+++ b/pkg/cmpstatus/hpa.go
@@ -39,7 +39,15 @@ func (h *HPA) Check(ctx context.Context, reg qv1.QuayRegistry) (qv1.Condition, e
 		}, nil
 	}
 
-	for _, hpasuffix := range []string{"quay-app", "clair-app", "quay-mirror"} {
+	hpaSuffixes := []string{"quay-app"}
+	if qv1.ComponentIsManaged(reg.Spec.Components, qv1.ComponentClair) {
+		hpaSuffixes = append(hpaSuffixes, "clair-app")
+	}
+	if qv1.ComponentIsManaged(reg.Spec.Components, qv1.ComponentMirror) {
+		hpaSuffixes = append(hpaSuffixes, "quay-mirror")
+	}
+
+	for _, hpasuffix := range hpaSuffixes {
 		nsn := types.NamespacedName{
 			Namespace: reg.Namespace,
 			Name:      fmt.Sprintf("%s-%s", reg.Name, hpasuffix),
@@ -52,7 +60,7 @@ func (h *HPA) Check(ctx context.Context, reg qv1.QuayRegistry) (qv1.Condition, e
 					Type:           qv1.ComponentHPAReady,
 					Status:         metav1.ConditionFalse,
 					Reason:         qv1.ConditionReasonComponentNotReady,
-					Message:        "Horizontal pod autoscaler not found",
+					Message:        fmt.Sprintf("Horizontal pod autoscaler %s not found", nsn.Name),
 					LastUpdateTime: metav1.NewTime(time.Now()),
 				}, nil
 			}

--- a/pkg/cmpstatus/hpa_test.go
+++ b/pkg/cmpstatus/hpa_test.go
@@ -14,6 +14,22 @@ import (
 	qv1 "github.com/quay/quay-operator/apis/quay/v1"
 )
 
+func ownedHPA(name string) *asv2.HorizontalPodAutoscaler {
+	return &asv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "QuayRegistry",
+					Name:       "registry",
+					APIVersion: "quay.redhat.com/v1",
+					UID:        "uid",
+				},
+			},
+		},
+	}
+}
+
 func TestHPACheck(t *testing.T) {
 	for _, tt := range []struct {
 		name string
@@ -66,7 +82,7 @@ func TestHPACheck(t *testing.T) {
 				Type:    qv1.ComponentHPAReady,
 				Status:  metav1.ConditionFalse,
 				Reason:  qv1.ConditionReasonComponentNotReady,
-				Message: "Horizontal pod autoscaler not found",
+				Message: "Horizontal pod autoscaler registry-quay-app not found",
 			},
 		},
 		{
@@ -114,49 +130,128 @@ func TestHPACheck(t *testing.T) {
 							Kind:    qv1.ComponentHPA,
 							Managed: true,
 						},
+						{
+							Kind:    qv1.ComponentClair,
+							Managed: true,
+						},
+						{
+							Kind:    qv1.ComponentMirror,
+							Managed: true,
+						},
 					},
 				},
 			},
 			objs: []client.Object{
-				&asv2.HorizontalPodAutoscaler{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "registry-quay-app",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Kind:       "QuayRegistry",
-								Name:       "registry",
-								APIVersion: "quay.redhat.com/v1",
-								UID:        "uid",
-							},
+				ownedHPA("registry-quay-app"),
+				ownedHPA("registry-quay-mirror"),
+				ownedHPA("registry-clair-app"),
+			},
+			cond: qv1.Condition{
+				Type:    qv1.ComponentHPAReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  qv1.ConditionReasonComponentReady,
+				Message: "Horizontal pod autoscaler found",
+			},
+		},
+		{
+			name: "hpa found with clair unmanaged",
+			quay: qv1.QuayRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "registry",
+					UID:  "uid",
+				},
+				Spec: qv1.QuayRegistrySpec{
+					ConfigBundleSecret: "config-bundle",
+					Components: []qv1.Component{
+						{
+							Kind:    qv1.ComponentHPA,
+							Managed: true,
+						},
+						{
+							Kind:    qv1.ComponentClair,
+							Managed: false,
+						},
+						{
+							Kind:    qv1.ComponentMirror,
+							Managed: true,
 						},
 					},
 				},
-				&asv2.HorizontalPodAutoscaler{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "registry-quay-mirror",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Kind:       "QuayRegistry",
-								Name:       "registry",
-								APIVersion: "quay.redhat.com/v1",
-								UID:        "uid",
-							},
+			},
+			objs: []client.Object{
+				ownedHPA("registry-quay-app"),
+				ownedHPA("registry-quay-mirror"),
+			},
+			cond: qv1.Condition{
+				Type:    qv1.ComponentHPAReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  qv1.ConditionReasonComponentReady,
+				Message: "Horizontal pod autoscaler found",
+			},
+		},
+		{
+			name: "hpa found with mirror unmanaged",
+			quay: qv1.QuayRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "registry",
+					UID:  "uid",
+				},
+				Spec: qv1.QuayRegistrySpec{
+					ConfigBundleSecret: "config-bundle",
+					Components: []qv1.Component{
+						{
+							Kind:    qv1.ComponentHPA,
+							Managed: true,
+						},
+						{
+							Kind:    qv1.ComponentClair,
+							Managed: true,
+						},
+						{
+							Kind:    qv1.ComponentMirror,
+							Managed: false,
 						},
 					},
 				},
-				&asv2.HorizontalPodAutoscaler{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "registry-clair-app",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Kind:       "QuayRegistry",
-								Name:       "registry",
-								APIVersion: "quay.redhat.com/v1",
-								UID:        "uid",
-							},
+			},
+			objs: []client.Object{
+				ownedHPA("registry-quay-app"),
+				ownedHPA("registry-clair-app"),
+			},
+			cond: qv1.Condition{
+				Type:    qv1.ComponentHPAReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  qv1.ConditionReasonComponentReady,
+				Message: "Horizontal pod autoscaler found",
+			},
+		},
+		{
+			name: "hpa found with clair and mirror unmanaged",
+			quay: qv1.QuayRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "registry",
+					UID:  "uid",
+				},
+				Spec: qv1.QuayRegistrySpec{
+					ConfigBundleSecret: "config-bundle",
+					Components: []qv1.Component{
+						{
+							Kind:    qv1.ComponentHPA,
+							Managed: true,
+						},
+						{
+							Kind:    qv1.ComponentClair,
+							Managed: false,
+						},
+						{
+							Kind:    qv1.ComponentMirror,
+							Managed: false,
 						},
 					},
 				},
+			},
+			objs: []client.Object{
+				ownedHPA("registry-quay-app"),
 			},
 			cond: qv1.Condition{
 				Type:    qv1.ComponentHPAReady,


### PR DESCRIPTION
## Summary
- Fix `ComponentHPAReady=False` / `Available=False` when HPA is managed but mirror or clair (or both) are unmanaged
- Only require clair-app and quay-mirror HPAs when their backing components are managed
- Include the missing HPA name in `ComponentHPAReady` failure messages for debuggability
- Add regression test coverage for all unmanaged component combinations

## Root Cause
The HPA health checker in `pkg/cmpstatus/hpa.go` hard-coded a loop over all three HPAs (`quay-app`, `clair-app`, `quay-mirror`) without checking whether the respective backing component is managed. When mirror or clair is unmanaged, kustomize never emits their HPA manifests, so the checker hits a not-found and permanently reports `ComponentHPAReady=False`, which cascades to `Available=False` — even though Quay is fully functional.

## Changes
| File | Change |
|------|--------|
| `pkg/cmpstatus/hpa.go` | Build HPA suffix list dynamically: always include `quay-app`, conditionally include `clair-app` (if clair managed) and `quay-mirror` (if mirror managed). Include HPA name in not-found error message. |
| `pkg/cmpstatus/hpa_test.go` | Add `ownedHPA()` test helper. Add 3 new test cases: clair unmanaged, mirror unmanaged, both unmanaged. Update existing "all managed" test to explicitly declare clair+mirror as managed. Update expected error message. |
| `pkg/cmpstatus/evaluator_test.go` | Update expected error message to include HPA name. |

## Jira
- [PROJQUAY-12383](https://redhat.atlassian.net/browse/PROJQUAY-12383)

## Test plan
- [x] `go test ./pkg/cmpstatus` — all unit tests pass
- [ ] Deploy QuayRegistry with `horizontalpodautoscaler: managed: true`, `mirror: managed: false` → verify `ComponentHPAReady=True` and `Available=True`
- [ ] Deploy QuayRegistry with `horizontalpodautoscaler: managed: true`, `clair: managed: false` → verify `ComponentHPAReady=True` and `Available=True`
- [ ] Deploy QuayRegistry with `horizontalpodautoscaler: managed: true`, both clair and mirror unmanaged → verify `ComponentHPAReady=True`
- [ ] Deploy QuayRegistry with all components managed (default) → verify no regression, all 3 HPAs checked, `Available=True`
- [ ] Verify not-found error message includes HPA name (e.g. `"Horizontal pod autoscaler registry-quay-app not found"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)