### PR TITLE
PROJQUAY-5850: operator: support STS configuration flow via OLM and CCO

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This Operator can be installed on any Kubernetes cluster running the [Operator L
 
 You can find the latest operator release on [operatorhub.io](https://operatorhub.io/operator/project-quay).
 
+For AWS clusters using short-lived credentials, see [AWS STS authentication for unmanaged S3 storage](docs/sts-iam-setup.md).
+
 The fastest way to get started is by deploying the operator in an OCP/OKD cluster
 using the setup scripts provided in the `hack` directory:
 

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -32,6 +32,7 @@ test/chainsaw/
 ├── values-openshift.yaml       # Values for OpenShift (all components managed)
 ├── values-kind.yaml            # Values for KinD (route/objectstorage/monitoring/tls unmanaged)
 ├── reconcile/                  # Core reconcile lifecycle (create, mutate, delete, recover)
+├── sts_cco/                    # AWS STS/CCO provisioning and real S3 operations
 ├── hpa/                        # HorizontalPodAutoscaler management
 ├── resource_overrides/         # Resource requests/limits and PVC volume overrides
 ├── ca_rotation/                # CA certificate rotation (destructive, OpenShift only)
@@ -54,6 +55,18 @@ make test-e2e-destructive
 # KinD — excludes OpenShift-only tests (ca-rotation, hpa, unmanaged-route)
 hack/setup-kind-e2e.sh && make test-e2e-kind
 ```
+
+The STS/CCO scenario is intentionally excluded from the standard OpenShift and KinD targets. It requires an AWS OpenShift cluster installed for STS, CCO in `Manual` mode, an S3 bucket, and an Operator installation configured with the test role. The role trust policy must allow `system:serviceaccount:<namespace>:sts-cco-quay-app` with audience `openshift`.
+
+```bash
+STS_TEST_NAMESPACE=quay-sts-e2e \
+STS_S3_BUCKET=example-quay-sts-e2e \
+STS_S3_REGION=us-east-1 \
+STS_ROLE_ARN=arn:aws:iam::123456789012:role/example-quay-sts \
+make test-e2e-sts
+```
+
+The test verifies the generated `CredentialsRequest`, CCO credentials, projected token and workload mounts, absence of static S3 keys, a real image push/pull, and repository mirroring. It creates the namespace if needed; use a dedicated empty namespace matching the IAM trust policy.
 
 Override parallelism and pass extra args:
 ```bash

--- a/apis/quay/v1/quayregistry_types.go
+++ b/apis/quay/v1/quayregistry_types.go
@@ -254,6 +254,9 @@ const (
 	ConditionReasonMonitoringComponentDependencyError    ConditionReason = "MonitoringComponentDependencyError"
 	ConditionReasonConfigInvalid                         ConditionReason = "ConfigInvalid"
 	ConditionReasonComponentOverrideInvalid              ConditionReason = "ComponentOverrideInvalid"
+	ConditionReasonCredentialRequestPending              ConditionReason = "CredentialRequestPending"
+	ConditionReasonCredentialRequestNotProvisioned       ConditionReason = "CredentialRequestNotProvisioned"
+	ConditionReasonConflictingCredentials                ConditionReason = "ConflictingCredentials"
 	ConditionReasonPVCPending                            ConditionReason = "PVCPending"
 	ConditionReasonPVCProvisioningFailed                 ConditionReason = "PVCProvisioningFailed"
 )

--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -179,12 +179,16 @@ spec:
                 - infrastructures
               verbs:
                 - get
+                - list
+                - watch
             - apiGroups:
                 - operator.openshift.io
               resources:
                 - cloudcredentials
               verbs:
                 - get
+                - list
+                - watch
             - apiGroups:
                 - networking.k8s.io
               resources:

--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
   name: quay-operator.v3.99.0-dev
@@ -186,6 +186,18 @@ spec:
                 - delete
                 - update
                 - patch
+            - apiGroups:
+                - cloudcredential.openshift.io
+              resources:
+                - credentialsrequests
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
           serviceAccountName: quay-operator
       permissions:
         - rules:

--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -175,6 +175,14 @@ spec:
                 - config.openshift.io
               resources:
                 - apiservers
+                - authentications
+                - infrastructures
+              verbs:
+                - get
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - cloudcredentials
               verbs:
                 - get
             - apiGroups:

--- a/bundle/manifests/quay-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/quay-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     containerImage: quay.io/projectquay/quay-operator:v3.99.0-dev
     createdAt: 2021-04-23T10:04:00Z
     support: Project Quay
-    description: Opinionated deployment of Quay on Kubernetes.
+    description: Opinionated deployment of Quay on Kubernetes, including AWS STS authentication for unmanaged S3 storage. See https://github.com/quay/quay-operator/blob/master/docs/sts-iam-setup.md.
     quay-version: v3.99.0-dev
     repository: https://github.com/quay/quay-operator
     tectonic-visibility: ocs
@@ -108,7 +108,7 @@ spec:
             description: Externally accessible URL for container pull/push and web frontend.
             x-descriptors:
               - 'urn:alm:descriptor:org.w3:link'
-  description: Opinionated deployment of Quay on Kubernetes.
+  description: Opinionated deployment of Quay on Kubernetes. AWS STS setup for unmanaged S3 storage is documented at https://github.com/quay/quay-operator/blob/master/docs/sts-iam-setup.md.
   displayName: Quay
   install:
     spec:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -69,9 +69,23 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - apiservers
+  - authentications
+  - infrastructures
   verbs:
   - get
 - apiGroups:
@@ -99,6 +113,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - cloudcredentials
+  verbs:
+  - get
 - apiGroups:
   - quay.redhat.com
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -88,6 +88,8 @@ rules:
   - infrastructures
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -119,6 +121,8 @@ rules:
   - cloudcredentials
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - quay.redhat.com
   resources:

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -930,6 +930,18 @@ func (r *QuayRegistryReconciler) checkPostgresTLSSecrets(
 	return nil
 }
 
+var (
+	errSTSConflictingCredentials = fmt.Errorf(
+		"ROLEARN is set but configBundleSecret contains static AWS credentials " +
+			"(s3_access_key/s3_secret_key or access_key/secret_key in DISTRIBUTED_STORAGE_CONFIG). " +
+			"Remove static credentials from your storage config to enable STS authentication",
+	)
+	errSTSCRDNotAvailable = fmt.Errorf(
+		"ROLEARN is set but CredentialsRequest CRD is not available. " +
+			"STS authentication requires OpenShift 4.14+ with Cloud Credential Operator",
+	)
+)
+
 // checkSTSCapability detects whether the operator is configured for AWS STS
 // authentication via the ROLEARN env var. When STS is active, it validates
 // that objectstorage is unmanaged and that the user's config bundle does not
@@ -951,18 +963,11 @@ func (r *QuayRegistryReconciler) checkSTSCapability(
 	}
 
 	if hasStaticAWSStorageKeys(usercfg) {
-		return fmt.Errorf(
-			"ROLEARN is set but configBundleSecret contains static AWS credentials " +
-				"(s3_access_key/s3_secret_key or access_key/secret_key in DISTRIBUTED_STORAGE_CONFIG). " +
-				"Remove static credentials from your storage config to enable STS authentication",
-		)
+		return errSTSConflictingCredentials
 	}
 
 	if !r.supportsCredentialsRequest {
-		return fmt.Errorf(
-			"ROLEARN is set but CredentialsRequest CRD is not available. " +
-				"STS authentication requires OpenShift 4.14+ with Cloud Credential Operator",
-		)
+		return errSTSCRDNotAvailable
 	}
 
 	qctx.StorageSTSEnabled = true

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -989,9 +989,9 @@ func hasStaticAWSStorageKeys(usercfg map[string]interface{}) bool {
 		return false
 	}
 
-	staticKeyFields := []string{
-		"s3_access_key", "s3_secret_key",
-		"access_key", "secret_key",
+	s3KeyFields := map[string][]string{
+		"S3Storage":    {"s3_access_key", "s3_secret_key"},
+		"STSS3Storage": {"sts_user_access_key", "sts_user_secret_key"},
 	}
 
 	for _, entry := range storageMap {
@@ -1000,12 +1000,22 @@ func hasStaticAWSStorageKeys(usercfg map[string]interface{}) bool {
 			continue
 		}
 
+		storageType, ok := entryList[0].(string)
+		if !ok {
+			continue
+		}
+
+		keyFields, isS3 := s3KeyFields[storageType]
+		if !isS3 {
+			continue
+		}
+
 		args, ok := entryList[1].(map[string]interface{})
 		if !ok {
 			continue
 		}
 
-		for _, key := range staticKeyFields {
+		for _, key := range keyFields {
 			if val, exists := args[key]; exists {
 				if str, ok := val.(string); ok && str != "" {
 					return true

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -996,7 +996,7 @@ func (r *QuayRegistryReconciler) checkAWSTimedTokenCluster(ctx context.Context) 
 		return fmt.Errorf("unable to determine infrastructure platform for STS: %w", err)
 	}
 
-	platform := infrastructure.Status.Platform
+	var platform configv1.PlatformType
 	if infrastructure.Status.PlatformStatus != nil {
 		platform = infrastructure.Status.PlatformStatus.Type
 	}

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -933,7 +934,7 @@ func (r *QuayRegistryReconciler) checkPostgresTLSSecrets(
 var (
 	errSTSConflictingCredentials = fmt.Errorf(
 		"ROLEARN is set but configBundleSecret contains static AWS credentials " +
-			"(s3_access_key/s3_secret_key or access_key/secret_key in DISTRIBUTED_STORAGE_CONFIG). " +
+			"(s3_access_key/s3_secret_key in DISTRIBUTED_STORAGE_CONFIG). " +
 			"Remove static credentials from your storage config to enable STS authentication",
 	)
 	errSTSCRDNotAvailable = fmt.Errorf(
@@ -943,16 +944,15 @@ var (
 )
 
 // checkSTSCapability detects whether the operator is configured for AWS STS
-// authentication via the ROLEARN env var. When STS is active, it validates
-// that objectstorage is unmanaged and that the user's config bundle does not
-// contain static AWS credentials (which would conflict with STS).
+// authentication via the ROLEARN env var. STS is enabled only for unmanaged
+// S3Storage on an AWS cluster using CCO's timed-token configuration.
 func (r *QuayRegistryReconciler) checkSTSCapability(
 	ctx context.Context,
 	qctx *quaycontext.QuayRegistryContext,
 	quay *v1.QuayRegistry,
 	usercfg map[string]interface{},
 ) error {
-	roleARN := os.Getenv("ROLEARN")
+	roleARN := strings.TrimSpace(os.Getenv("ROLEARN"))
 	if roleARN == "" {
 		return nil
 	}
@@ -962,67 +962,125 @@ func (r *QuayRegistryReconciler) checkSTSCapability(
 		return nil
 	}
 
-	if hasStaticAWSStorageKeys(usercfg) {
+	buckets, staticCredentials, err := s3StorageConfiguration(usercfg)
+	if err != nil {
+		return err
+	}
+	if len(buckets) == 0 {
+		r.Log.Info("ROLEARN is set but no unmanaged S3Storage backend is configured; skipping STS")
+		return nil
+	}
+	if staticCredentials {
 		return errSTSConflictingCredentials
 	}
 
 	if !r.supportsCredentialsRequest {
 		return errSTSCRDNotAvailable
 	}
+	if err := r.checkAWSTimedTokenCluster(ctx); err != nil {
+		return err
+	}
 
 	qctx.StorageSTSEnabled = true
 	qctx.STSRoleARN = roleARN
-	r.Log.Info("STS authentication enabled", "roleARN", roleARN)
+	qctx.STSStorageBuckets = buckets
+	r.Log.Info("STS authentication enabled", "roleARN", roleARN, "buckets", buckets)
 	return nil
 }
 
-// hasStaticAWSStorageKeys checks the parsed config.yaml for static AWS
-// credentials in DISTRIBUTED_STORAGE_CONFIG entries.
-func hasStaticAWSStorageKeys(usercfg map[string]interface{}) bool {
+// checkAWSTimedTokenCluster mirrors the capability checks used by CCO for
+// short-lived tokens and additionally restricts this AWS-specific flow to AWS.
+func (r *QuayRegistryReconciler) checkAWSTimedTokenCluster(ctx context.Context) error {
+	var infrastructure configv1.Infrastructure
+	if err := r.Get(ctx, types.NamespacedName{Name: "cluster"}, &infrastructure); err != nil {
+		return fmt.Errorf("unable to determine infrastructure platform for STS: %w", err)
+	}
+
+	platform := infrastructure.Status.Platform
+	if infrastructure.Status.PlatformStatus != nil {
+		platform = infrastructure.Status.PlatformStatus.Type
+	}
+	if platform != configv1.AWSPlatformType {
+		return fmt.Errorf("ROLEARN is set but the cluster platform is %q; AWS STS requires an AWS cluster", platform)
+	}
+
+	cloudCredential := &unstructured.Unstructured{}
+	cloudCredential.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "operator.openshift.io", Version: "v1", Kind: "CloudCredential",
+	})
+	if err := r.Get(ctx, types.NamespacedName{Name: "cluster"}, cloudCredential); err != nil {
+		return fmt.Errorf("unable to determine Cloud Credential Operator mode for STS: %w", err)
+	}
+	mode, _, err := unstructured.NestedString(cloudCredential.Object, "spec", "credentialsMode")
+	if err != nil {
+		return fmt.Errorf("unable to read Cloud Credential Operator mode for STS: %w", err)
+	}
+	if mode != "Manual" {
+		return fmt.Errorf("ROLEARN is set but Cloud Credential Operator mode is %q; AWS STS requires Manual mode", mode)
+	}
+
+	var authentication configv1.Authentication
+	if err := r.Get(ctx, types.NamespacedName{Name: "cluster"}, &authentication); err != nil {
+		return fmt.Errorf("unable to determine service account issuer for STS: %w", err)
+	}
+	if strings.TrimSpace(authentication.Spec.ServiceAccountIssuer) == "" {
+		return fmt.Errorf("ROLEARN is set but the cluster service account issuer is empty; AWS STS requires a configured OIDC issuer")
+	}
+
+	return nil
+}
+
+// s3StorageConfiguration returns the buckets used by S3Storage entries and
+// whether any of those entries contain static AWS credentials. Other storage
+// drivers, including the legacy STSS3Storage driver, are intentionally ignored.
+func s3StorageConfiguration(usercfg map[string]interface{}) ([]string, bool, error) {
 	dsc, ok := usercfg["DISTRIBUTED_STORAGE_CONFIG"]
 	if !ok {
-		return false
+		return nil, false, nil
 	}
 
 	storageMap, ok := dsc.(map[string]interface{})
 	if !ok {
-		return false
+		return nil, false, fmt.Errorf("DISTRIBUTED_STORAGE_CONFIG must be a map")
 	}
 
-	s3KeyFields := map[string][]string{
-		"S3Storage":    {"s3_access_key", "s3_secret_key"},
-		"STSS3Storage": {"sts_user_access_key", "sts_user_secret_key"},
-	}
-
-	for _, entry := range storageMap {
+	bucketSet := map[string]struct{}{}
+	staticCredentials := false
+	for location, entry := range storageMap {
 		entryList, ok := entry.([]interface{})
 		if !ok || len(entryList) < 2 {
 			continue
 		}
-
 		storageType, ok := entryList[0].(string)
-		if !ok {
+		if !ok || storageType != "S3Storage" {
 			continue
 		}
-
-		keyFields, isS3 := s3KeyFields[storageType]
-		if !isS3 {
-			continue
-		}
-
 		args, ok := entryList[1].(map[string]interface{})
 		if !ok {
-			continue
+			return nil, false, fmt.Errorf("S3Storage location %q must contain a configuration map", location)
 		}
-
-		for _, key := range keyFields {
-			if val, exists := args[key]; exists {
-				if str, ok := val.(string); ok && str != "" {
-					return true
-				}
+		bucket, ok := args["s3_bucket"].(string)
+		bucket = strings.TrimSpace(bucket)
+		if !ok || bucket == "" {
+			return nil, false, fmt.Errorf("S3Storage location %q is missing s3_bucket", location)
+		}
+		bucketSet[bucket] = struct{}{}
+		for _, key := range []string{"s3_access_key", "s3_secret_key"} {
+			if value, ok := args[key].(string); ok && strings.TrimSpace(value) != "" {
+				staticCredentials = true
 			}
 		}
 	}
 
-	return false
+	buckets := make([]string, 0, len(bucketSet))
+	for bucket := range bucketSet {
+		buckets = append(buckets, bucket)
+	}
+	slices.Sort(buckets)
+	return buckets, staticCredentials, nil
+}
+
+func hasStaticAWSStorageKeys(usercfg map[string]interface{}) bool {
+	_, hasStatic, _ := s3StorageConfiguration(usercfg)
+	return hasStatic
 }

--- a/controllers/quay/features.go
+++ b/controllers/quay/features.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	err "errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -927,4 +928,86 @@ func (r *QuayRegistryReconciler) checkPostgresTLSSecrets(
 	}
 
 	return nil
+}
+
+// checkSTSCapability detects whether the operator is configured for AWS STS
+// authentication via the ROLEARN env var. When STS is active, it validates
+// that objectstorage is unmanaged and that the user's config bundle does not
+// contain static AWS credentials (which would conflict with STS).
+func (r *QuayRegistryReconciler) checkSTSCapability(
+	ctx context.Context,
+	qctx *quaycontext.QuayRegistryContext,
+	quay *v1.QuayRegistry,
+	usercfg map[string]interface{},
+) error {
+	roleARN := os.Getenv("ROLEARN")
+	if roleARN == "" {
+		return nil
+	}
+
+	if v1.ComponentIsManaged(quay.Spec.Components, v1.ComponentObjectStorage) {
+		r.Log.Info("ROLEARN is set but objectstorage is managed; STS only applies to unmanaged objectstorage pointing at AWS S3")
+		return nil
+	}
+
+	if hasStaticAWSStorageKeys(usercfg) {
+		return fmt.Errorf(
+			"ROLEARN is set but configBundleSecret contains static AWS credentials " +
+				"(s3_access_key/s3_secret_key or access_key/secret_key in DISTRIBUTED_STORAGE_CONFIG). " +
+				"Remove static credentials from your storage config to enable STS authentication",
+		)
+	}
+
+	if !r.supportsCredentialsRequest {
+		return fmt.Errorf(
+			"ROLEARN is set but CredentialsRequest CRD is not available. " +
+				"STS authentication requires OpenShift 4.14+ with Cloud Credential Operator",
+		)
+	}
+
+	qctx.StorageSTSEnabled = true
+	qctx.STSRoleARN = roleARN
+	r.Log.Info("STS authentication enabled", "roleARN", roleARN)
+	return nil
+}
+
+// hasStaticAWSStorageKeys checks the parsed config.yaml for static AWS
+// credentials in DISTRIBUTED_STORAGE_CONFIG entries.
+func hasStaticAWSStorageKeys(usercfg map[string]interface{}) bool {
+	dsc, ok := usercfg["DISTRIBUTED_STORAGE_CONFIG"]
+	if !ok {
+		return false
+	}
+
+	storageMap, ok := dsc.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	staticKeyFields := []string{
+		"s3_access_key", "s3_secret_key",
+		"access_key", "secret_key",
+	}
+
+	for _, entry := range storageMap {
+		entryList, ok := entry.([]interface{})
+		if !ok || len(entryList) < 2 {
+			continue
+		}
+
+		args, ok := entryList[1].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, key := range staticKeyFields {
+			if val, exists := args[key]; exists {
+				if str, ok := val.(string); ok && str != "" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/controllers/quay/features_test.go
+++ b/controllers/quay/features_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/cert"
@@ -1122,123 +1125,106 @@ func TestCheckSTSCapability(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	_ = v1.AddToScheme(scheme)
+	_ = configv1.Install(scheme)
 
-	newReconciler := func(objs ...client.Object) *QuayRegistryReconciler {
-		cb := fake.NewClientBuilder().WithScheme(scheme)
-		for _, obj := range objs {
-			cb = cb.WithObjects(obj)
+	s3Config := func(args map[string]interface{}) map[string]interface{} {
+		if args == nil {
+			args = map[string]interface{}{}
 		}
-		return &QuayRegistryReconciler{
-			Client:                     cb.Build(),
-			Log:                        logf.Log.WithName("test"),
-			supportsCredentialsRequest: true,
+		if _, ok := args["s3_bucket"]; !ok {
+			args["s3_bucket"] = "quay-bucket"
+		}
+		return map[string]interface{}{
+			"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+				"default": []interface{}{"S3Storage", args},
+			},
+		}
+	}
+	storageConfig := func(driver string, args map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+				"default": []interface{}{driver, args},
+			},
 		}
 	}
 
 	for _, tt := range []struct {
 		name                 string
-		rolearn              string
+		roleARN              string
 		supportsCredReq      bool
 		objectStorageManaged bool
+		platform             configv1.PlatformType
+		ccoMode              string
+		issuer               string
 		usercfg              map[string]interface{}
 		expectSTSEnabled     bool
-		expectError          bool
 		expectErrorContains  string
 	}{
-		{
-			name:             "ROLEARN not set",
-			rolearn:          "",
-			supportsCredReq:  true,
-			expectSTSEnabled: false,
-		},
-		{
-			name:                 "ROLEARN set, objectstorage managed",
-			rolearn:              "arn:aws:iam::123:role/test",
-			supportsCredReq:      true,
-			objectStorageManaged: true,
-			usercfg:              map[string]interface{}{},
-			expectSTSEnabled:     false,
-		},
-		{
-			name:            "ROLEARN set, static keys present",
-			rolearn:         "arn:aws:iam::123:role/test",
-			supportsCredReq: true,
-			usercfg: map[string]interface{}{
-				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
-					"default": []interface{}{
-						"S3Storage",
-						map[string]interface{}{
-							"s3_access_key": "AKIA...",
-							"s3_secret_key": "secret",
-						},
-					},
-				},
-			},
-			expectError:         true,
-			expectErrorContains: "static AWS credentials",
-		},
-		{
-			name:                "ROLEARN set, CRD not available",
-			rolearn:             "arn:aws:iam::123:role/test",
-			supportsCredReq:     false,
-			usercfg:             map[string]interface{}{},
-			expectError:         true,
-			expectErrorContains: "CredentialsRequest CRD is not available",
-		},
-		{
-			name:             "ROLEARN set, all good",
-			rolearn:          "arn:aws:iam::123:role/test",
-			supportsCredReq:  true,
-			usercfg:          map[string]interface{}{},
-			expectSTSEnabled: true,
-		},
+		{name: "ROLEARN not set", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: s3Config(nil)},
+		{name: "managed objectstorage", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, objectStorageManaged: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: s3Config(nil)},
+		{name: "RadosGWStorage is ignored", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: storageConfig("RadosGWStorage", map[string]interface{}{"access_key": "ceph", "secret_key": "secret"})},
+		{name: "RHOCSStorage is ignored", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: storageConfig("RHOCSStorage", map[string]interface{}{"access_key": "ocs", "secret_key": "secret"})},
+		{name: "SwiftStorage is ignored", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: storageConfig("SwiftStorage", map[string]interface{}{"swift_user": "user", "swift_password": "secret"})},
+		{name: "legacy STSS3Storage is ignored", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: storageConfig("STSS3Storage", map[string]interface{}{"s3_bucket": "legacy"})},
+		{name: "missing storage config is ignored", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: map[string]interface{}{}},
+		{name: "static keys conflict", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: s3Config(map[string]interface{}{"s3_access_key": "AKIA...", "s3_secret_key": "secret"}), expectErrorContains: "static AWS credentials"},
+		{name: "CRD unavailable", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: false, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: s3Config(nil), expectErrorContains: "CredentialsRequest CRD is not available"},
+		{name: "non-AWS platform", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.GCPPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: s3Config(nil), expectErrorContains: "requires an AWS cluster"},
+		{name: "Mint mode", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Mint", issuer: "https://issuer.example.com", usercfg: s3Config(nil), expectErrorContains: "requires Manual mode"},
+		{name: "Passthrough mode", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Passthrough", issuer: "https://issuer.example.com", usercfg: s3Config(nil), expectErrorContains: "requires Manual mode"},
+		{name: "issuer missing", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", usercfg: s3Config(nil), expectErrorContains: "OIDC issuer"},
+		{name: "AWS timed-token cluster", roleARN: "arn:aws:iam::123:role/test", supportsCredReq: true, platform: configv1.AWSPlatformType, ccoMode: "Manual", issuer: "https://issuer.example.com", usercfg: s3Config(nil), expectSTSEnabled: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.rolearn != "" {
-				t.Setenv("ROLEARN", tt.rolearn)
-			} else {
-				t.Setenv("ROLEARN", "")
-			}
+			t.Setenv("ROLEARN", tt.roleARN)
 
-			r := newReconciler()
-			r.supportsCredentialsRequest = tt.supportsCredReq
+			infrastructure := &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{Type: tt.platform},
+				},
+			}
+			authentication := &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       configv1.AuthenticationSpec{ServiceAccountIssuer: tt.issuer},
+			}
+			cloudCredential := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "operator.openshift.io/v1",
+				"kind":       "CloudCredential",
+				"metadata":   map[string]interface{}{"name": "cluster"},
+				"spec":       map[string]interface{}{"credentialsMode": tt.ccoMode},
+			}}
+			cli := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(infrastructure, authentication, cloudCredential).Build()
+			r := &QuayRegistryReconciler{
+				Client:                     cli,
+				Log:                        logf.Log.WithName("test"),
+				supportsCredentialsRequest: tt.supportsCredReq,
+			}
 
 			qctx := quaycontext.NewQuayRegistryContext()
 			quay := &v1.QuayRegistry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test-ns",
-				},
-				Spec: v1.QuayRegistrySpec{
-					Components: []v1.Component{
-						{Kind: v1.ComponentObjectStorage, Managed: tt.objectStorageManaged},
-					},
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: v1.QuayRegistrySpec{Components: []v1.Component{
+					{Kind: v1.ComponentObjectStorage, Managed: tt.objectStorageManaged},
+				}},
 			}
 
-			usercfg := tt.usercfg
-			if usercfg == nil {
-				usercfg = map[string]interface{}{}
-			}
-
-			err := r.checkSTSCapability(context.Background(), qctx, quay, usercfg)
-
-			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error but got nil")
-				}
-				if tt.expectErrorContains != "" && !strings.Contains(err.Error(), tt.expectErrorContains) {
-					t.Errorf("error %q does not contain %q", err.Error(), tt.expectErrorContains)
+			err := r.checkSTSCapability(context.Background(), qctx, quay, tt.usercfg)
+			if tt.expectErrorContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectErrorContains) {
+					t.Fatalf("error = %v, want error containing %q", err, tt.expectErrorContains)
 				}
 				return
 			}
-
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
 			if qctx.StorageSTSEnabled != tt.expectSTSEnabled {
 				t.Errorf("StorageSTSEnabled = %v, want %v", qctx.StorageSTSEnabled, tt.expectSTSEnabled)
+			}
+			if tt.expectSTSEnabled && !reflect.DeepEqual(qctx.STSStorageBuckets, []string{"quay-bucket"}) {
+				t.Errorf("STSStorageBuckets = %v, want [quay-bucket]", qctx.STSStorageBuckets)
 			}
 		})
 	}
@@ -1269,8 +1255,8 @@ func TestHasStaticAWSStorageKeys(t *testing.T) {
 					"default": []interface{}{
 						"S3Storage",
 						map[string]interface{}{
-							"s3_access_key": "AKIAIOSFODNN7EXAMPLE",
-							"s3_secret_key": "wJalrXUtnFEMI",
+							"s3_access_key": "test-access-key",
+							"s3_secret_key": "test-secret-key",
 							"s3_bucket":     "my-bucket",
 						},
 					},
@@ -1363,5 +1349,28 @@ func TestHasStaticAWSStorageKeys(t *testing.T) {
 				t.Errorf("hasStaticAWSStorageKeys() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestS3StorageConfiguration(t *testing.T) {
+	config := map[string]interface{}{
+		"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+			"secondary": []interface{}{"S3Storage", map[string]interface{}{"s3_bucket": "z-bucket"}},
+			"primary":   []interface{}{"S3Storage", map[string]interface{}{"s3_bucket": "a-bucket"}},
+			"duplicate": []interface{}{"S3Storage", map[string]interface{}{"s3_bucket": "a-bucket"}},
+			"rados":     []interface{}{"RadosGWStorage", map[string]interface{}{"access_key": "ceph", "secret_key": "secret"}},
+			"legacy":    []interface{}{"STSS3Storage", map[string]interface{}{"s3_bucket": "legacy", "sts_user_access_key": "old"}},
+		},
+	}
+
+	buckets, hasStatic, err := s3StorageConfiguration(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasStatic {
+		t.Fatal("non-S3Storage credentials must not be treated as a static AWS conflict")
+	}
+	if !reflect.DeepEqual(buckets, []string{"a-bucket", "z-bucket"}) {
+		t.Fatalf("buckets = %v, want sorted unique S3Storage buckets", buckets)
 	}
 }

--- a/controllers/quay/features_test.go
+++ b/controllers/quay/features_test.go
@@ -1148,18 +1148,21 @@ func TestCheckSTSCapability(t *testing.T) {
 		{
 			name:             "ROLEARN not set",
 			rolearn:          "",
+			supportsCredReq:  true,
 			expectSTSEnabled: false,
 		},
 		{
 			name:                 "ROLEARN set, objectstorage managed",
 			rolearn:              "arn:aws:iam::123:role/test",
+			supportsCredReq:      true,
 			objectStorageManaged: true,
 			usercfg:              map[string]interface{}{},
 			expectSTSEnabled:     false,
 		},
 		{
-			name:    "ROLEARN set, static keys present",
-			rolearn: "arn:aws:iam::123:role/test",
+			name:            "ROLEARN set, static keys present",
+			rolearn:         "arn:aws:iam::123:role/test",
+			supportsCredReq: true,
 			usercfg: map[string]interface{}{
 				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
 					"default": []interface{}{
@@ -1185,6 +1188,7 @@ func TestCheckSTSCapability(t *testing.T) {
 		{
 			name:             "ROLEARN set, all good",
 			rolearn:          "arn:aws:iam::123:role/test",
+			supportsCredReq:  true,
 			usercfg:          map[string]interface{}{},
 			expectSTSEnabled: true,
 		},
@@ -1197,11 +1201,7 @@ func TestCheckSTSCapability(t *testing.T) {
 			}
 
 			r := newReconciler()
-			if tt.supportsCredReq || tt.name == "ROLEARN set, all good" || tt.name == "ROLEARN set, objectstorage managed" || tt.name == "ROLEARN set, static keys present" {
-				r.supportsCredentialsRequest = true
-			} else {
-				r.supportsCredentialsRequest = false
-			}
+			r.supportsCredentialsRequest = tt.supportsCredReq
 
 			qctx := quaycontext.NewQuayRegistryContext()
 			quay := &v1.QuayRegistry{

--- a/controllers/quay/features_test.go
+++ b/controllers/quay/features_test.go
@@ -1279,7 +1279,7 @@ func TestHasStaticAWSStorageKeys(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "RadosGWStorage with static keys",
+			name: "RadosGWStorage with keys is not flagged",
 			usercfg: map[string]interface{}{
 				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
 					"default": []interface{}{
@@ -1292,7 +1292,23 @@ func TestHasStaticAWSStorageKeys(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
+		},
+		{
+			name: "RHOCSStorage with keys is not flagged",
+			usercfg: map[string]interface{}{
+				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+					"default": []interface{}{
+						"RHOCSStorage",
+						map[string]interface{}{
+							"access_key":  "myaccesskey",
+							"secret_key":  "mysecretkey",
+							"bucket_name": "my-bucket",
+						},
+					},
+				},
+			},
+			expected: false,
 		},
 		{
 			name: "S3Storage with empty keys",

--- a/controllers/quay/features_test.go
+++ b/controllers/quay/features_test.go
@@ -1115,3 +1115,237 @@ func TestEnsurePostgresServiceCAAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckSTSCapability(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+
+	newReconciler := func(objs ...client.Object) *QuayRegistryReconciler {
+		cb := fake.NewClientBuilder().WithScheme(scheme)
+		for _, obj := range objs {
+			cb = cb.WithObjects(obj)
+		}
+		return &QuayRegistryReconciler{
+			Client:                     cb.Build(),
+			Log:                        logf.Log.WithName("test"),
+			supportsCredentialsRequest: true,
+		}
+	}
+
+	for _, tt := range []struct {
+		name                 string
+		rolearn              string
+		supportsCredReq      bool
+		objectStorageManaged bool
+		usercfg              map[string]interface{}
+		expectSTSEnabled     bool
+		expectError          bool
+		expectErrorContains  string
+	}{
+		{
+			name:             "ROLEARN not set",
+			rolearn:          "",
+			expectSTSEnabled: false,
+		},
+		{
+			name:                 "ROLEARN set, objectstorage managed",
+			rolearn:              "arn:aws:iam::123:role/test",
+			objectStorageManaged: true,
+			usercfg:              map[string]interface{}{},
+			expectSTSEnabled:     false,
+		},
+		{
+			name:    "ROLEARN set, static keys present",
+			rolearn: "arn:aws:iam::123:role/test",
+			usercfg: map[string]interface{}{
+				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+					"default": []interface{}{
+						"S3Storage",
+						map[string]interface{}{
+							"s3_access_key": "AKIA...",
+							"s3_secret_key": "secret",
+						},
+					},
+				},
+			},
+			expectError:         true,
+			expectErrorContains: "static AWS credentials",
+		},
+		{
+			name:                "ROLEARN set, CRD not available",
+			rolearn:             "arn:aws:iam::123:role/test",
+			supportsCredReq:     false,
+			usercfg:             map[string]interface{}{},
+			expectError:         true,
+			expectErrorContains: "CredentialsRequest CRD is not available",
+		},
+		{
+			name:             "ROLEARN set, all good",
+			rolearn:          "arn:aws:iam::123:role/test",
+			usercfg:          map[string]interface{}{},
+			expectSTSEnabled: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.rolearn != "" {
+				t.Setenv("ROLEARN", tt.rolearn)
+			} else {
+				t.Setenv("ROLEARN", "")
+			}
+
+			r := newReconciler()
+			if tt.supportsCredReq || tt.name == "ROLEARN set, all good" || tt.name == "ROLEARN set, objectstorage managed" || tt.name == "ROLEARN set, static keys present" {
+				r.supportsCredentialsRequest = true
+			} else {
+				r.supportsCredentialsRequest = false
+			}
+
+			qctx := quaycontext.NewQuayRegistryContext()
+			quay := &v1.QuayRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-ns",
+				},
+				Spec: v1.QuayRegistrySpec{
+					Components: []v1.Component{
+						{Kind: v1.ComponentObjectStorage, Managed: tt.objectStorageManaged},
+					},
+				},
+			}
+
+			usercfg := tt.usercfg
+			if usercfg == nil {
+				usercfg = map[string]interface{}{}
+			}
+
+			err := r.checkSTSCapability(context.Background(), qctx, quay, usercfg)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tt.expectErrorContains != "" && !strings.Contains(err.Error(), tt.expectErrorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.expectErrorContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if qctx.StorageSTSEnabled != tt.expectSTSEnabled {
+				t.Errorf("StorageSTSEnabled = %v, want %v", qctx.StorageSTSEnabled, tt.expectSTSEnabled)
+			}
+		})
+	}
+}
+
+func TestHasStaticAWSStorageKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		usercfg  map[string]interface{}
+		expected bool
+	}{
+		{
+			name:     "empty config",
+			usercfg:  map[string]interface{}{},
+			expected: false,
+		},
+		{
+			name: "no DISTRIBUTED_STORAGE_CONFIG",
+			usercfg: map[string]interface{}{
+				"SERVER_HOSTNAME": "registry.example.com",
+			},
+			expected: false,
+		},
+		{
+			name: "S3Storage with static keys",
+			usercfg: map[string]interface{}{
+				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+					"default": []interface{}{
+						"S3Storage",
+						map[string]interface{}{
+							"s3_access_key": "AKIAIOSFODNN7EXAMPLE",
+							"s3_secret_key": "wJalrXUtnFEMI",
+							"s3_bucket":     "my-bucket",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "RadosGWStorage with static keys",
+			usercfg: map[string]interface{}{
+				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+					"default": []interface{}{
+						"RadosGWStorage",
+						map[string]interface{}{
+							"access_key":  "myaccesskey",
+							"secret_key":  "mysecretkey",
+							"bucket_name": "my-bucket",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "S3Storage with empty keys",
+			usercfg: map[string]interface{}{
+				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+					"default": []interface{}{
+						"S3Storage",
+						map[string]interface{}{
+							"s3_access_key": "",
+							"s3_secret_key": "",
+							"s3_bucket":     "my-bucket",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "STSS3Storage without static keys",
+			usercfg: map[string]interface{}{
+				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+					"default": []interface{}{
+						"STSS3Storage",
+						map[string]interface{}{
+							"s3_bucket":    "my-bucket",
+							"sts_role_arn": "arn:aws:iam::123456789:role/quay",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "S3Storage without credential keys at all",
+			usercfg: map[string]interface{}{
+				"DISTRIBUTED_STORAGE_CONFIG": map[string]interface{}{
+					"default": []interface{}{
+						"S3Storage",
+						map[string]interface{}{
+							"s3_bucket": "my-bucket",
+							"host":      "s3.amazonaws.com",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasStaticAWSStorageKeys(tt.usercfg)
+			if result != tt.expected {
+				t.Errorf("hasStaticAWSStorageKeys() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -1134,7 +1134,8 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				fmt.Sprintf("unable to inspect flattened config for STS: %s", err),
 			)
 		}
-		if err := yaml.Unmarshal(stsBundle.Data["config.yaml"], &stsUserConfig); err != nil {
+		var flattenedCfg map[string]interface{}
+		if err := yaml.Unmarshal(stsBundle.Data["config.yaml"], &flattenedCfg); err != nil {
 			return r.reconcileWithCondition(
 				ctx,
 				&quay,
@@ -1144,9 +1145,10 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				fmt.Sprintf("unable to parse flattened config for STS: %s", err),
 			)
 		}
-		if stsUserConfig == nil {
-			stsUserConfig = make(map[string]interface{})
+		if flattenedCfg == nil {
+			flattenedCfg = make(map[string]interface{})
 		}
+		stsUserConfig = flattenedCfg
 	}
 
 	stsErr := r.checkSTSCapability(ctx, quayContext, updatedQuay, stsUserConfig)

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -1007,12 +1007,16 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if err := r.checkSTSCapability(ctx, quayContext, updatedQuay, usercfg); err != nil {
+		reason := v1.ConditionReasonConfigInvalid
+		if goerrors.Is(err, errSTSConflictingCredentials) {
+			reason = v1.ConditionReasonConflictingCredentials
+		}
 		return r.reconcileWithCondition(
 			ctx,
 			&quay,
 			v1.ConditionTypeRolloutBlocked,
 			metav1.ConditionTrue,
-			v1.ConditionReasonConflictingCredentials,
+			reason,
 			err.Error(),
 		)
 	}

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -17,11 +17,11 @@ package controllers
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	goerrors "errors"
 	"fmt"
 	"maps"
 	"os"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -58,6 +58,7 @@ import (
 	quaycontext "github.com/quay/quay-operator/pkg/context"
 	"github.com/quay/quay-operator/pkg/credentialsrequest"
 	"github.com/quay/quay-operator/pkg/kustomize"
+	"github.com/quay/quay-operator/pkg/middleware"
 )
 
 const (
@@ -510,10 +511,11 @@ func (r *QuayRegistryReconciler) cleanupProgrammaticBootstrapTokenResources(
 }
 
 const (
-	stsCredentialRequestSuffix = "aws-credentials"
-	stsCredentialSecretSuffix  = "aws-sts-credentials"
-	stsCloudTokenPath          = "/var/run/secrets/openshift/serviceaccount/token"
-	stsProvisionTimeout        = 5 * time.Minute
+	stsCredentialRequestSuffix    = "aws-credentials"
+	stsCredentialSecretSuffix     = "aws-sts-credentials"
+	stsCloudTokenPath             = "/var/run/secrets/openshift/serviceaccount/token"
+	stsProvisionTimeout           = 5 * time.Minute
+	stsRequestTimestampAnnotation = "quay.redhat.com/sts-requested-at"
 )
 
 // ensureCredentialsRequest creates or updates the CredentialsRequest for STS
@@ -535,19 +537,15 @@ func (r *QuayRegistryReconciler) ensureCredentialsRequest(
 		crName, quay.GetNamespace(),
 		secretName, quay.GetNamespace(),
 		qctx.STSRoleARN, stsCloudTokenPath,
-		[]string{saName},
+		[]string{saName}, qctx.STSStorageBuckets,
 	)
 	if err != nil {
 		return r.Requeue, fmt.Errorf("unable to build CredentialsRequest: %w", err)
 	}
 
-	desired.SetOwnerReferences([]metav1.OwnerReference{
-		{
-			APIVersion: v1.GroupVersion.String(),
-			Kind:       "QuayRegistry",
-			Name:       quay.GetName(),
-			UID:        quay.GetUID(),
-		},
+	desired.SetOwnerReferences([]metav1.OwnerReference{credentialsRequestOwnerReference(quay)})
+	desired.SetAnnotations(map[string]string{
+		stsRequestTimestampAnnotation: time.Now().UTC().Format(time.RFC3339Nano),
 	})
 
 	var existing unstructured.Unstructured
@@ -567,55 +565,53 @@ func (r *QuayRegistryReconciler) ensureCredentialsRequest(
 		return r.Requeue, nil
 	}
 
-	// Update the CredentialsRequest if the spec has changed (e.g., role ARN changed).
-	existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
-	desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
-	if existingSpec != nil && desiredSpec != nil {
-		existingJSON, _ := json.Marshal(existingSpec)
-		desiredJSON, _ := json.Marshal(desiredSpec)
-		if string(existingJSON) != string(desiredJSON) {
-			r.Log.Info("updating CredentialsRequest spec", "name", crName)
-			existing.Object["spec"] = desired.Object["spec"]
-			if err := r.Update(ctx, &existing); err != nil {
-				return r.Requeue, fmt.Errorf("unable to update CredentialsRequest: %w", err)
-			}
-			return r.Requeue, nil
-		}
+	if !credentialsRequestOwnedBy(&existing, quay) {
+		return r.Requeue, fmt.Errorf("CredentialsRequest %s/%s already exists and is not owned by this QuayRegistry", quay.GetNamespace(), crName)
 	}
 
-	// Check if CCO has provisioned the Secret.
+	// Update the CredentialsRequest if its spec has changed.
+	existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+	desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	if !reflect.DeepEqual(existingSpec, desiredSpec) {
+		r.Log.Info("updating CredentialsRequest spec", "name", crName)
+		existing.Object["spec"] = desired.Object["spec"]
+		annotations := existing.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[stsRequestTimestampAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+		existing.SetAnnotations(annotations)
+		if err := r.Update(ctx, &existing); err != nil {
+			return r.Requeue, fmt.Errorf("unable to update CredentialsRequest: %w", err)
+		}
+		return r.Requeue, nil
+	}
+
+	provisioned, _, err := unstructured.NestedBool(existing.Object, "status", "provisioned")
+	if err != nil {
+		return r.Requeue, fmt.Errorf("unable to read CredentialsRequest provisioned status: %w", err)
+	}
+	lastSyncGeneration, _, err := unstructured.NestedInt64(existing.Object, "status", "lastSyncGeneration")
+	if err != nil {
+		return r.Requeue, fmt.Errorf("unable to read CredentialsRequest sync generation: %w", err)
+	}
+	if !provisioned || lastSyncGeneration != existing.GetGeneration() {
+		return r.waitForSTSCredentials(ctx, quay, &existing,
+			"Cloud Credential Operator has not provisioned the current CredentialsRequest generation")
+	}
+
 	var ccoSecret corev1.Secret
 	err = r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: quay.GetNamespace()}, &ccoSecret)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return r.Requeue, fmt.Errorf("unable to check CCO Secret: %w", err)
 		}
-
-		elapsed := time.Since(existing.GetCreationTimestamp().Time)
-		if elapsed > stsProvisionTimeout {
-			return r.reconcileWithCondition(
-				ctx, quay,
-				v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
-				v1.ConditionReasonCredentialRequestNotProvisioned,
-				"Cloud Credential Operator has not provisioned AWS credentials. "+
-					"Verify CCO is running and the cluster is OpenShift 4.14+. "+
-					"See operator logs for details.",
-			)
-		}
-
-		r.Log.Info("waiting for CCO to provision STS credentials", "elapsed", elapsed.Round(time.Second))
-		if err := r.updateWithCondition(
-			ctx, quay,
-			v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
-			v1.ConditionReasonCredentialRequestPending,
-			"Waiting for Cloud Credential Operator to provision AWS credentials for STS authentication",
-		); err != nil {
-			r.Log.Error(err, "failed to update conditions")
-		}
-		return r.Requeue, nil
+		return r.waitForSTSCredentials(ctx, quay, &existing,
+			"Cloud Credential Operator has not created the requested Secret")
 	}
 
-	if _, ok := ccoSecret.Data["credentials"]; !ok {
+	credentialsData, ok := ccoSecret.Data["credentials"]
+	if !ok {
 		return r.reconcileWithCondition(
 			ctx, quay,
 			v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
@@ -623,11 +619,128 @@ func (r *QuayRegistryReconciler) ensureCredentialsRequest(
 			"CCO Secret exists but does not contain a 'credentials' key",
 		)
 	}
+	if err := validateSTSSharedCredentials(credentialsData, qctx.STSRoleARN, stsCloudTokenPath); err != nil {
+		return r.reconcileWithCondition(
+			ctx, quay,
+			v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
+			v1.ConditionReasonCredentialRequestNotProvisioned,
+			fmt.Sprintf("CCO Secret does not contain valid STS web identity credentials: %s", err),
+		)
+	}
 
 	qctx.STSCredentialSecretName = secretName
 	qctx.STSCredentialProvisioned = true
 	r.Log.Info("STS credentials provisioned by CCO", "secret", secretName)
 	return ctrl.Result{}, nil
+}
+
+func credentialsRequestOwnerReference(quay *v1.QuayRegistry) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: v1.GroupVersion.String(),
+		Kind:       "QuayRegistry",
+		Name:       quay.GetName(),
+		UID:        quay.GetUID(),
+	}
+}
+
+func credentialsRequestOwnedBy(request metav1.Object, quay *v1.QuayRegistry) bool {
+	desired := credentialsRequestOwnerReference(quay)
+	for _, owner := range request.GetOwnerReferences() {
+		if owner.APIVersion == desired.APIVersion && owner.Kind == desired.Kind &&
+			owner.Name == desired.Name && owner.UID == desired.UID {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *QuayRegistryReconciler) waitForSTSCredentials(
+	ctx context.Context,
+	quay *v1.QuayRegistry,
+	request metav1.Object,
+	detail string,
+) (ctrl.Result, error) {
+	requestedAt := request.GetCreationTimestamp().Time
+	if value := request.GetAnnotations()[stsRequestTimestampAnnotation]; value != "" {
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			requestedAt = parsed
+		}
+	}
+	elapsed := time.Since(requestedAt)
+	if elapsed > stsProvisionTimeout {
+		return r.reconcileWithCondition(
+			ctx, quay,
+			v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
+			v1.ConditionReasonCredentialRequestNotProvisioned,
+			detail+". Verify CCO is running in Manual mode on an AWS STS cluster. See operator logs for details.",
+		)
+	}
+
+	r.Log.Info("waiting for CCO to provision STS credentials", "elapsed", elapsed.Round(time.Second), "detail", detail)
+	if err := r.updateWithCondition(
+		ctx, quay,
+		v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
+		v1.ConditionReasonCredentialRequestPending,
+		"Waiting for Cloud Credential Operator to provision AWS credentials for STS authentication",
+	); err != nil {
+		return r.Requeue, fmt.Errorf("unable to update pending STS condition: %w", err)
+	}
+	return r.Requeue, nil
+}
+
+func validateSTSSharedCredentials(data []byte, roleARN, tokenPath string) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return fmt.Errorf("credentials file is empty")
+	}
+
+	values := map[string]string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "[") {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if found {
+			values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	if values["aws_access_key_id"] != "" || values["aws_secret_access_key"] != "" {
+		return fmt.Errorf("credentials file contains static AWS access keys")
+	}
+	if values["role_arn"] != roleARN {
+		return fmt.Errorf("role_arn does not match the configured ROLEARN")
+	}
+	if values["web_identity_token_file"] != tokenPath {
+		return fmt.Errorf("web_identity_token_file does not match the projected service account token path")
+	}
+	return nil
+}
+
+func (r *QuayRegistryReconciler) cleanupCredentialsRequest(
+	ctx context.Context,
+	quay *v1.QuayRegistry,
+) error {
+	if !r.supportsCredentialsRequest {
+		return nil
+	}
+	request := &unstructured.Unstructured{}
+	request.SetGroupVersionKind(credentialsrequest.CredentialsRequestGVK)
+	requestName := fmt.Sprintf("%s-%s", quay.GetName(), stsCredentialRequestSuffix)
+	if err := r.Get(ctx, types.NamespacedName{Name: requestName, Namespace: quay.GetNamespace()}, request); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("unable to check for stale CredentialsRequest: %w", err)
+	}
+	if !credentialsRequestOwnedBy(request, quay) {
+		r.Log.Info("leaving same-name CredentialsRequest that is not owned by this QuayRegistry", "name", requestName)
+		return nil
+	}
+	r.Log.Info("deleting CredentialsRequest because STS no longer applies", "name", requestName)
+	if err := r.Delete(ctx, request); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("unable to delete stale CredentialsRequest: %w", err)
+	}
+	return nil
 }
 
 // quayAppDeploymentRolledOut returns true when the quay-app Deployment has fully
@@ -680,7 +793,8 @@ func (r *QuayRegistryReconciler) quayAppDeploymentRolledOut(
 // +kubebuilder:rbac:groups=objectbucket.io,resources=objectbucketclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;authentications;infrastructures,verbs=get
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=cloudcredentials,verbs=get
 // +kubebuilder:rbac:groups=cloudcredential.openshift.io,resources=credentialsrequests,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile is called every time an update happens in a QuayRegistry object. It attempts to
@@ -1006,9 +1120,39 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		)
 	}
 
-	if err := r.checkSTSCapability(ctx, quayContext, updatedQuay, usercfg); err != nil {
+	stsUserConfig := usercfg
+	if strings.TrimSpace(os.Getenv("ROLEARN")) != "" &&
+		!v1.ComponentIsManaged(updatedQuay.Spec.Components, v1.ComponentObjectStorage) {
+		stsBundle, err := middleware.FlattenSecret(cbundle)
+		if err != nil {
+			return r.reconcileWithCondition(
+				ctx,
+				&quay,
+				v1.ConditionTypeRolloutBlocked,
+				metav1.ConditionTrue,
+				v1.ConditionReasonConfigInvalid,
+				fmt.Sprintf("unable to inspect flattened config for STS: %s", err),
+			)
+		}
+		if err := yaml.Unmarshal(stsBundle.Data["config.yaml"], &stsUserConfig); err != nil {
+			return r.reconcileWithCondition(
+				ctx,
+				&quay,
+				v1.ConditionTypeRolloutBlocked,
+				metav1.ConditionTrue,
+				v1.ConditionReasonConfigInvalid,
+				fmt.Sprintf("unable to parse flattened config for STS: %s", err),
+			)
+		}
+		if stsUserConfig == nil {
+			stsUserConfig = make(map[string]interface{})
+		}
+	}
+
+	stsErr := r.checkSTSCapability(ctx, quayContext, updatedQuay, stsUserConfig)
+	if stsErr != nil {
 		reason := v1.ConditionReasonConfigInvalid
-		if goerrors.Is(err, errSTSConflictingCredentials) {
+		if goerrors.Is(stsErr, errSTSConflictingCredentials) {
 			reason = v1.ConditionReasonConflictingCredentials
 		}
 		return r.reconcileWithCondition(
@@ -1017,8 +1161,21 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			v1.ConditionTypeRolloutBlocked,
 			metav1.ConditionTrue,
 			reason,
-			err.Error(),
+			stsErr.Error(),
 		)
+	}
+
+	if !quayContext.StorageSTSEnabled {
+		if err := r.cleanupCredentialsRequest(ctx, updatedQuay); err != nil {
+			return r.reconcileWithCondition(
+				ctx,
+				&quay,
+				v1.ConditionTypeRolloutBlocked,
+				metav1.ConditionTrue,
+				v1.ConditionReasonCredentialRequestNotProvisioned,
+				fmt.Sprintf("unable to clean up STS credential request: %s", err),
+			)
+		}
 	}
 
 	if quayContext.StorageSTSEnabled {

--- a/controllers/quay/quayregistry_controller.go
+++ b/controllers/quay/quayregistry_controller.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	goerrors "errors"
 	"fmt"
 	"maps"
@@ -55,6 +56,7 @@ import (
 
 	v1 "github.com/quay/quay-operator/apis/quay/v1"
 	quaycontext "github.com/quay/quay-operator/pkg/context"
+	"github.com/quay/quay-operator/pkg/credentialsrequest"
 	"github.com/quay/quay-operator/pkg/kustomize"
 )
 
@@ -84,10 +86,11 @@ type QuayRegistryReconciler struct {
 	Requeue              ctrl.Result
 	SkipResourceRequests bool
 
-	// Cached route discovery results (write-once, read-many)
-	supportsRoutes      bool
-	clusterHostname     atomic.Pointer[string]
-	clusterWildcardCert atomic.Pointer[[]byte]
+	// Cached API discovery results (write-once, read-many)
+	supportsRoutes             bool
+	supportsCredentialsRequest bool
+	clusterHostname            atomic.Pointer[string]
+	clusterWildcardCert        atomic.Pointer[[]byte]
 }
 
 // manageQuayDeletion makes sure that we process a QuayRegistry once it is flagged for
@@ -506,6 +509,127 @@ func (r *QuayRegistryReconciler) cleanupProgrammaticBootstrapTokenResources(
 	return nil
 }
 
+const (
+	stsCredentialRequestSuffix = "aws-credentials"
+	stsCredentialSecretSuffix  = "aws-sts-credentials"
+	stsCloudTokenPath          = "/var/run/secrets/openshift/serviceaccount/token"
+	stsProvisionTimeout        = 5 * time.Minute
+)
+
+// ensureCredentialsRequest creates or updates the CredentialsRequest for STS
+// authentication and checks whether CCO has provisioned the resulting Secret.
+func (r *QuayRegistryReconciler) ensureCredentialsRequest(
+	ctx context.Context,
+	qctx *quaycontext.QuayRegistryContext,
+	quay *v1.QuayRegistry,
+) (ctrl.Result, error) {
+	if !qctx.StorageSTSEnabled {
+		return ctrl.Result{}, nil
+	}
+
+	crName := fmt.Sprintf("%s-%s", quay.GetName(), stsCredentialRequestSuffix)
+	secretName := fmt.Sprintf("%s-%s", quay.GetName(), stsCredentialSecretSuffix)
+	saName := fmt.Sprintf("%s-quay-app", quay.GetName())
+
+	desired, err := credentialsrequest.NewCredentialsRequest(
+		crName, quay.GetNamespace(),
+		secretName, quay.GetNamespace(),
+		qctx.STSRoleARN, stsCloudTokenPath,
+		[]string{saName},
+	)
+	if err != nil {
+		return r.Requeue, fmt.Errorf("unable to build CredentialsRequest: %w", err)
+	}
+
+	desired.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: v1.GroupVersion.String(),
+			Kind:       "QuayRegistry",
+			Name:       quay.GetName(),
+			UID:        quay.GetUID(),
+		},
+	})
+
+	var existing unstructured.Unstructured
+	existing.SetGroupVersionKind(credentialsrequest.CredentialsRequestGVK)
+	err = r.Get(ctx, types.NamespacedName{Name: crName, Namespace: quay.GetNamespace()}, &existing)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return r.Requeue, fmt.Errorf("unable to get CredentialsRequest: %w", err)
+		}
+
+		r.Log.Info("creating CredentialsRequest for STS", "name", crName)
+		if err := r.Create(ctx, desired); err != nil {
+			return r.Requeue, fmt.Errorf("unable to create CredentialsRequest: %w", err)
+		}
+
+		qctx.STSCredentialProvisioned = false
+		return r.Requeue, nil
+	}
+
+	// Update the CredentialsRequest if the spec has changed (e.g., role ARN changed).
+	existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+	desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	if existingSpec != nil && desiredSpec != nil {
+		existingJSON, _ := json.Marshal(existingSpec)
+		desiredJSON, _ := json.Marshal(desiredSpec)
+		if string(existingJSON) != string(desiredJSON) {
+			r.Log.Info("updating CredentialsRequest spec", "name", crName)
+			existing.Object["spec"] = desired.Object["spec"]
+			if err := r.Update(ctx, &existing); err != nil {
+				return r.Requeue, fmt.Errorf("unable to update CredentialsRequest: %w", err)
+			}
+			return r.Requeue, nil
+		}
+	}
+
+	// Check if CCO has provisioned the Secret.
+	var ccoSecret corev1.Secret
+	err = r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: quay.GetNamespace()}, &ccoSecret)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return r.Requeue, fmt.Errorf("unable to check CCO Secret: %w", err)
+		}
+
+		elapsed := time.Since(existing.GetCreationTimestamp().Time)
+		if elapsed > stsProvisionTimeout {
+			return r.reconcileWithCondition(
+				ctx, quay,
+				v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
+				v1.ConditionReasonCredentialRequestNotProvisioned,
+				"Cloud Credential Operator has not provisioned AWS credentials. "+
+					"Verify CCO is running and the cluster is OpenShift 4.14+. "+
+					"See operator logs for details.",
+			)
+		}
+
+		r.Log.Info("waiting for CCO to provision STS credentials", "elapsed", elapsed.Round(time.Second))
+		if err := r.updateWithCondition(
+			ctx, quay,
+			v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
+			v1.ConditionReasonCredentialRequestPending,
+			"Waiting for Cloud Credential Operator to provision AWS credentials for STS authentication",
+		); err != nil {
+			r.Log.Error(err, "failed to update conditions")
+		}
+		return r.Requeue, nil
+	}
+
+	if _, ok := ccoSecret.Data["credentials"]; !ok {
+		return r.reconcileWithCondition(
+			ctx, quay,
+			v1.ConditionTypeRolloutBlocked, metav1.ConditionTrue,
+			v1.ConditionReasonCredentialRequestNotProvisioned,
+			"CCO Secret exists but does not contain a 'credentials' key",
+		)
+	}
+
+	qctx.STSCredentialSecretName = secretName
+	qctx.STSCredentialProvisioned = true
+	r.Log.Info("STS credentials provisioned by CCO", "secret", secretName)
+	return ctrl.Result{}, nil
+}
+
 // quayAppDeploymentRolledOut returns true when the quay-app Deployment has fully
 // rolled out — that is, every desired replica is both updated and available. It is
 // used to gate the deletion of old rendered config secrets so that no running pod
@@ -557,6 +681,7 @@ func (r *QuayRegistryReconciler) quayAppDeploymentRolledOut(
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get
+// +kubebuilder:rbac:groups=cloudcredential.openshift.io,resources=credentialsrequests,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile is called every time an update happens in a QuayRegistry object. It attempts to
 // create all needed objects to get a quay instance running.
@@ -879,6 +1004,34 @@ func (r *QuayRegistryReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			v1.ConditionReasonConfigInvalid,
 			err.Error(),
 		)
+	}
+
+	if err := r.checkSTSCapability(ctx, quayContext, updatedQuay, usercfg); err != nil {
+		return r.reconcileWithCondition(
+			ctx,
+			&quay,
+			v1.ConditionTypeRolloutBlocked,
+			metav1.ConditionTrue,
+			v1.ConditionReasonConflictingCredentials,
+			err.Error(),
+		)
+	}
+
+	if quayContext.StorageSTSEnabled {
+		result, err := r.ensureCredentialsRequest(ctx, quayContext, updatedQuay)
+		if err != nil {
+			return r.reconcileWithCondition(
+				ctx,
+				&quay,
+				v1.ConditionTypeRolloutBlocked,
+				metav1.ConditionTrue,
+				v1.ConditionReasonCredentialRequestNotProvisioned,
+				fmt.Sprintf("STS credential request error: %s", err),
+			)
+		}
+		if !quayContext.STSCredentialProvisioned {
+			return result, nil
+		}
 	}
 
 	updatedQuay.Status.Conditions = v1.RemoveCondition(
@@ -1490,6 +1643,16 @@ func (r *QuayRegistryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r.Log.Info("Route API detected at startup")
 	} else {
 		r.Log.Info("Route API not available, running in non-OpenShift mode")
+	}
+
+	_, err = mgr.GetRESTMapper().RESTMapping(
+		schema.GroupKind{Group: "cloudcredential.openshift.io", Kind: "CredentialsRequest"},
+	)
+	r.supportsCredentialsRequest = (err == nil)
+	if r.supportsCredentialsRequest {
+		r.Log.Info("CredentialsRequest API detected at startup")
+	} else {
+		r.Log.Info("CredentialsRequest API not available, STS support disabled")
 	}
 
 	genChanged := builder.WithPredicates(predicate.GenerationChangedPredicate{})

--- a/controllers/quay/sts_test.go
+++ b/controllers/quay/sts_test.go
@@ -1,0 +1,329 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1 "github.com/quay/quay-operator/apis/quay/v1"
+	quaycontext "github.com/quay/quay-operator/pkg/context"
+	"github.com/quay/quay-operator/pkg/credentialsrequest"
+)
+
+const (
+	testSTSRoleARN = "arn:aws:iam::123456789012:role/quay-role"
+	testSTSBucket  = "quay-bucket"
+)
+
+func testQuayRegistry() *v1.QuayRegistry {
+	return &v1.QuayRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+}
+
+func testSTSContext() *quaycontext.QuayRegistryContext {
+	return &quaycontext.QuayRegistryContext{
+		StorageSTSEnabled: true,
+		STSRoleARN:        testSTSRoleARN,
+		STSStorageBuckets: []string{testSTSBucket},
+	}
+}
+
+func testCredentialsRequest(t *testing.T, quay *v1.QuayRegistry) *unstructured.Unstructured {
+	t.Helper()
+	request, err := credentialsrequest.NewCredentialsRequest(
+		"test-aws-credentials", quay.Namespace,
+		"test-aws-sts-credentials", quay.Namespace,
+		testSTSRoleARN, stsCloudTokenPath,
+		[]string{"test-quay-app"}, []string{testSTSBucket},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SetOwnerReferences([]metav1.OwnerReference{credentialsRequestOwnerReference(quay)})
+	request.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-time.Minute)))
+	request.SetGeneration(1)
+	return request
+}
+
+func testSTSReconciler(t *testing.T, quay *v1.QuayRegistry, objects ...client.Object) *QuayRegistryReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	allObjects := append([]client.Object{quay}, objects...)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(quay).
+		WithObjects(allObjects...).Build()
+	return &QuayRegistryReconciler{
+		Client:                     cli,
+		Log:                        logf.Log.WithName("sts-test"),
+		EventRecorder:              record.NewFakeRecorder(20),
+		Requeue:                    ctrl.Result{RequeueAfter: 10 * time.Second},
+		supportsCredentialsRequest: true,
+	}
+}
+
+func TestEnsureCredentialsRequestCreatesOwnedRequest(t *testing.T) {
+	quay := testQuayRegistry()
+	r := testSTSReconciler(t, quay)
+	qctx := testSTSContext()
+
+	result, err := r.ensureCredentialsRequest(context.Background(), qctx, quay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("RequeueAfter = %s, want 10s", result.RequeueAfter)
+	}
+
+	request := &unstructured.Unstructured{}
+	request.SetGroupVersionKind(credentialsrequest.CredentialsRequestGVK)
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Name: "test-aws-credentials", Namespace: quay.Namespace,
+	}, request); err != nil {
+		t.Fatal(err)
+	}
+	if !credentialsRequestOwnedBy(request, quay) {
+		t.Fatal("created CredentialsRequest is not owned by the QuayRegistry")
+	}
+	roleARN, _, err := unstructured.NestedString(request.Object, "spec", "providerSpec", "stsIAMRoleARN")
+	if err != nil || roleARN != testSTSRoleARN {
+		t.Fatalf("stsIAMRoleARN = %q, error = %v", roleARN, err)
+	}
+}
+
+func TestEnsureCredentialsRequestRejectsForeignOwner(t *testing.T) {
+	quay := testQuayRegistry()
+	request := testCredentialsRequest(t, quay)
+	request.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: v1.GroupVersion.String(), Kind: "QuayRegistry",
+		Name: "other", UID: types.UID("other-uid"),
+	}})
+	r := testSTSReconciler(t, quay, request)
+
+	_, err := r.ensureCredentialsRequest(context.Background(), testSTSContext(), quay)
+	if err == nil || !strings.Contains(err.Error(), "not owned") {
+		t.Fatalf("error = %v, want ownership conflict", err)
+	}
+}
+
+func TestEnsureCredentialsRequestUpdatesSpecDrift(t *testing.T) {
+	quay := testQuayRegistry()
+	request := testCredentialsRequest(t, quay)
+	request.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-time.Hour)))
+	if err := unstructured.SetNestedField(request.Object, "arn:aws:iam::123456789012:role/old", "spec", "providerSpec", "stsIAMRoleARN"); err != nil {
+		t.Fatal(err)
+	}
+	r := testSTSReconciler(t, quay, request)
+
+	result, err := r.ensureCredentialsRequest(context.Background(), testSTSContext(), quay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("RequeueAfter = %s, want 10s", result.RequeueAfter)
+	}
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(credentialsrequest.CredentialsRequestGVK)
+	if err := r.Get(context.Background(), types.NamespacedName{Name: request.GetName(), Namespace: request.GetNamespace()}, updated); err != nil {
+		t.Fatal(err)
+	}
+	roleARN, _, err := unstructured.NestedString(updated.Object, "spec", "providerSpec", "stsIAMRoleARN")
+	if err != nil || roleARN != testSTSRoleARN {
+		t.Fatalf("updated role ARN = %q, error = %v", roleARN, err)
+	}
+
+	// A spec update starts a fresh provisioning timeout even for an old request.
+	result, err = r.ensureCredentialsRequest(context.Background(), testSTSContext(), quay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("second RequeueAfter = %s, want 10s", result.RequeueAfter)
+	}
+	condition := v1.GetCondition(quay.Status.Conditions, v1.ConditionTypeRolloutBlocked)
+	if condition == nil || condition.Reason != v1.ConditionReasonCredentialRequestPending {
+		t.Fatalf("condition = %#v, want CredentialRequestPending", condition)
+	}
+}
+
+func TestEnsureCredentialsRequestWaitsForCurrentGeneration(t *testing.T) {
+	quay := testQuayRegistry()
+	request := testCredentialsRequest(t, quay)
+	request.SetGeneration(3)
+	if err := unstructured.SetNestedField(request.Object, true, "status", "provisioned"); err != nil {
+		t.Fatal(err)
+	}
+	if err := unstructured.SetNestedField(request.Object, int64(2), "status", "lastSyncGeneration"); err != nil {
+		t.Fatal(err)
+	}
+	r := testSTSReconciler(t, quay, request)
+
+	result, err := r.ensureCredentialsRequest(context.Background(), testSTSContext(), quay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("RequeueAfter = %s, want 10s", result.RequeueAfter)
+	}
+	condition := v1.GetCondition(quay.Status.Conditions, v1.ConditionTypeRolloutBlocked)
+	if condition == nil || condition.Reason != v1.ConditionReasonCredentialRequestPending {
+		t.Fatalf("condition = %#v, want CredentialRequestPending", condition)
+	}
+}
+
+func TestEnsureCredentialsRequestTimesOut(t *testing.T) {
+	quay := testQuayRegistry()
+	request := testCredentialsRequest(t, quay)
+	request.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-6 * time.Minute)))
+	r := testSTSReconciler(t, quay, request)
+
+	_, err := r.ensureCredentialsRequest(context.Background(), testSTSContext(), quay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	condition := v1.GetCondition(quay.Status.Conditions, v1.ConditionTypeRolloutBlocked)
+	if condition == nil || condition.Reason != v1.ConditionReasonCredentialRequestNotProvisioned {
+		t.Fatalf("condition = %#v, want CredentialRequestNotProvisioned", condition)
+	}
+}
+
+func TestEnsureCredentialsRequestAcceptsCurrentWebIdentitySecret(t *testing.T) {
+	quay := testQuayRegistry()
+	request := testCredentialsRequest(t, quay)
+	if err := unstructured.SetNestedField(request.Object, true, "status", "provisioned"); err != nil {
+		t.Fatal(err)
+	}
+	if err := unstructured.SetNestedField(request.Object, int64(1), "status", "lastSyncGeneration"); err != nil {
+		t.Fatal(err)
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-aws-sts-credentials", Namespace: quay.Namespace},
+		Data: map[string][]byte{"credentials": []byte(
+			"[default]\nrole_arn = " + testSTSRoleARN + "\nweb_identity_token_file = " + stsCloudTokenPath,
+		)},
+	}
+	r := testSTSReconciler(t, quay, request, secret)
+	qctx := testSTSContext()
+
+	result, err := r.ensureCredentialsRequest(context.Background(), qctx, quay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+	if !qctx.STSCredentialProvisioned || qctx.STSCredentialSecretName != secret.Name {
+		t.Fatalf("STS context not marked provisioned: %#v", qctx)
+	}
+}
+
+func TestEnsureCredentialsRequestRejectsStaticSecret(t *testing.T) {
+	quay := testQuayRegistry()
+	request := testCredentialsRequest(t, quay)
+	if err := unstructured.SetNestedField(request.Object, true, "status", "provisioned"); err != nil {
+		t.Fatal(err)
+	}
+	if err := unstructured.SetNestedField(request.Object, int64(1), "status", "lastSyncGeneration"); err != nil {
+		t.Fatal(err)
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-aws-sts-credentials", Namespace: quay.Namespace},
+		Data: map[string][]byte{"credentials": []byte(
+			"[default]\naws_access_key_id = AKIA\naws_secret_access_key = secret",
+		)},
+	}
+	r := testSTSReconciler(t, quay, request, secret)
+
+	_, err := r.ensureCredentialsRequest(context.Background(), testSTSContext(), quay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	condition := v1.GetCondition(quay.Status.Conditions, v1.ConditionTypeRolloutBlocked)
+	if condition == nil || condition.Reason != v1.ConditionReasonCredentialRequestNotProvisioned ||
+		!strings.Contains(condition.Message, "static AWS access keys") {
+		t.Fatalf("condition = %#v, want static-credential rejection", condition)
+	}
+}
+
+func TestValidateSTSSharedCredentials(t *testing.T) {
+	valid := "[default]\nrole_arn = " + testSTSRoleARN + "\nweb_identity_token_file = " + stsCloudTokenPath
+	for _, tt := range []struct {
+		name    string
+		data    string
+		roleARN string
+		token   string
+		wantErr string
+	}{
+		{name: "valid", data: valid, roleARN: testSTSRoleARN, token: stsCloudTokenPath},
+		{name: "empty", wantErr: "empty"},
+		{name: "static keys", data: "[default]\naws_access_key_id = AKIA\naws_secret_access_key = secret", roleARN: testSTSRoleARN, token: stsCloudTokenPath, wantErr: "static"},
+		{name: "wrong role", data: valid, roleARN: "arn:aws:iam::123:role/other", token: stsCloudTokenPath, wantErr: "role_arn"},
+		{name: "wrong token path", data: valid, roleARN: testSTSRoleARN, token: "/wrong", wantErr: "web_identity_token_file"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSTSSharedCredentials([]byte(tt.data), tt.roleARN, tt.token)
+			if tt.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("error = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCleanupCredentialsRequestHonorsOwnership(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		owned     bool
+		wantFound bool
+	}{
+		{name: "owned request is deleted", owned: true},
+		{name: "foreign request is preserved", wantFound: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			quay := testQuayRegistry()
+			request := testCredentialsRequest(t, quay)
+			if !tt.owned {
+				request.SetOwnerReferences(nil)
+			}
+			r := testSTSReconciler(t, quay, request)
+
+			if err := r.cleanupCredentialsRequest(context.Background(), quay); err != nil {
+				t.Fatal(err)
+			}
+			fetched := &unstructured.Unstructured{}
+			fetched.SetGroupVersionKind(credentialsrequest.CredentialsRequestGVK)
+			err := r.Get(context.Background(), types.NamespacedName{Name: request.GetName(), Namespace: request.GetNamespace()}, fetched)
+			if tt.wantFound && err != nil {
+				t.Fatalf("foreign request should remain: %v", err)
+			}
+			if !tt.wantFound && !apierrors.IsNotFound(err) {
+				t.Fatalf("owned request should be deleted, get error = %v", err)
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,12 @@ The Quay Operator is capable of managing the lifecycle of many of Quay's depende
 
 ## Configuring Quay
 
+### AWS STS for unmanaged S3
+
+On AWS STS-enabled OpenShift clusters, Quay can authenticate to unmanaged S3 storage with short-lived credentials brokered by the Cloud Credential Operator. The storage configuration must use `S3Storage` without static access keys, and the Operator Subscription must provide `ROLEARN`.
+
+See [AWS STS authentication for unmanaged S3 storage](sts-iam-setup.md) for IAM permissions, trust-policy creation, installation, troubleshooting, and standalone RHEL instructions.
+
 ### Zero-Config, Batteries-Included
 
 If you opt to have all components of Quay fully managed by the Operator and desire no additional configuration changes, you can omit the `spec.configBundleSecret` field of the `QuayRegistry` (in fact, all fields of the `spec` are optional). The Operator will generate a `Secret` for you containing a bundle of `config.yaml` (with all component fields) and TLS key/cert pair (self-signed). The `spec.configBundleSecret` field will then be auto-populated by the Operator during reconciliation.

--- a/docs/sts-iam-setup.md
+++ b/docs/sts-iam-setup.md
@@ -138,7 +138,6 @@ DISTRIBUTED_STORAGE_CONFIG:
       port: 443
       s3_bucket: example-quay-bucket
       storage_path: /datastorage/registry
-      is_secure: true
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
   - default
 DISTRIBUTED_STORAGE_PREFERENCE:

--- a/docs/sts-iam-setup.md
+++ b/docs/sts-iam-setup.md
@@ -1,0 +1,234 @@
+# AWS STS authentication for unmanaged S3 storage
+
+The Quay Operator can use OpenShift's Cloud Credential Operator (CCO) to give Quay workloads short-lived AWS credentials. This avoids storing IAM user access keys in the Quay configuration.
+
+This workflow requires:
+
+- OpenShift 4.14 or later on AWS;
+- a cluster installed for AWS Security Token Service (STS), with CCO in `Manual` mode and a configured service-account issuer;
+- an IAM role trusted by the OpenShift cluster's OIDC provider;
+- `objectstorage` set to `managed: false`;
+- a Quay `S3Storage` configuration without `s3_access_key` or `s3_secret_key`.
+
+Managed object storage such as NooBaa handles its own credentials and does not use this flow. The legacy Quay `STSS3Storage` driver is also not used; CCO's web-identity credentials file works with the standard `S3Storage` driver.
+
+## 1. Create the IAM policy
+
+Replace `QUAY_BUCKET` and `QUAY_ROLE_NAME` before running these commands. The policy is limited to the configured bucket and the S3 operations Quay requires.
+
+```bash
+export QUAY_BUCKET=example-quay-bucket
+export QUAY_ROLE_NAME=example-quay-sts
+export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+export AWS_PARTITION="$(aws sts get-caller-identity --query Arn --output text | cut -d: -f2)"
+
+cat >quay-s3-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": "arn:${AWS_PARTITION}:s3:::${QUAY_BUCKET}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Resource": "arn:${AWS_PARTITION}:s3:::${QUAY_BUCKET}/*"
+    }
+  ]
+}
+EOF
+
+aws iam create-policy \
+  --policy-name "${QUAY_ROLE_NAME}" \
+  --policy-document file://quay-s3-policy.json
+```
+
+The detected `AWS_PARTITION` also supports partitions such as AWS GovCloud (`aws-us-gov`).
+
+## 2. Create the role trust policy
+
+The role must trust the service account used by the Quay application and mirror workloads. Its name is `<QuayRegistry name>-quay-app`.
+
+```bash
+export QUAY_NAMESPACE=example-quay
+export QUAY_REGISTRY_NAME=example
+export QUAY_SERVICE_ACCOUNT="${QUAY_REGISTRY_NAME}-quay-app"
+export OIDC_ISSUER="$(oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}')"
+export OIDC_PROVIDER="${OIDC_ISSUER#https://}"
+
+cat >quay-trust-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${OIDC_PROVIDER}:aud": "openshift",
+          "${OIDC_PROVIDER}:sub": "system:serviceaccount:${QUAY_NAMESPACE}:${QUAY_SERVICE_ACCOUNT}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+aws iam create-role \
+  --role-name "${QUAY_ROLE_NAME}" \
+  --assume-role-policy-document file://quay-trust-policy.json
+
+aws iam attach-role-policy \
+  --role-name "${QUAY_ROLE_NAME}" \
+  --policy-arn "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:policy/${QUAY_ROLE_NAME}"
+
+export QUAY_ROLE_ARN="arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/${QUAY_ROLE_NAME}"
+```
+
+If one operator installation manages multiple Quay registries, the role's trust policy must allow each registry service-account subject, or each operator installation must be configured with a role appropriate for its managed registries.
+
+## 3. Install or update the Operator with `ROLEARN`
+
+For a CLI installation, set `ROLEARN` in the OLM Subscription. Manual install-plan approval is recommended so permission changes can be reviewed during upgrades.
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: quay-operator
+  namespace: openshift-operators
+spec:
+  channel: stable-3.19
+  installPlanApproval: Manual
+  name: quay-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    env:
+      - name: ROLEARN
+        value: arn:aws:iam::123456789012:role/example-quay-sts
+```
+
+The OpenShift console displays the AWS role field for Operator versions declaring token-authentication support.
+
+## 4. Configure credential-free S3 storage
+
+Create a config bundle containing `S3Storage` without static access keys:
+
+```yaml
+DISTRIBUTED_STORAGE_CONFIG:
+  default:
+    - S3Storage
+    - host: s3.amazonaws.com
+      port: 443
+      s3_bucket: example-quay-bucket
+      storage_path: /datastorage/registry
+      is_secure: true
+DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
+  - default
+DISTRIBUTED_STORAGE_PREFERENCE:
+  - default
+```
+
+```bash
+oc create secret generic example-config \
+  -n example-quay \
+  --from-file=config.yaml
+```
+
+Reference that Secret and mark object storage unmanaged:
+
+```yaml
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: example
+  namespace: example-quay
+spec:
+  configBundleSecret: example-config
+  components:
+    - kind: objectstorage
+      managed: false
+```
+
+When reconciliation succeeds, the Operator creates `example-aws-credentials`. CCO provisions `example-aws-sts-credentials`, and the Operator mounts it into the Quay application and mirror pods.
+
+## 5. Verify the integration
+
+Inspect status without printing credential or token contents:
+
+```bash
+oc get quayregistry example -n example-quay \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+
+oc get credentialsrequest example-aws-credentials -n example-quay \
+  -o jsonpath='{.status.provisioned}{"\t"}{.status.lastSyncGeneration}{"\n"}'
+
+oc get deployment example-quay-app -n example-quay \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AWS_SHARED_CREDENTIALS_FILE")].value}{"\n"}'
+```
+
+The environment value should be `/aws-sts/credentials`. Complete validation by pushing and pulling an image and, when enabled, running a repository mirror.
+
+Do not print or copy the projected service-account token into logs or support cases.
+
+## Conditions and troubleshooting
+
+| Reason | Meaning | Action |
+|---|---|---|
+| `CredentialRequestPending` | CCO has not yet provisioned the current request generation | Wait for CCO reconciliation and inspect the CredentialsRequest status |
+| `CredentialRequestNotProvisioned` | Provisioning timed out or the generated credentials are not valid web-identity credentials | Verify AWS platform, CCO Manual mode, OIDC issuer, role ARN, and CCO logs |
+| `ConflictingCredentials` | The S3 config contains `s3_access_key` or `s3_secret_key` | Remove static keys from every `S3Storage` entry |
+| `ConfigInvalid` with an STS message | The cluster, backend, or CCO mode cannot support the requested flow | Correct the reported prerequisite or remove `ROLEARN` |
+
+Useful checks:
+
+```bash
+oc get infrastructure cluster -o jsonpath='{.status.platformStatus.type}{"\n"}'
+oc get cloudcredential cluster -o jsonpath='{.spec.credentialsMode}{"\n"}'
+oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}{"\n"}'
+oc get credentialsrequest -n example-quay
+```
+
+Removing `ROLEARN`, changing to managed object storage, or changing away from `S3Storage` causes the Operator to delete its CredentialsRequest and remove the STS mounts on the next successful reconciliation.
+
+## Standalone RHEL-based Quay
+
+CCO and the Quay Operator are not present in a standalone RHEL deployment. The administrator must provide an OIDC token, keep it refreshed, and mount both it and an AWS shared credentials file into the Quay container.
+
+Example credentials file:
+
+```ini
+[default]
+role_arn = arn:aws:iam::123456789012:role/example-quay-sts
+web_identity_token_file = /run/secrets/quay/aws-web-identity-token
+```
+
+Mount the files read-only and set:
+
+```text
+AWS_SHARED_CREDENTIALS_FILE=/run/secrets/quay/aws-credentials
+```
+
+Continue to use `S3Storage` without static keys in `config.yaml`. The external identity system is responsible for issuing and rotating the token at `web_identity_token_file`; Quay does not create that token or configure the AWS OIDC provider. Test the token with AWS `AssumeRoleWithWebIdentity` before starting Quay.
+
+## Further reading
+
+- [OpenShift: enabling CCO-based AWS STS for Operators](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operators/developing-operators#osdk-cco-aws-sts)
+- [Cloud Credential Operator modes](https://github.com/openshift/cloud-credential-operator/blob/release-4.14/README.md#4-short-lived-tokens)
+- [AWS AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -75,6 +75,7 @@ type QuayRegistryContext struct {
 	// STS/CCO (Cloud Credential Operator)
 	StorageSTSEnabled        bool
 	STSRoleARN               string
+	STSStorageBuckets        []string
 	STSCredentialSecretName  string
 	STSCredentialProvisioned bool
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -71,6 +71,12 @@ type QuayRegistryContext struct {
 	ClairPostgresUseServiceCA bool
 	PostgresSSLRootCert       string
 	ClairPostgresSSLRootCert  string
+
+	// STS/CCO (Cloud Credential Operator)
+	StorageSTSEnabled        bool
+	STSRoleARN               string
+	STSCredentialSecretName  string
+	STSCredentialProvisioned bool
 }
 
 // NewQuayRegistryContext returns a fresh context for reconciling a `QuayRegistry`.

--- a/pkg/credentialsrequest/types.go
+++ b/pkg/credentialsrequest/types.go
@@ -56,8 +56,17 @@ func NewCredentialsRequest(
 ) (*unstructured.Unstructured, error) {
 	providerSpec, err := NewAWSProviderSpec(roleARN, []StatementEntry{
 		{
-			Effect:   "Allow",
-			Action:   []string{"s3:*"},
+			Effect: "Allow",
+			Action: []string{
+				"s3:GetObject",
+				"s3:PutObject",
+				"s3:DeleteObject",
+				"s3:ListBucket",
+				"s3:GetBucketLocation",
+				"s3:ListBucketMultipartUploads",
+				"s3:AbortMultipartUpload",
+				"s3:ListMultipartUploadParts",
+			},
 			Resource: "arn:aws:s3:*:*:*",
 		},
 	})

--- a/pkg/credentialsrequest/types.go
+++ b/pkg/credentialsrequest/types.go
@@ -1,0 +1,101 @@
+package credentialsrequest
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var CredentialsRequestGVK = schema.GroupVersionKind{
+	Group:   "cloudcredential.openshift.io",
+	Version: "v1",
+	Kind:    "CredentialsRequest",
+}
+
+type AWSProviderSpec struct {
+	APIVersion       string           `json:"apiVersion"`
+	Kind             string           `json:"kind"`
+	StatementEntries []StatementEntry `json:"statementEntries"`
+	STSIAMRoleARN    string           `json:"stsIAMRoleARN,omitempty"`
+}
+
+type StatementEntry struct {
+	Effect   string   `json:"effect"`
+	Action   []string `json:"action"`
+	Resource string   `json:"resource"`
+}
+
+type SecretRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type CredentialsRequestSpec struct {
+	SecretRef           SecretRef       `json:"secretRef"`
+	ProviderSpec        json.RawMessage `json:"providerSpec"`
+	ServiceAccountNames []string        `json:"serviceAccountNames"`
+	CloudTokenPath      string          `json:"cloudTokenPath"`
+}
+
+func NewAWSProviderSpec(roleARN string, statements []StatementEntry) (json.RawMessage, error) {
+	spec := AWSProviderSpec{
+		APIVersion:       "cloudcredential.openshift.io/v1",
+		Kind:             "AWSProviderSpec",
+		StatementEntries: statements,
+		STSIAMRoleARN:    roleARN,
+	}
+	return json.Marshal(spec)
+}
+
+func NewCredentialsRequest(
+	name, namespace string,
+	secretRefName, secretRefNamespace string,
+	roleARN, cloudTokenPath string,
+	serviceAccountNames []string,
+) (*unstructured.Unstructured, error) {
+	providerSpec, err := NewAWSProviderSpec(roleARN, []StatementEntry{
+		{
+			Effect:   "Allow",
+			Action:   []string{"s3:*"},
+			Resource: "arn:aws:s3:*:*:*",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	spec := CredentialsRequestSpec{
+		SecretRef: SecretRef{
+			Name:      secretRefName,
+			Namespace: secretRefNamespace,
+		},
+		ProviderSpec:        providerSpec,
+		ServiceAccountNames: serviceAccountNames,
+		CloudTokenPath:      cloudTokenPath,
+	}
+
+	specJSON, err := json.Marshal(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	var specMap map[string]interface{}
+	if err := json.Unmarshal(specJSON, &specMap); err != nil {
+		return nil, err
+	}
+
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": CredentialsRequestGVK.Group + "/" + CredentialsRequestGVK.Version,
+			"kind":       CredentialsRequestGVK.Kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": specMap,
+		},
+	}
+
+	return cr, nil
+}

--- a/pkg/credentialsrequest/types.go
+++ b/pkg/credentialsrequest/types.go
@@ -2,11 +2,16 @@ package credentialsrequest
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// These wire types intentionally mirror cloudcredential.openshift.io/v1 in
+// OpenShift 4.14+, without importing CCO's dependency-heavy internal API.
+// Source: github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
 var CredentialsRequestGVK = schema.GroupVersionKind{
 	Group:   "cloudcredential.openshift.io",
 	Version: "v1",
@@ -52,24 +57,52 @@ func NewCredentialsRequest(
 	name, namespace string,
 	secretRefName, secretRefNamespace string,
 	roleARN, cloudTokenPath string,
-	serviceAccountNames []string,
+	serviceAccountNames, buckets []string,
 ) (*unstructured.Unstructured, error) {
-	providerSpec, err := NewAWSProviderSpec(roleARN, []StatementEntry{
-		{
-			Effect: "Allow",
-			Action: []string{
-				"s3:GetObject",
-				"s3:PutObject",
-				"s3:DeleteObject",
-				"s3:ListBucket",
-				"s3:GetBucketLocation",
-				"s3:ListBucketMultipartUploads",
-				"s3:AbortMultipartUpload",
-				"s3:ListMultipartUploadParts",
+	if len(buckets) == 0 {
+		return nil, fmt.Errorf("at least one S3 bucket is required")
+	}
+
+	partition, err := awsPartitionFromRoleARN(roleARN)
+	if err != nil {
+		return nil, err
+	}
+
+	statements := make([]StatementEntry, 0, len(buckets)*2)
+	for _, bucket := range buckets {
+		bucket = strings.TrimSpace(bucket)
+		if bucket == "" {
+			return nil, fmt.Errorf("S3 bucket must not be empty")
+		}
+		if strings.ContainsAny(bucket, "*?") {
+			return nil, fmt.Errorf("S3 bucket %q contains wildcard characters", bucket)
+		}
+		bucketARN := fmt.Sprintf("arn:%s:s3:::%s", partition, bucket)
+		statements = append(statements,
+			StatementEntry{
+				Effect: "Allow",
+				Action: []string{
+					"s3:ListBucket",
+					"s3:GetBucketLocation",
+					"s3:ListBucketMultipartUploads",
+				},
+				Resource: bucketARN,
 			},
-			Resource: "arn:aws:s3:*:*:*",
-		},
-	})
+			StatementEntry{
+				Effect: "Allow",
+				Action: []string{
+					"s3:GetObject",
+					"s3:PutObject",
+					"s3:DeleteObject",
+					"s3:AbortMultipartUpload",
+					"s3:ListMultipartUploadParts",
+				},
+				Resource: bucketARN + "/*",
+			},
+		)
+	}
+
+	providerSpec, err := NewAWSProviderSpec(roleARN, statements)
 	if err != nil {
 		return nil, err
 	}
@@ -107,4 +140,13 @@ func NewCredentialsRequest(
 	}
 
 	return cr, nil
+}
+
+func awsPartitionFromRoleARN(roleARN string) (string, error) {
+	parts := strings.SplitN(strings.TrimSpace(roleARN), ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[1] == "" || parts[2] != "iam" ||
+		parts[3] != "" || parts[4] == "" || !strings.HasPrefix(parts[5], "role/") || len(parts[5]) == len("role/") {
+		return "", fmt.Errorf("ROLEARN must be a valid AWS IAM role ARN")
+	}
+	return parts[1], nil
 }

--- a/pkg/credentialsrequest/types_test.go
+++ b/pkg/credentialsrequest/types_test.go
@@ -1,0 +1,98 @@
+package credentialsrequest
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewCredentialsRequest(t *testing.T) {
+	cr, err := NewCredentialsRequest(
+		"test-aws-credentials", "test-namespace",
+		"test-aws-sts-credentials", "test-namespace",
+		"arn:aws:iam::123456789012:role/quay-role",
+		"/var/run/secrets/openshift/serviceaccount/token",
+		[]string{"test-quay-app"},
+	)
+	if err != nil {
+		t.Fatalf("NewCredentialsRequest() error = %v", err)
+	}
+
+	t.Run("correct GVK", func(t *testing.T) {
+		gvk := cr.GroupVersionKind()
+		if gvk.Group != "cloudcredential.openshift.io" {
+			t.Errorf("Group = %q, want %q", gvk.Group, "cloudcredential.openshift.io")
+		}
+		if gvk.Version != "v1" {
+			t.Errorf("Version = %q, want %q", gvk.Version, "v1")
+		}
+		if gvk.Kind != "CredentialsRequest" {
+			t.Errorf("Kind = %q, want %q", gvk.Kind, "CredentialsRequest")
+		}
+	})
+
+	t.Run("correct metadata", func(t *testing.T) {
+		if cr.GetName() != "test-aws-credentials" {
+			t.Errorf("Name = %q, want %q", cr.GetName(), "test-aws-credentials")
+		}
+		if cr.GetNamespace() != "test-namespace" {
+			t.Errorf("Namespace = %q, want %q", cr.GetNamespace(), "test-namespace")
+		}
+	})
+
+	t.Run("correct spec fields", func(t *testing.T) {
+		spec, ok := cr.Object["spec"].(map[string]interface{})
+		if !ok {
+			t.Fatal("spec is not a map")
+		}
+
+		secretRef, ok := spec["secretRef"].(map[string]interface{})
+		if !ok {
+			t.Fatal("secretRef is not a map")
+		}
+		if secretRef["name"] != "test-aws-sts-credentials" {
+			t.Errorf("secretRef.name = %v, want %q", secretRef["name"], "test-aws-sts-credentials")
+		}
+		if secretRef["namespace"] != "test-namespace" {
+			t.Errorf("secretRef.namespace = %v, want %q", secretRef["namespace"], "test-namespace")
+		}
+
+		if spec["cloudTokenPath"] != "/var/run/secrets/openshift/serviceaccount/token" {
+			t.Errorf("cloudTokenPath = %v, want %q", spec["cloudTokenPath"], "/var/run/secrets/openshift/serviceaccount/token")
+		}
+
+		saNames, ok := spec["serviceAccountNames"].([]interface{})
+		if !ok {
+			t.Fatal("serviceAccountNames is not a slice")
+		}
+		if len(saNames) != 1 || saNames[0] != "test-quay-app" {
+			t.Errorf("serviceAccountNames = %v, want [test-quay-app]", saNames)
+		}
+	})
+
+	t.Run("providerSpec contains role ARN", func(t *testing.T) {
+		spec := cr.Object["spec"].(map[string]interface{})
+		providerSpec := spec["providerSpec"]
+		providerJSON, err := json.Marshal(providerSpec)
+		if err != nil {
+			t.Fatalf("failed to marshal providerSpec: %v", err)
+		}
+
+		var ps AWSProviderSpec
+		if err := json.Unmarshal(providerJSON, &ps); err != nil {
+			t.Fatalf("failed to unmarshal providerSpec: %v", err)
+		}
+
+		if ps.STSIAMRoleARN != "arn:aws:iam::123456789012:role/quay-role" {
+			t.Errorf("stsIAMRoleARN = %q, want %q", ps.STSIAMRoleARN, "arn:aws:iam::123456789012:role/quay-role")
+		}
+		if ps.Kind != "AWSProviderSpec" {
+			t.Errorf("Kind = %q, want %q", ps.Kind, "AWSProviderSpec")
+		}
+		if len(ps.StatementEntries) == 0 {
+			t.Fatal("StatementEntries is empty")
+		}
+		if ps.StatementEntries[0].Effect != "Allow" {
+			t.Errorf("Effect = %q, want %q", ps.StatementEntries[0].Effect, "Allow")
+		}
+	})
+}

--- a/pkg/credentialsrequest/types_test.go
+++ b/pkg/credentialsrequest/types_test.go
@@ -11,7 +11,7 @@ func TestNewCredentialsRequest(t *testing.T) {
 		"test-aws-sts-credentials", "test-namespace",
 		"arn:aws:iam::123456789012:role/quay-role",
 		"/var/run/secrets/openshift/serviceaccount/token",
-		[]string{"test-quay-app"},
+		[]string{"test-quay-app"}, []string{"quay-bucket"},
 	)
 	if err != nil {
 		t.Fatalf("NewCredentialsRequest() error = %v", err)
@@ -88,11 +88,75 @@ func TestNewCredentialsRequest(t *testing.T) {
 		if ps.Kind != "AWSProviderSpec" {
 			t.Errorf("Kind = %q, want %q", ps.Kind, "AWSProviderSpec")
 		}
-		if len(ps.StatementEntries) == 0 {
-			t.Fatal("StatementEntries is empty")
+		if len(ps.StatementEntries) != 2 {
+			t.Fatalf("len(StatementEntries) = %d, want 2", len(ps.StatementEntries))
 		}
 		if ps.StatementEntries[0].Effect != "Allow" {
 			t.Errorf("Effect = %q, want %q", ps.StatementEntries[0].Effect, "Allow")
 		}
+		if ps.StatementEntries[0].Resource != "arn:aws:s3:::quay-bucket" {
+			t.Errorf("bucket Resource = %q", ps.StatementEntries[0].Resource)
+		}
+		if ps.StatementEntries[1].Resource != "arn:aws:s3:::quay-bucket/*" {
+			t.Errorf("object Resource = %q", ps.StatementEntries[1].Resource)
+		}
 	})
+}
+
+func TestNewCredentialsRequestRequiresBucket(t *testing.T) {
+	_, err := NewCredentialsRequest(
+		"test", "test-ns", "secret", "test-ns",
+		"arn:aws:iam::123456789012:role/quay-role",
+		"/var/run/secrets/openshift/serviceaccount/token",
+		[]string{"test-quay-app"}, nil,
+	)
+	if err == nil {
+		t.Fatal("expected an error when no S3 bucket is supplied")
+	}
+}
+
+func TestNewCredentialsRequestRejectsInvalidScope(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		roleARN string
+		bucket  string
+	}{
+		{name: "malformed role ARN", roleARN: "not-an-arn", bucket: "quay-bucket"},
+		{name: "non-IAM ARN", roleARN: "arn:aws:s3:::bucket", bucket: "quay-bucket"},
+		{name: "bucket wildcard", roleARN: "arn:aws:iam::123456789012:role/quay-role", bucket: "quay-*"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewCredentialsRequest(
+				"test", "test-ns", "secret", "test-ns",
+				tt.roleARN, "/var/run/token", []string{"test-quay-app"}, []string{tt.bucket},
+			)
+			if err == nil {
+				t.Fatal("expected invalid scope to be rejected")
+			}
+		})
+	}
+}
+
+func TestNewCredentialsRequestUsesRolePartition(t *testing.T) {
+	cr, err := NewCredentialsRequest(
+		"test", "test-ns", "secret", "test-ns",
+		"arn:aws-us-gov:iam::123456789012:role/quay-role",
+		"/var/run/secrets/openshift/serviceaccount/token",
+		[]string{"test-quay-app"}, []string{"quay-bucket"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := cr.Object["spec"].(map[string]interface{})
+	providerJSON, err := json.Marshal(spec["providerSpec"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var provider AWSProviderSpec
+	if err := json.Unmarshal(providerJSON, &provider); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.StatementEntries[0].Resource; got != "arn:aws-us-gov:s3:::quay-bucket" {
+		t.Fatalf("Resource = %q, want GovCloud partition", got)
+	}
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -700,29 +700,31 @@ func applySTSCredentials(dep *appsv1.Deployment, qctx *quaycontext.QuayRegistryC
 		Value: "/aws-sts/credentials",
 	}
 
-	dep.Spec.Template.Spec.Volumes = appendVolumeIfAbsent(dep.Spec.Template.Spec.Volumes, credVolume)
-	dep.Spec.Template.Spec.Volumes = appendVolumeIfAbsent(dep.Spec.Template.Spec.Volumes, tokenVolume)
+	dep.Spec.Template.Spec.Volumes = upsertVolume(dep.Spec.Template.Spec.Volumes, credVolume)
+	dep.Spec.Template.Spec.Volumes = upsertVolume(dep.Spec.Template.Spec.Volumes, tokenVolume)
 
 	for i := range dep.Spec.Template.Spec.Containers {
 		ref := &dep.Spec.Template.Spec.Containers[i]
-		ref.VolumeMounts = appendVolumeMountIfAbsent(ref.VolumeMounts, credMount)
-		ref.VolumeMounts = appendVolumeMountIfAbsent(ref.VolumeMounts, tokenMount)
+		ref.VolumeMounts = upsertVolumeMount(ref.VolumeMounts, credMount)
+		ref.VolumeMounts = upsertVolumeMount(ref.VolumeMounts, tokenMount)
 		UpsertContainerEnv(ref, envVar)
 	}
 }
 
-func appendVolumeIfAbsent(volumes []corev1.Volume, vol corev1.Volume) []corev1.Volume {
-	for _, v := range volumes {
+func upsertVolume(volumes []corev1.Volume, vol corev1.Volume) []corev1.Volume {
+	for i, v := range volumes {
 		if v.Name == vol.Name {
+			volumes[i] = vol
 			return volumes
 		}
 	}
 	return append(volumes, vol)
 }
 
-func appendVolumeMountIfAbsent(mounts []corev1.VolumeMount, mount corev1.VolumeMount) []corev1.VolumeMount {
-	for _, m := range mounts {
+func upsertVolumeMount(mounts []corev1.VolumeMount, mount corev1.VolumeMount) []corev1.VolumeMount {
+	for i, m := range mounts {
 		if m.Name == mount.Name {
+			mounts[i] = mount
 			return mounts
 		}
 	}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -232,6 +232,12 @@ func Process(quay *v1.QuayRegistry, qctx *quaycontext.QuayRegistryContext, obj c
 			return dep, nil
 		}
 
+		if qctx.StorageSTSEnabled && qctx.STSCredentialProvisioned {
+			if strings.HasSuffix(dep.Name, "quay-app") || strings.HasSuffix(dep.Name, "quay-mirror") {
+				applySTSCredentials(dep, qctx)
+			}
+		}
+
 		fgns, err := v1.FieldGroupNamesForManagedComponents(quay)
 		if err != nil {
 			return nil, err
@@ -649,4 +655,76 @@ func clairPostgresCASecretName(quay *v1.QuayRegistry, override *v1.TLSOverride) 
 		return override.SecretRef.Name
 	}
 	return quay.GetName() + "-clairpostgres-ca"
+}
+
+func applySTSCredentials(dep *appsv1.Deployment, qctx *quaycontext.QuayRegistryContext) {
+	credVolume := corev1.Volume{
+		Name: "aws-sts-credentials",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: qctx.STSCredentialSecretName,
+			},
+		},
+	}
+
+	tokenVolume := corev1.Volume{
+		Name: "bound-sa-token",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Path:     "token",
+							Audience: "openshift",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	credMount := corev1.VolumeMount{
+		Name:      "aws-sts-credentials",
+		MountPath: "/aws-sts",
+		ReadOnly:  true,
+	}
+
+	tokenMount := corev1.VolumeMount{
+		Name:      "bound-sa-token",
+		MountPath: "/var/run/secrets/openshift/serviceaccount",
+		ReadOnly:  true,
+	}
+
+	envVar := corev1.EnvVar{
+		Name:  "AWS_SHARED_CREDENTIALS_FILE",
+		Value: "/aws-sts/credentials",
+	}
+
+	dep.Spec.Template.Spec.Volumes = appendVolumeIfAbsent(dep.Spec.Template.Spec.Volumes, credVolume)
+	dep.Spec.Template.Spec.Volumes = appendVolumeIfAbsent(dep.Spec.Template.Spec.Volumes, tokenVolume)
+
+	for i := range dep.Spec.Template.Spec.Containers {
+		ref := &dep.Spec.Template.Spec.Containers[i]
+		ref.VolumeMounts = appendVolumeMountIfAbsent(ref.VolumeMounts, credMount)
+		ref.VolumeMounts = appendVolumeMountIfAbsent(ref.VolumeMounts, tokenMount)
+		UpsertContainerEnv(ref, envVar)
+	}
+}
+
+func appendVolumeIfAbsent(volumes []corev1.Volume, vol corev1.Volume) []corev1.Volume {
+	for _, v := range volumes {
+		if v.Name == vol.Name {
+			return volumes
+		}
+	}
+	return append(volumes, vol)
+}
+
+func appendVolumeMountIfAbsent(mounts []corev1.VolumeMount, mount corev1.VolumeMount) []corev1.VolumeMount {
+	for _, m := range mounts {
+		if m.Name == mount.Name {
+			return mounts
+		}
+	}
+	return append(mounts, mount)
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -695,9 +695,17 @@ func applySTSCredentials(dep *appsv1.Deployment, qctx *quaycontext.QuayRegistryC
 		ReadOnly:  true,
 	}
 
-	envVar := corev1.EnvVar{
-		Name:  "AWS_SHARED_CREDENTIALS_FILE",
-		Value: "/aws-sts/credentials",
+	// The Go AWS SDK requires shared config loading to resolve the CCO profile's
+	// role_arn and web_identity_token_file fields. Boto3 reads the same profile.
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "AWS_SHARED_CREDENTIALS_FILE",
+			Value: "/aws-sts/credentials",
+		},
+		{
+			Name:  "AWS_SDK_LOAD_CONFIG",
+			Value: "true",
+		},
 	}
 
 	dep.Spec.Template.Spec.Volumes = upsertVolume(dep.Spec.Template.Spec.Volumes, credVolume)
@@ -707,7 +715,9 @@ func applySTSCredentials(dep *appsv1.Deployment, qctx *quaycontext.QuayRegistryC
 		ref := &dep.Spec.Template.Spec.Containers[i]
 		ref.VolumeMounts = upsertVolumeMount(ref.VolumeMounts, credMount)
 		ref.VolumeMounts = upsertVolumeMount(ref.VolumeMounts, tokenMount)
-		UpsertContainerEnv(ref, envVar)
+		for _, envVar := range envVars {
+			UpsertContainerEnv(ref, envVar)
+		}
 	}
 }
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -1291,3 +1291,88 @@ func TestProcessPostgresDeploymentCAHashAnnotation(t *testing.T) {
 		}
 	})
 }
+
+func TestApplySTSCredentials(t *testing.T) {
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "quay-app"},
+					},
+				},
+			},
+		},
+	}
+
+	qctx := &quaycontext.QuayRegistryContext{
+		StorageSTSEnabled:        true,
+		STSCredentialProvisioned: true,
+		STSCredentialSecretName:  "test-aws-sts-credentials",
+	}
+
+	applySTSCredentials(dep, qctx)
+
+	t.Run("adds CCO Secret volume", func(t *testing.T) {
+		found := false
+		for _, v := range dep.Spec.Template.Spec.Volumes {
+			if v.Name == "aws-sts-credentials" {
+				found = true
+				assert.Equal(t, "test-aws-sts-credentials", v.Secret.SecretName)
+			}
+		}
+		assert.True(t, found, "aws-sts-credentials volume not found")
+	})
+
+	t.Run("adds bound-sa-token volume", func(t *testing.T) {
+		found := false
+		for _, v := range dep.Spec.Template.Spec.Volumes {
+			if v.Name == "bound-sa-token" {
+				found = true
+				assert.NotNil(t, v.Projected)
+				assert.Equal(t, "token", v.Projected.Sources[0].ServiceAccountToken.Path)
+				assert.Equal(t, "openshift", v.Projected.Sources[0].ServiceAccountToken.Audience)
+			}
+		}
+		assert.True(t, found, "bound-sa-token volume not found")
+	})
+
+	t.Run("adds volume mounts to container", func(t *testing.T) {
+		container := dep.Spec.Template.Spec.Containers[0]
+		credMountFound := false
+		tokenMountFound := false
+		for _, m := range container.VolumeMounts {
+			if m.Name == "aws-sts-credentials" && m.MountPath == "/aws-sts" {
+				credMountFound = true
+			}
+			if m.Name == "bound-sa-token" && m.MountPath == "/var/run/secrets/openshift/serviceaccount" {
+				tokenMountFound = true
+			}
+		}
+		assert.True(t, credMountFound, "aws-sts-credentials mount not found")
+		assert.True(t, tokenMountFound, "bound-sa-token mount not found")
+	})
+
+	t.Run("sets AWS_SHARED_CREDENTIALS_FILE env var", func(t *testing.T) {
+		container := dep.Spec.Template.Spec.Containers[0]
+		found := false
+		for _, e := range container.Env {
+			if e.Name == "AWS_SHARED_CREDENTIALS_FILE" {
+				found = true
+				assert.Equal(t, "/aws-sts/credentials", e.Value)
+			}
+		}
+		assert.True(t, found, "AWS_SHARED_CREDENTIALS_FILE env not found")
+	})
+
+	t.Run("idempotent on second call", func(t *testing.T) {
+		volCountBefore := len(dep.Spec.Template.Spec.Volumes)
+		mountCountBefore := len(dep.Spec.Template.Spec.Containers[0].VolumeMounts)
+
+		applySTSCredentials(dep, qctx)
+
+		assert.Equal(t, volCountBefore, len(dep.Spec.Template.Spec.Volumes))
+		assert.Equal(t, mountCountBefore, len(dep.Spec.Template.Spec.Containers[0].VolumeMounts))
+	})
+}

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -1375,4 +1375,54 @@ func TestApplySTSCredentials(t *testing.T) {
 		assert.Equal(t, volCountBefore, len(dep.Spec.Template.Spec.Volumes))
 		assert.Equal(t, mountCountBefore, len(dep.Spec.Template.Spec.Containers[0].VolumeMounts))
 	})
+
+	t.Run("replaces conflicting volume definition", func(t *testing.T) {
+		staleSecret := "old-stale-secret"
+		conflictDep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								Name: "aws-sts-credentials",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: staleSecret,
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{
+								Name: "quay-app",
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "aws-sts-credentials", MountPath: "/old-path"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applySTSCredentials(conflictDep, qctx)
+
+		for _, v := range conflictDep.Spec.Template.Spec.Volumes {
+			if v.Name == "aws-sts-credentials" {
+				assert.Equal(t, "test-aws-sts-credentials", v.Secret.SecretName,
+					"stale Secret name should be replaced")
+			}
+		}
+
+		for _, m := range conflictDep.Spec.Template.Spec.Containers[0].VolumeMounts {
+			if m.Name == "aws-sts-credentials" {
+				assert.Equal(t, "/aws-sts", m.MountPath,
+					"stale mount path should be replaced")
+			}
+		}
+
+		assert.Equal(t, 2, len(conflictDep.Spec.Template.Spec.Volumes),
+			"should have exactly 2 volumes (replaced + new)")
+	})
 }

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -1332,13 +1332,12 @@ func TestProcessSTSCredentialsTargetsOnlyQuayWorkloads(t *testing.T) {
 			processed, err := Process(quay, qctx, dep, false)
 			assert.NoError(t, err)
 			result := processed.(*appsv1.Deployment)
-			found := false
+			envValues := map[string]string{}
 			for _, env := range result.Spec.Template.Spec.Containers[0].Env {
-				if env.Name == "AWS_SHARED_CREDENTIALS_FILE" {
-					found = true
-				}
+				envValues[env.Name] = env.Value
 			}
-			assert.Equal(t, tt.wantSTS, found)
+			assert.Equal(t, tt.wantSTS, envValues["AWS_SHARED_CREDENTIALS_FILE"] == "/aws-sts/credentials")
+			assert.Equal(t, tt.wantSTS, envValues["AWS_SDK_LOAD_CONFIG"] == "true")
 			if tt.withInit {
 				assert.Empty(t, result.Spec.Template.Spec.InitContainers[0].Env)
 				assert.Empty(t, result.Spec.Template.Spec.InitContainers[0].VolumeMounts)
@@ -1409,26 +1408,26 @@ func TestApplySTSCredentials(t *testing.T) {
 		assert.True(t, tokenMountFound, "bound-sa-token mount not found")
 	})
 
-	t.Run("sets AWS_SHARED_CREDENTIALS_FILE env var", func(t *testing.T) {
+	t.Run("sets AWS credential environment", func(t *testing.T) {
 		container := dep.Spec.Template.Spec.Containers[0]
-		found := false
-		for _, e := range container.Env {
-			if e.Name == "AWS_SHARED_CREDENTIALS_FILE" {
-				found = true
-				assert.Equal(t, "/aws-sts/credentials", e.Value)
-			}
+		envValues := map[string]string{}
+		for _, env := range container.Env {
+			envValues[env.Name] = env.Value
 		}
-		assert.True(t, found, "AWS_SHARED_CREDENTIALS_FILE env not found")
+		assert.Equal(t, "/aws-sts/credentials", envValues["AWS_SHARED_CREDENTIALS_FILE"])
+		assert.Equal(t, "true", envValues["AWS_SDK_LOAD_CONFIG"])
 	})
 
 	t.Run("idempotent on second call", func(t *testing.T) {
 		volCountBefore := len(dep.Spec.Template.Spec.Volumes)
 		mountCountBefore := len(dep.Spec.Template.Spec.Containers[0].VolumeMounts)
+		envCountBefore := len(dep.Spec.Template.Spec.Containers[0].Env)
 
 		applySTSCredentials(dep, qctx)
 
 		assert.Equal(t, volCountBefore, len(dep.Spec.Template.Spec.Volumes))
 		assert.Equal(t, mountCountBefore, len(dep.Spec.Template.Spec.Containers[0].VolumeMounts))
+		assert.Equal(t, envCountBefore, len(dep.Spec.Template.Spec.Containers[0].Env))
 	})
 
 	t.Run("replaces conflicting volume definition", func(t *testing.T) {

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -1292,6 +1292,61 @@ func TestProcessPostgresDeploymentCAHashAnnotation(t *testing.T) {
 	})
 }
 
+func TestProcessSTSCredentialsTargetsOnlyQuayWorkloads(t *testing.T) {
+	quay := &v1.QuayRegistry{Spec: v1.QuayRegistrySpec{Components: []v1.Component{
+		{Kind: v1.ComponentQuay, Managed: true},
+		{Kind: v1.ComponentMirror, Managed: true},
+		{Kind: v1.ComponentClair, Managed: true},
+	}}}
+	qctx := &quaycontext.QuayRegistryContext{
+		StorageSTSEnabled:        true,
+		STSCredentialProvisioned: true,
+		STSCredentialSecretName:  "test-aws-sts-credentials",
+	}
+
+	for _, tt := range []struct {
+		name      string
+		component string
+		wantSTS   bool
+		withInit  bool
+	}{
+		{name: "test-quay-app", component: "quay", wantSTS: true},
+		{name: "test-quay-mirror", component: "mirror", wantSTS: true, withInit: true},
+		{name: "test-clair-app", component: "clair"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tt.name, Labels: map[string]string{"quay-component": tt.component},
+					Annotations: map[string]string{"quay-component": tt.component},
+				},
+				Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: tt.name}}},
+				}},
+			}
+			if tt.withInit {
+				dep.Spec.Template.Spec.InitContainers = []corev1.Container{{Name: "init"}}
+			}
+
+			processed, err := Process(quay, qctx, dep, false)
+			assert.NoError(t, err)
+			result := processed.(*appsv1.Deployment)
+			found := false
+			for _, env := range result.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "AWS_SHARED_CREDENTIALS_FILE" {
+					found = true
+				}
+			}
+			assert.Equal(t, tt.wantSTS, found)
+			if tt.withInit {
+				assert.Empty(t, result.Spec.Template.Spec.InitContainers[0].Env)
+				assert.Empty(t, result.Spec.Template.Spec.InitContainers[0].VolumeMounts)
+			}
+		})
+	}
+}
+
 func TestApplySTSCredentials(t *testing.T) {
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-quay-app"},

--- a/test/chainsaw/Makefile
+++ b/test/chainsaw/Makefile
@@ -6,12 +6,13 @@ CHAINSAW_CONFIG := test/chainsaw/.chainsaw.yaml
 CHAINSAW_TEST_DIR := test/chainsaw/
 CHAINSAW_VALUES_OPENSHIFT := test/chainsaw/values-openshift.yaml
 CHAINSAW_VALUES_KIND := test/chainsaw/values-kind.yaml
+CHAINSAW_STS_TEST_DIR := test/chainsaw/sts_cco/
 CHAINSAW_REPORT_FORMAT ?=
 CHAINSAW_REPORT_PATH ?=
 CHAINSAW_REPORT_NAME ?= chainsaw-report
 CHAINSAW_REPORT_FLAGS := $(if $(CHAINSAW_REPORT_FORMAT),--report-format $(CHAINSAW_REPORT_FORMAT) --report-name $(CHAINSAW_REPORT_NAME) --report-path $(or $(CHAINSAW_REPORT_PATH),.))
 
-.PHONY: chainsaw test-e2e test-e2e-destructive test-e2e-hpa test-e2e-kind
+.PHONY: chainsaw test-e2e test-e2e-destructive test-e2e-hpa test-e2e-kind test-e2e-sts
 
 chainsaw: $(CHAINSAW) ## Download chainsaw locally if necessary.
 $(CHAINSAW): $(LOCALBIN)
@@ -20,10 +21,19 @@ $(CHAINSAW): $(LOCALBIN)
 	{ curl -sL "https://github.com/kyverno/chainsaw/releases/download/$(CHAINSAW_VERSION)/chainsaw_linux_amd64.tar.gz" | tar -xz -C $(LOCALBIN) chainsaw; }
 
 test-e2e: chainsaw ## Run Chainsaw e2e tests (excludes destructive tests)
-	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/postgres.tls.lifecycle" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
+	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/postgres.tls.lifecycle|/sts_cco" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
 
 test-e2e-destructive: chainsaw ## Run destructive Chainsaw e2e tests (ca-rotation, postgres-tls-lifecycle, OpenShift only)
 	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --include-test-regex "/ca.rotation|/postgres.tls.lifecycle" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
 
 test-e2e-kind: chainsaw ## Run Chainsaw e2e tests (KinD)
-	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_KIND) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/hpa|/tls.security.profile|/postgres.tls.lifecycle|/postgres.tls.service.ca" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
+	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_KIND) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/hpa|/tls.security.profile|/postgres.tls.lifecycle|/postgres.tls.service.ca|/sts_cco" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
+
+test-e2e-sts: chainsaw ## Run STS/CCO tests against an AWS OpenShift cluster
+	@test -n "$(STS_TEST_NAMESPACE)" || (echo "ERROR: STS_TEST_NAMESPACE is required" && exit 1)
+	@test -n "$(STS_S3_BUCKET)" || (echo "ERROR: STS_S3_BUCKET is required" && exit 1)
+	@test -n "$(STS_S3_REGION)" || (echo "ERROR: STS_S3_REGION is required" && exit 1)
+	@test -n "$(STS_ROLE_ARN)" || (echo "ERROR: STS_ROLE_ARN is required" && exit 1)
+	@kubectl get namespace "$(STS_TEST_NAMESPACE)" >/dev/null 2>&1 || kubectl create namespace "$(STS_TEST_NAMESPACE)"
+	@NAMESPACE="$(STS_TEST_NAMESPACE)" STS_S3_BUCKET="$(STS_S3_BUCKET)" STS_S3_REGION="$(STS_S3_REGION)" STS_ROLE_ARN="$(STS_ROLE_ARN)" \
+		$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_STS_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --namespace "$(STS_TEST_NAMESPACE)" --parallel 1 $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)

--- a/test/chainsaw/Makefile
+++ b/test/chainsaw/Makefile
@@ -21,13 +21,13 @@ $(CHAINSAW): $(LOCALBIN)
 	{ curl -sL "https://github.com/kyverno/chainsaw/releases/download/$(CHAINSAW_VERSION)/chainsaw_linux_amd64.tar.gz" | tar -xz -C $(LOCALBIN) chainsaw; }
 
 test-e2e: chainsaw ## Run Chainsaw e2e tests (excludes destructive tests)
-	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/postgres.tls.lifecycle|/sts_cco" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
+	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/postgres.tls.lifecycle|/sts-cco" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
 
 test-e2e-destructive: chainsaw ## Run destructive Chainsaw e2e tests (ca-rotation, postgres-tls-lifecycle, OpenShift only)
 	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_OPENSHIFT) --parallel $(CHAINSAW_PARALLEL) --include-test-regex "/ca.rotation|/postgres.tls.lifecycle" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
 
 test-e2e-kind: chainsaw ## Run Chainsaw e2e tests (KinD)
-	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_KIND) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/hpa|/tls.security.profile|/postgres.tls.lifecycle|/postgres.tls.service.ca|/sts_cco" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
+	$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --test-dir $(CHAINSAW_TEST_DIR) --values $(CHAINSAW_VALUES_KIND) --parallel $(CHAINSAW_PARALLEL) --exclude-test-regex "/ca.rotation|/hpa|/tls.security.profile|/postgres.tls.lifecycle|/postgres.tls.service.ca|/sts-cco" $(CHAINSAW_REPORT_FLAGS) $(CHAINSAW_EXTRA_ARGS)
 
 test-e2e-sts: chainsaw ## Run STS/CCO tests against an AWS OpenShift cluster
 	@test -n "$(STS_TEST_NAMESPACE)" || (echo "ERROR: STS_TEST_NAMESPACE is required" && exit 1)

--- a/test/chainsaw/sts_cco/01-create-registry.yaml
+++ b/test/chainsaw/sts_cco/01-create-registry.yaml
@@ -1,0 +1,31 @@
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: sts-cco
+spec:
+  configBundleSecret: sts-cco-config
+  components:
+  - kind: quay
+    managed: true
+  - kind: postgres
+    managed: true
+  - kind: redis
+    managed: true
+  - kind: cache
+    managed: true
+  - kind: mirror
+    managed: true
+  - kind: clair
+    managed: false
+  - kind: clairpostgres
+    managed: false
+  - kind: horizontalpodautoscaler
+    managed: false
+  - kind: objectstorage
+    managed: false
+  - kind: route
+    managed: true
+  - kind: monitoring
+    managed: false
+  - kind: tls
+    managed: true

--- a/test/chainsaw/sts_cco/chainsaw-test.yaml
+++ b/test/chainsaw/sts_cco/chainsaw-test.yaml
@@ -159,6 +159,9 @@ spec:
                 any(.env[]?;
                   .name == "AWS_SHARED_CREDENTIALS_FILE" and .value == "/aws-sts/credentials")) and
               all(.spec.template.spec.containers[];
+                any(.env[]?;
+                  .name == "AWS_SDK_LOAD_CONFIG" and .value == "true")) and
+              all(.spec.template.spec.containers[];
                 any(.volumeMounts[]?;
                   .name == "aws-sts-credentials" and .mountPath == "/aws-sts" and .readOnly == true)) and
               all(.spec.template.spec.containers[];
@@ -174,7 +177,9 @@ spec:
                 .metadata.name != "sts-cco-quay-app" and
                 .metadata.name != "sts-cco-quay-mirror");
                 all(.spec.template.spec.containers[]?;
-                  all(.env[]?; .name != "AWS_SHARED_CREDENTIALS_FILE")) and
+                  all(.env[]?;
+                    .name != "AWS_SHARED_CREDENTIALS_FILE" and
+                    .name != "AWS_SDK_LOAD_CONFIG")) and
                 all(.spec.template.spec.volumes[]?;
                   .name != "aws-sts-credentials" and .name != "bound-sa-token"))
             ' >/dev/null

--- a/test/chainsaw/sts_cco/chainsaw-test.yaml
+++ b/test/chainsaw/sts_cco/chainsaw-test.yaml
@@ -1,0 +1,321 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: sts-cco
+spec:
+  concurrent: false
+  steps:
+  - name: validate-cluster-and-create-config
+    try:
+    - script:
+        shell: /bin/bash
+        content: |
+          set -euo pipefail
+
+          for command in kubectl jq curl crane base64; do
+            command -v "${command}" >/dev/null || {
+              echo "ERROR: ${command} is required for the STS E2E test"
+              exit 1
+            }
+          done
+
+          [ "$(kubectl get infrastructure cluster -o jsonpath='{.status.platformStatus.type}')" = "AWS" ] || {
+            echo "ERROR: the STS E2E test requires an AWS OpenShift cluster"
+            exit 1
+          }
+          [ "$(kubectl get cloudcredential cluster -o jsonpath='{.spec.credentialsMode}')" = "Manual" ] || {
+            echo "ERROR: Cloud Credential Operator must use Manual credentials mode"
+            exit 1
+          }
+          kubectl get crd credentialsrequests.cloudcredential.openshift.io >/dev/null
+          [ -n "$(kubectl get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}')" ] || {
+            echo "ERROR: the cluster service-account issuer is empty"
+            exit 1
+          }
+
+          CONFIG_FILE="/tmp/sts-cco-config-${NAMESPACE}"
+          trap 'rm -f "${CONFIG_FILE}"' EXIT
+          cat >"${CONFIG_FILE}" <<EOF
+          FEATURE_MAILING: false
+          FEATURE_USER_INITIALIZE: true
+          CREATE_NAMESPACE_ON_PUSH: true
+          FEATURE_REPO_MIRROR: true
+          REPO_MIRROR_INTERVAL: 30
+          DISTRIBUTED_STORAGE_CONFIG:
+            default:
+              - S3Storage
+              - s3_bucket: ${STS_S3_BUCKET}
+                s3_region: ${STS_S3_REGION}
+                storage_path: /quay-operator-e2e/${NAMESPACE}
+          DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
+            - default
+          DISTRIBUTED_STORAGE_PREFERENCE:
+            - default
+          EOF
+
+          kubectl create secret generic sts-cco-config -n "${NAMESPACE}" \
+            --from-file=config.yaml="${CONFIG_FILE}"
+    - apply:
+        file: 01-create-registry.yaml
+
+  - name: verify-cco-provisioning
+    try:
+    - script:
+        shell: /bin/bash
+        timeout: 12m0s
+        content: |
+          set -euo pipefail
+
+          REQUEST=sts-cco-aws-credentials
+          SECRET=sts-cco-aws-sts-credentials
+
+          echo "Waiting for the CredentialsRequest to be provisioned..."
+          for attempt in $(seq 1 72); do
+            if kubectl get credentialsrequest "${REQUEST}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+              GENERATION=$(kubectl get credentialsrequest "${REQUEST}" -n "${NAMESPACE}" -o jsonpath='{.metadata.generation}')
+              SYNC_GENERATION=$(kubectl get credentialsrequest "${REQUEST}" -n "${NAMESPACE}" -o jsonpath='{.status.lastSyncGeneration}')
+              PROVISIONED=$(kubectl get credentialsrequest "${REQUEST}" -n "${NAMESPACE}" -o jsonpath='{.status.provisioned}')
+              if [ "${PROVISIONED}" = "true" ] && [ "${SYNC_GENERATION}" = "${GENERATION}" ] && \
+                kubectl get secret "${SECRET}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+                break
+              fi
+            fi
+            [ "${attempt}" -lt 72 ] || {
+              echo "ERROR: CCO did not provision the current CredentialsRequest generation"
+              exit 1
+            }
+            sleep 10
+          done
+
+          PARTITION=$(printf '%s' "${STS_ROLE_ARN}" | cut -d: -f2)
+          BUCKET_ARN="arn:${PARTITION}:s3:::${STS_S3_BUCKET}"
+          OBJECT_ARN="${BUCKET_ARN}/*"
+          QUAY_UID=$(kubectl get quayregistry sts-cco -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}')
+
+          kubectl get credentialsrequest "${REQUEST}" -n "${NAMESPACE}" -o json | jq -e \
+            --arg namespace "${NAMESPACE}" --arg role "${STS_ROLE_ARN}" \
+            --arg bucket "${BUCKET_ARN}" --arg objects "${OBJECT_ARN}" --arg ownerUID "${QUAY_UID}" '
+              .spec.providerSpec.stsIAMRoleARN == $role and
+              .spec.cloudTokenPath == "/var/run/secrets/openshift/serviceaccount/token" and
+              .spec.secretRef == {"name":"sts-cco-aws-sts-credentials","namespace":$namespace} and
+              .spec.serviceAccountNames == ["sts-cco-quay-app"] and
+              any(.metadata.ownerReferences[]?;
+                .apiVersion == "quay.redhat.com/v1" and .kind == "QuayRegistry" and
+                .name == "sts-cco" and .uid == $ownerUID) and
+              any(.spec.providerSpec.statementEntries[]?;
+                .resource == $bucket and
+                (.action | sort) == (["s3:GetBucketLocation","s3:ListBucket","s3:ListBucketMultipartUploads"] | sort)) and
+              any(.spec.providerSpec.statementEntries[]?;
+                .resource == $objects and
+                (.action | sort) == (["s3:AbortMultipartUpload","s3:DeleteObject","s3:GetObject","s3:ListMultipartUploadParts","s3:PutObject"] | sort))
+            ' >/dev/null
+
+          CREDENTIALS=$(kubectl get secret "${SECRET}" -n "${NAMESPACE}" -o jsonpath='{.data.credentials}' | base64 -d)
+          FILE_ROLE=$(printf '%s\n' "${CREDENTIALS}" | awk -F= '
+            /^[[:space:]]*role_arn[[:space:]]*=/ {
+              value=$0; sub(/^[^=]*=[[:space:]]*/, "", value); print value
+            }')
+          TOKEN_PATH=$(printf '%s\n' "${CREDENTIALS}" | awk -F= '
+            /^[[:space:]]*web_identity_token_file[[:space:]]*=/ {
+              value=$0; sub(/^[^=]*=[[:space:]]*/, "", value); print value
+            }')
+          [ "${FILE_ROLE}" = "${STS_ROLE_ARN}" ] || {
+            echo "ERROR: CCO credentials role does not match STS_ROLE_ARN"
+            exit 1
+          }
+          [ "${TOKEN_PATH}" = "/var/run/secrets/openshift/serviceaccount/token" ] || {
+            echo "ERROR: CCO credentials reference the wrong token path"
+            exit 1
+          }
+          if printf '%s\n' "${CREDENTIALS}" | grep -Eq '^[[:space:]]*aws_(access_key_id|secret_access_key)[[:space:]]*='; then
+            echo "ERROR: CCO credentials contain static AWS access keys"
+            exit 1
+          fi
+
+  - name: verify-workloads
+    try:
+    - script:
+        shell: /bin/bash
+        timeout: 20m0s
+        content: |
+          set -euo pipefail
+
+          for deployment in sts-cco-quay-app sts-cco-quay-mirror; do
+            echo "Waiting for ${deployment} rollout..."
+            kubectl rollout status deployment/"${deployment}" -n "${NAMESPACE}" --timeout=15m
+
+            kubectl get deployment "${deployment}" -n "${NAMESPACE}" -o json | jq -e '
+              .spec.template.spec.serviceAccountName == "sts-cco-quay-app" and
+              any(.spec.template.spec.volumes[]?;
+                .name == "aws-sts-credentials" and
+                .secret.secretName == "sts-cco-aws-sts-credentials") and
+              any(.spec.template.spec.volumes[]?;
+                .name == "bound-sa-token" and
+                any(.projected.sources[]?;
+                  .serviceAccountToken.path == "token" and .serviceAccountToken.audience == "openshift")) and
+              all(.spec.template.spec.containers[];
+                any(.env[]?;
+                  .name == "AWS_SHARED_CREDENTIALS_FILE" and .value == "/aws-sts/credentials")) and
+              all(.spec.template.spec.containers[];
+                any(.volumeMounts[]?;
+                  .name == "aws-sts-credentials" and .mountPath == "/aws-sts" and .readOnly == true)) and
+              all(.spec.template.spec.containers[];
+                any(.volumeMounts[]?;
+                  .name == "bound-sa-token" and
+                  .mountPath == "/var/run/secrets/openshift/serviceaccount" and .readOnly == true))
+            ' >/dev/null
+          done
+
+          kubectl get deployments -n "${NAMESPACE}" \
+            -l quay-operator/quayregistry=sts-cco -o json | jq -e '
+              all(.items[] | select(
+                .metadata.name != "sts-cco-quay-app" and
+                .metadata.name != "sts-cco-quay-mirror");
+                all(.spec.template.spec.containers[]?;
+                  all(.env[]?; .name != "AWS_SHARED_CREDENTIALS_FILE")) and
+                all(.spec.template.spec.volumes[]?;
+                  .name != "aws-sts-credentials" and .name != "bound-sa-token"))
+            ' >/dev/null
+
+          CONFIG_SECRET=$(kubectl get deployment sts-cco-quay-app -n "${NAMESPACE}" -o json | jq -r '
+            .spec.template.spec.volumes[]
+            | select(.name == "config").projected.sources[]?.secret.name
+            | select(startswith("sts-cco-quay-config-secret"))
+          ' | head -1)
+          [ -n "${CONFIG_SECRET}" ] || {
+            echo "ERROR: could not find the rendered Quay config Secret"
+            exit 1
+          }
+          RENDERED_CONFIG=$(kubectl get secret "${CONFIG_SECRET}" -n "${NAMESPACE}" -o jsonpath='{.data.config\.yaml}' | base64 -d)
+          printf '%s\n' "${RENDERED_CONFIG}" | grep -q 'S3Storage'
+          printf '%s\n' "${RENDERED_CONFIG}" | grep -Fq "${STS_S3_BUCKET}"
+          if printf '%s\n' "${RENDERED_CONFIG}" | grep -Eq 's3_(access_key|secret_key):'; then
+            echo "ERROR: rendered Quay config contains static S3 credentials"
+            exit 1
+          fi
+
+  - name: verify-s3-push-pull-and-mirroring
+    try:
+    - script:
+        shell: /bin/bash
+        timeout: 20m0s
+        content: |
+          set -euo pipefail
+
+          ENDPOINT="https://$(kubectl get route sts-cco-quay -n "${NAMESPACE}" -o jsonpath='{.spec.host}')"
+          REGISTRY=${ENDPOINT#https://}
+          USERNAME=admin
+          PASSWORD=$(printf 'sts-e2e-%s-%s' "${NAMESPACE}" "$(date +%s)")
+          API_RESPONSE="/tmp/sts-cco-api-${NAMESPACE}.json"
+          PULLED_IMAGE="/tmp/sts-cco-image-${NAMESPACE}.tar"
+          DOCKER_CONFIG="/tmp/sts-cco-docker-${NAMESPACE}"
+          export DOCKER_CONFIG
+          mkdir -p "${DOCKER_CONFIG}"
+          trap 'rm -f "${API_RESPONSE}" "${PULLED_IMAGE}"; rm -rf "${DOCKER_CONFIG}"' EXIT
+
+          echo "Waiting for the Quay API..."
+          for attempt in $(seq 1 60); do
+            if curl -skf "${ENDPOINT}/api/v1/discovery" >/dev/null; then
+              break
+            fi
+            [ "${attempt}" -lt 60 ] || {
+              echo "ERROR: Quay API did not become available"
+              exit 1
+            }
+            sleep 5
+          done
+
+          HTTP_CODE=$(curl -sk -o "${API_RESPONSE}" -w '%{http_code}' \
+            -X POST "${ENDPOINT}/api/v1/user/initialize" \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"email\":\"admin@test.invalid\",\"access_token\":true}")
+          case "${HTTP_CODE}" in
+            200|201) ;;
+            *) echo "ERROR: user initialization returned HTTP ${HTTP_CODE}"; exit 1 ;;
+          esac
+          TOKEN=$(jq -r '.access_token // empty' "${API_RESPONSE}")
+          [ -n "${TOKEN}" ] || {
+            echo "ERROR: user initialization did not return an access token"
+            exit 1
+          }
+          rm -f "${API_RESPONSE}"
+
+          crane auth login --insecure "${REGISTRY}" -u "${USERNAME}" -p "${PASSWORD}"
+          SOURCE_IMAGE=quay.io/quay/busybox:latest
+          TARGET_IMAGE="${REGISTRY}/${USERNAME}/sts-e2e:latest"
+
+          echo "Copying an image into the STS-backed registry..."
+          crane copy --insecure --platform linux/amd64 "${SOURCE_IMAGE}" "${TARGET_IMAGE}"
+          PUSH_DIGEST=$(crane digest --insecure "${TARGET_IMAGE}")
+          crane pull --insecure "${TARGET_IMAGE}" "${PULLED_IMAGE}"
+          [ -s "${PULLED_IMAGE}" ] || {
+            echo "ERROR: pulled image archive is empty"
+            exit 1
+          }
+          [ "${PUSH_DIGEST}" = "$(crane digest --insecure "${TARGET_IMAGE}")" ] || {
+            echo "ERROR: pushed image digest changed after pull"
+            exit 1
+          }
+
+          api_request() {
+            local method=$1
+            local path=$2
+            local data=${3:-}
+            local code
+            if [ -n "${data}" ]; then
+              code=$(curl -sk -o "${API_RESPONSE}" -w '%{http_code}' \
+                -X "${method}" "${ENDPOINT}${path}" -H "Authorization: Bearer ${TOKEN}" \
+                -H 'Content-Type: application/json' -d "${data}")
+            else
+              code=$(curl -sk -o "${API_RESPONSE}" -w '%{http_code}' \
+                -X "${method}" "${ENDPOINT}${path}" -H "Authorization: Bearer ${TOKEN}")
+            fi
+            case "${code}" in
+              200|201|202|204) ;;
+              *) echo "ERROR: ${method} ${path} returned HTTP ${code}"; return 1 ;;
+            esac
+          }
+
+          echo "Configuring a repository mirror..."
+          api_request PUT /api/v1/user/robots/stsmirror '{}'
+          api_request POST /api/v1/repository \
+            '{"repository":"sts-mirror","namespace":"admin","visibility":"private","description":"STS E2E mirror"}'
+          START_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          MIRROR_CONFIG=$(jq -nc --arg start "${START_DATE}" '{
+            is_enabled: true,
+            external_reference: "quay.io/quay/busybox",
+            external_registry_username: null,
+            external_registry_password: null,
+            sync_interval: 86400,
+            skopeo_timeout_interval: 300,
+            sync_start_date: $start,
+            root_rule: {rule_kind: "tag_glob_csv", rule_value: ["latest"]},
+            robot_username: "admin+stsmirror",
+            external_registry_config: {verify_tls: true}
+          }')
+          api_request POST /api/v1/repository/admin/sts-mirror/mirror "${MIRROR_CONFIG}"
+          api_request POST /api/v1/repository/admin/sts-mirror/mirror/sync-now
+
+          echo "Waiting for the mirror worker to copy the image..."
+          for attempt in $(seq 1 90); do
+            api_request GET /api/v1/repository/admin/sts-mirror/mirror
+            MIRROR_STATUS=$(jq -r '.sync_status // empty' "${API_RESPONSE}")
+            if [ "${MIRROR_STATUS}" = "SUCCESS" ]; then
+              break
+            fi
+            [ "${attempt}" -lt 90 ] || {
+              echo "ERROR: repository mirror did not succeed; final status=${MIRROR_STATUS:-unknown}"
+              exit 1
+            }
+            sleep 10
+          done
+
+          rm -f "${PULLED_IMAGE}"
+          crane pull --insecure "${REGISTRY}/admin/sts-mirror:latest" "${PULLED_IMAGE}"
+          [ -s "${PULLED_IMAGE}" ] || {
+            echo "ERROR: mirrored image archive is empty"
+            exit 1
+          }
+          echo "PASS: CCO provisioning, STS-backed push/pull, and repository mirroring succeeded"


### PR DESCRIPTION
## Summary

- Integrate the Quay operator with OpenShift's Cloud Credential Operator (CCO) so that Quay pods on STS-enabled clusters authenticate to AWS S3 using short-lived tokens instead of static IAM access keys
- When ROLEARN env var is set via OLM subscription config, the operator creates a CredentialsRequest, CCO provisions a Secret, and the operator mounts it into quay-app/quay-mirror pods with AWS_SHARED_CREDENTIALS_FILE
- Blocks rollout when static AWS credentials conflict with STS, degrades when CCO fails to provision credentials within 5 minutes, and falls back to normal operation when ROLEARN is unset

## Key design decisions

- **Local CredentialsRequest types** (`pkg/credentialsrequest/`) instead of importing the CCO library to avoid transitive dependency conflicts (CCO@latest requires k8s v0.36, we are on v0.28)
- **CRD detection via RESTMapper at startup** (cached bool) instead of `r.List()` every reconcile — matches the existing Route API detection pattern
- **Block rollout on credential conflict** — when ROLEARN is set but static s3_access_key/s3_secret_key exist in configBundleSecret, the operator blocks with a clear message telling the admin to remove static credentials

## Files changed

| File | Change |
|------|--------|
| `pkg/credentialsrequest/types.go` | New — local CredentialsRequest types and builder |
| `pkg/context/context.go` | Add STS context fields |
| `apis/quay/v1/quayregistry_types.go` | Add condition reason constants |
| `controllers/quay/features.go` | `checkSTSCapability()` + `hasStaticAWSStorageKeys()` |
| `controllers/quay/quayregistry_controller.go` | `ensureCredentialsRequest()` + reconcile loop wiring + RBAC |
| `pkg/middleware/middleware.go` | `applySTSCredentials()` — volume/mount/env injection |
| `bundle/manifests/quay-operator.clusterserviceversion.yaml` | `token-auth-aws: "true"` + CredentialsRequest RBAC |

## Test plan

- [x] `TestCheckSTSCapability` — 5 cases: ROLEARN unset, managed objectstorage, static key conflict, CRD unavailable, happy path
- [x] `TestHasStaticAWSStorageKeys` — 7 cases: empty config, S3Storage with/without keys, RadosGWStorage, STSS3Storage, empty keys
- [x] `TestApplySTSCredentials` — 5 cases: volumes, mounts, env var, idempotency
- [x] `TestNewCredentialsRequest` — 4 cases: GVK, metadata, spec fields, providerSpec with role ARN
- [x] Full build passes (`go build ./...`)
- [x] `go vet` clean
- [x] `gofmt` clean
- [ ] E2E test on STS-enabled cluster (requires ROSA/OSD environment)

## Related

- JIRA: [PROJQUAY-5850](https://redhat.atlassian.net/browse/PROJQUAY-5850)
- Reference: Short-Lived Token Auth Guide ([OCPSTRAT-171](https://redhat.atlassian.net/browse/OCPSTRAT-171))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS STS authentication for Quay deployments using unmanaged S3 storage.
  * Automatically provisions short-lived credentials and applies them to Quay application and mirror components.
  * Reports credential readiness, pending requests, unavailable provisioning support, and conflicting credentials.
  * Updates credential configuration when storage or credential definitions change.

* **Documentation**
  * Added setup and configuration guidance for AWS STS, IAM permissions, and troubleshooting.

* **Tests**
  * Expanded coverage for STS detection, provisioning, validation, mounting, cleanup, and conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->