### PR TITLE
fix(#1298): nest tools block under reviews in CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -228,6 +228,17 @@ reviews:
           environment variables, not mutable tags like :latest.
 
   # ---------------------------------------------------------------------------
+  # Tools — static analysis integrations
+  # ---------------------------------------------------------------------------
+  tools:
+    # golangci-lint — no project-level config file; uses pre-commit default settings.
+    golangci-lint:
+      enabled: true
+    # gitleaks — scan for leaked secrets/credentials in diffs.
+    gitleaks:
+      enabled: true
+
+  # ---------------------------------------------------------------------------
   # Pre-merge checks — automated validation rules
   # ---------------------------------------------------------------------------
   pre_merge_checks:
@@ -291,17 +302,6 @@ knowledge_base:
       - "GEMINI.md"
   learnings:
     scope: local
-
-# -----------------------------------------------------------------------------
-# Tools — static analysis integrations
-# -----------------------------------------------------------------------------
-tools:
-  # golangci-lint — no project-level config file; uses pre-commit default settings.
-  golangci-lint:
-    enabled: true
-  # gitleaks — scan for leaked secrets/credentials in diffs.
-  gitleaks:
-    enabled: true
 
 # -----------------------------------------------------------------------------
 # Chat — auto-reply to @coderabbitai mentions


### PR DESCRIPTION
The `tools:` block in `.coderabbit.yaml` sat at the YAML document root, as a sibling of `reviews:`, `knowledge_base:` and `chat:`. The CodeRabbit v2 schema (https://coderabbit.ai/integrations/schema.v2.json) sets `additionalProperties: false` at the root and only allows `language`, `tone_instructions`, `early_access`, `enable_free_tier`, `inheritance`, `issue_enrichment`, `code_generation`, `reviews`, `knowledge_base` and `chat` there. `tools` is defined under `reviews`, so the root-level block was rejected as an unrecognized key — which is exactly the `Validation error: Unrecognized key: "tools"` warning CodeRabbit posted on #1296 — and both the golangci-lint and gitleaks integrations were silently disabled for every review.

This moves the block to `reviews.tools`, keeping the `golangci-lint` and `gitleaks` keys (both valid per the schema, each taking an `enabled` boolean) and their explanatory comments, and relocates the section banner as a nested subsection alongside the other `reviews.*` subsections. No settings change, only their position in the document.

---

Closes #1298

### Validation

- [x] `tools:` now sits inside the `reviews:` block (`.coderabbit.yaml` line 233), where the v2 schema defines it, with the `golangci-lint` and `gitleaks` keys and their `enabled` booleans unchanged
- [x] The file validated cleanly against schema.v2.json when the change was made
- [ ] **Not verifiable on this PR** — criteria 1 and 2 in the issue (no configuration warning; golangci-lint/gitleaks findings appearing in reviews) can only be confirmed *after* this merges. CodeRabbit reviews a fork PR using the target branch's configuration, so the review here reads `master`'s root-level `tools:` key and warns about it regardless of what this branch does. See [the comment below](https://github.com/quay/quay-operator/pull/1316#issuecomment-5404607148) for the details; both criteria should be checked on the first PR opened after this one lands.
