### PR TITLE
fix: Move CodeRabbit tools config under reviews so linters run

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,6 +27,14 @@ early_access: false
 # Review profile & presentation
 # -----------------------------------------------------------------------------
 reviews:
+  tools:
+    # golangci-lint — no project-level config file; uses pre-commit default settings.
+    golangci-lint:
+      enabled: true
+    # gitleaks — scan for leaked secrets/credentials in diffs.
+    gitleaks:
+      enabled: true
+
   profile: chill
   high_level_summary: true
   review_status: true
@@ -295,14 +303,6 @@ knowledge_base:
 # -----------------------------------------------------------------------------
 # Tools — static analysis integrations
 # -----------------------------------------------------------------------------
-tools:
-  # golangci-lint — no project-level config file; uses pre-commit default settings.
-  golangci-lint:
-    enabled: true
-  # gitleaks — scan for leaked secrets/credentials in diffs.
-  gitleaks:
-    enabled: true
-
 # -----------------------------------------------------------------------------
 # Chat — auto-reply to @coderabbitai mentions
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Move CodeRabbit tools config under reviews so linters run

## Changes

- Nest tools (golangci-lint, gitleaks) under reviews — top-level tools key is unrecognized

Fixes #1298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated linting and secret-detection checks during code reviews.
  * Updated review tool configuration for improved code quality and security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->