### PR TITLE
PROJQUAY-11653: fix: Add NetworkPolicy RBAC to satisfy Conforma olm.required_network_policy_rbac_for_operands

### DIFF
--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -177,6 +177,15 @@ spec:
                 - apiservers
               verbs:
                 - get
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
+                - patch
           serviceAccountName: quay-operator
       permissions:
         - rules:


### PR DESCRIPTION
## What

Adds a `clusterPermissions` rule to the ClusterServiceVersion granting
`create`, `delete`, `update`, `patch` on `networking.k8s.io/networkpolicies`
for the `quay-operator` service account.

## Why

A new Enterprise Contract (Conforma) policy rule,
[`olm.required_network_policy_rbac_for_operands`](https://conforma.dev/docs/policy/packages/release_olm.html#olm__required_network_policy_rbac_for_operands),
became effective org-wide on **2026-08-07**. It requires every OLM operator
bundle's CSV to declare RBAC for managing NetworkPolicy lifecycle for its
operands, and started failing Quay's operator bundle releases (first hit
during the Quay 3.18.1 z-stream release).

The operator does not currently create NetworkPolicy objects itself; this is
a forward-looking compliance grant with no behavior change, matching the
policy's stated intent ("operators are required to manage the network
policies of their operands").

## Rollout plan

This targets `master` first. Once merged, it should be cherry-picked to the
active `redhat-3.1x` release branches as their z-stream releases come up, so
each active y-stream stops failing this Conforma check on its next bundle
release. Starting with 3.18.x since that's the release currently blocked.

Related: `quay-bridge-operator` and `container-security-operator` bundles hit
the identical violation and will need the equivalent fix in their own repos.