### PR TITLE
NO-ISSUE: docs(#1299): distinguish Ginkgo and testing.T guidance for test files

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -199,12 +199,17 @@ reviews:
           up an API server.
         - Cleanup: resources created in tests must be cleaned up via defer,
           t.Cleanup, or AfterEach. Flag leaked resources.
-        - No time.Sleep: for async assertions in the Ginkgo suite use
-          Eventually/Consistently with an explicit timeout and polling
-          interval. Flag time.Sleep anywhere.
-        - Assertion quality: Gomega assertions should include meaningful
-          context via .WithOffset() or descriptive wrappers; testing.T
-          failures should name the case and report got vs. want.
+        - No time.Sleep for asynchronous assertions: in the Ginkgo controller
+          suite use Eventually/Consistently with an explicit timeout and
+          polling interval. Flag time.Sleep that waits for asynchronous
+          behaviour; do not raise it against standard testing.T utility or
+          fake-client tests, which have nothing to wait on.
+        - Assertion quality: Gomega assertions should carry meaningful context
+          through descriptive failure messages or wrappers. .WithOffset() (and
+          the *WithOffset variants) does not add context — it only attributes
+          a failure to the caller of a shared helper, so only ask for it on
+          that basis. testing.T failures should name the case and report got
+          vs. want.
         - Table-driven tests: for functions with many input/output combinations,
           prefer table-driven patterns ([]struct{} loops in standard tests,
           DescribeTable in Ginkgo).

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -178,20 +178,36 @@ reviews:
         Unit and integration tests.
 
         Review checklist:
-        - Test framework: this project uses Ginkgo v2 with Gomega matchers
-          for controller tests, and standard testing package elsewhere. Verify
-          correct framework usage.
-        - envtest: controller tests use envtest (sigs.k8s.io/controller-runtime/pkg/envtest).
-          Verify proper test environment setup and teardown.
-        - Cleanup: resources created in tests must be cleaned up via defer or
-          AfterEach. Flag leaked resources.
-        - No time.Sleep: use gomega.Eventually/Consistently with timeout and
-          polling interval instead of time.Sleep for async assertions.
-        - Assertion messages: Gomega assertions should include meaningful
-          context via .WithOffset() or descriptive wrappers.
+        - Test framework: the framework follows what a test exercises, not the
+          directory it lives in. Controller INTEGRATION tests that drive the
+          full reconcile loop against a live API server use Ginkgo v2 with
+          Gomega matchers; they belong to the suite bootstrapped by
+          controllers/quay/suite_test.go and today consist of the
+          Describe("Reconciling a QuayRegistry") block in
+          controllers/quay/quayregistry_controller_test.go. Everything else
+          uses standard testing.T with table-driven subtests — including
+          utility and pure-function tests that live under controllers/quay/
+          (tls_test.go, features_test.go) and the fake-client testing.T tests
+          that sit alongside the Ginkgo block in
+          quayregistry_controller_test.go. Standard testing.T is the correct
+          and preferred choice for those; do not ask for conversion to
+          Ginkgo/Gomega on that basis alone.
+        - envtest: only the Ginkgo controller suite uses envtest
+          (sigs.k8s.io/controller-runtime/pkg/envtest). Verify proper test
+          environment setup and teardown there. Unit tests should keep using
+          sigs.k8s.io/controller-runtime/pkg/client/fake rather than standing
+          up an API server.
+        - Cleanup: resources created in tests must be cleaned up via defer,
+          t.Cleanup, or AfterEach. Flag leaked resources.
+        - No time.Sleep: for async assertions in the Ginkgo suite use
+          Eventually/Consistently with an explicit timeout and polling
+          interval. Flag time.Sleep anywhere.
+        - Assertion quality: Gomega assertions should include meaningful
+          context via .WithOffset() or descriptive wrappers; testing.T
+          failures should name the case and report got vs. want.
         - Table-driven tests: for functions with many input/output combinations,
-          prefer table-driven patterns (DescribeTable in Ginkgo, or
-          []struct{} loops in standard tests).
+          prefer table-driven patterns ([]struct{} loops in standard tests,
+          DescribeTable in Ginkgo).
 
     # RBAC manifests
     - path: "config/rbac/**/*.yaml"


### PR DESCRIPTION
The `**/*_test.go` path instruction said the project "uses Ginkgo v2 with Gomega matchers for controller tests, and standard testing package elsewhere". Read literally, that makes every file under `controllers/` Ginkgo territory, which is what produced the false-positive nitpick on #1296 asking for `controllers/quay/tls_test.go` to be converted to Ginkgo even though it is a pure-function table test.

What is actually in the tree: of 23 test files, only two import `onsi/ginkgo`. `controllers/quay/suite_test.go` bootstraps envtest and runs the specs, and `controllers/quay/quayregistry_controller_test.go` holds a single `Describe("Reconciling a QuayRegistry")` block. The remaining 87 top-level test functions — including 11 in that same controller test file, plus `controllers/quay/tls_test.go` and `features_test.go` — are standard `testing.T` table-driven tests using the fake client.

This rewords the instruction so the framework is tied to what a test exercises rather than to the directory it lives in: Ginkgo v2 + Gomega + envtest for controller integration tests that drive the reconcile loop, standard `testing.T` for utility and fake-client tests wherever they live, including under `controllers/quay/`. The envtest, `time.Sleep` and assertion bullets are scoped the same way so they no longer imply Gomega applies to every test file.

Config-only change; no Go code is touched.

---

Closes #1299

### Validation

- [x] Counts above taken from the tree at `master`: of the 23 `*_test.go` files, `git grep -l onsi/ginkgo -- '*_test.go'` returns exactly `controllers/quay/suite_test.go` and `controllers/quay/quayregistry_controller_test.go`
- [x] This change introduces no new schema errors: validated against [schema.v2.json](https://coderabbit.ai/integrations/schema.v2.json), both `master` and this branch produce the same single pre-existing error — `Additional properties are not allowed ('tools' was unexpected)`, from the root-level `tools:` key. That key is unrelated to this change and is fixed separately in #1316, after which the file validates with zero errors. The `path_instructions` entry edited here is schema-valid.
- [ ] The real check is behavioural — future PRs touching `controllers/quay/tls_test.go` should stop drawing Ginkgo-conversion nitpicks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified test review guidance for integration tests using envtest versus standard unit and utility tests.
  * Added guidance on test suite locations, cleanup requirements, and assertion practices.
  * Specified that envtest should be limited to the controller test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
